### PR TITLE
fix(ci): bump verify/068 jti_deny count 26->27 for mig 127 (unblock #6239 deploy)

### DIFF
--- a/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
+++ b/apps/web-platform/supabase/verify/068_jti_deny_rls_predicate_and_revoke_rpc.sql
@@ -12,12 +12,13 @@
 --     (REVOKED FROM authenticated, service_role only).
 --   * revoke_jti is NOT granted to authenticated (service-role-only).
 --   * my_revocation_status is granted TO authenticated.
---   * Exactly 26 RESTRICTIVE policies named *_jti_not_denied exist.
---   * Each of the 26 tenant tables has its own per-table presence
+--   * Exactly 27 RESTRICTIVE policies named *_jti_not_denied exist.
+--   * Each of the 27 tenant tables has its own per-table presence
 --     assertion (21 base from mig 068 + workspace_activity (mig 076)
 --     + kb_files (mig 077) + beta_contacts / interview_notes /
---     beta_contact_stage_transitions (mig 126)) — so the named set
---     equals the aggregate count, not just the count.
+--     beta_contact_stage_transitions (mig 126) + beta_contact_access_log
+--     (mig 127)) — so the named set equals the aggregate count, not just
+--     the count.
 
 -- (1) revoke_jti present + SECURITY DEFINER
 SELECT 'revoke_jti_fn_present' AS check_name,
@@ -73,10 +74,11 @@ SELECT 'my_revocation_status_authenticated_grant_present',
               'EXECUTE'
             ) THEN 0 ELSE 1 END::int
 UNION ALL
--- (7) Exactly 26 RESTRICTIVE jti_not_denied policies (21 base + workspace_activity
---     + kb_files from mig 076/077 + beta_contacts/interview_notes/beta_contact_stage_transitions from mig 126)
-SELECT 'jti_deny_policies_count_26',
-       CASE WHEN count(*) = 26 THEN 0 ELSE 1 END::int
+-- (7) Exactly 27 RESTRICTIVE jti_not_denied policies (21 base + workspace_activity
+--     + kb_files from mig 076/077 + beta_contacts/interview_notes/beta_contact_stage_transitions from mig 126
+--     + beta_contact_access_log from mig 127)
+SELECT 'jti_deny_policies_count_27',
+       CASE WHEN count(*) = 27 THEN 0 ELSE 1 END::int
   FROM pg_policies
  WHERE schemaname = 'public'
    AND policyname LIKE '%_jti_not_denied'
@@ -218,6 +220,12 @@ SELECT 'beta_contact_stage_transitions_jti_not_denied_policy_present',
        CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
   FROM pg_policies WHERE schemaname='public' AND tablename='beta_contact_stage_transitions'
    AND policyname='beta_contact_stage_transitions_jti_not_denied' AND permissive='RESTRICTIVE'
+UNION ALL
+-- beta_contact_access_log (mig 127, #6172) — the 27th jti_not_denied policy.
+SELECT 'beta_contact_access_log_jti_not_denied_policy_present',
+       CASE WHEN count(*) = 1 THEN 0 ELSE 1 END::int
+  FROM pg_policies WHERE schemaname='public' AND tablename='beta_contact_access_log'
+   AND policyname='beta_contact_access_log_jti_not_denied' AND permissive='RESTRICTIVE'
 UNION ALL
 -- (34-36) anon-role REVOKE matrix: none of the three 068 functions
 -- must be EXECUTE-able by anon. Pre-fix, the sentinel asserted only


### PR DESCRIPTION
## Summary

Post-merge hotfix: the `web-platform-release` run for #6239 FAILED at `verify-migrations` → `deploy` was **skipped**, because migration 127 (`beta_contact_access_log`, #6172) added the 27th RESTRICTIVE `*_jti_not_denied` policy but `verify/068`'s `jti_deny_policies_count_26` sentinel hard-codes 26.

**No outage** — migration 127 is additive and the currently-deployed (prior) code does not reference the new table/RPC, so prod is healthy on the old version. This unblocks the deploy so the CRM UI actually ships.

The recurring count-sentinel drift class (postmortem `verify-068-jti-deny-count-sentinel-drift`; #6229 previously did 23→26 for mig 126).

Fix: bump the count sentinel `26 → 27` **and** add the per-table `beta_contact_access_log` presence assertion (per the "count-bump-must-not-leave-per-member-assertions-incomplete" learning). Live prd count is 27 (the FAIL proved it ≠ 26; mig-127 added exactly one).

Ref #6172

## User-Brand Impact

**If this lands broken:** a deploy-gate verify sentinel is a CI-only artifact; a wrong count blocks deploys (already the current state) but touches no user-data path.

- **Brand-survival threshold:** none, reason: verify/068 is a deploy-time RLS-policy-count sentinel with no runtime user-data path; the fix only re-aligns the hard-coded count with the live schema (validated against prd).

## Changelog

### Web Platform
- verify/068 jti_deny policy count sentinel bumped 26→27 + beta_contact_access_log per-table presence assertion (unblocks the #6239 release deploy).

## Test plan

- [x] Live prd count validated at 27 (the failing verify run + mig-127 applied = exactly one over the prior 26).
- [ ] Post-merge: `web-platform-release` verify-migrations passes → deploy proceeds → CRM UI live.

Generated with [Claude Code](https://claude.com/claude-code)
