### PR TITLE
fix(workstream): show only the username in the issue-detail 'Created by' row (no glyph chip)

### DIFF
--- a/apps/web-platform/components/workstream/issue-detail-sheet.tsx
+++ b/apps/web-platform/components/workstream/issue-detail-sheet.tsx
@@ -24,7 +24,7 @@ import {
   type WorkstreamIssue,
   type WorkstreamStatus,
 } from "@/lib/workstream";
-import { AssigneeChip, CreatorChip, UserAvatar } from "./assignee-chip";
+import { AssigneeChip, UserAvatar } from "./assignee-chip";
 import { PriorityPill } from "./priority-pill";
 import { IssueConciergePanel } from "./issue-concierge-panel";
 
@@ -196,11 +196,8 @@ export function IssueDetailSheet({
 
                 {issue.creator && (
                   <Row label="Created by">
-                    <span className="flex items-center gap-2">
-                      <CreatorChip creator={issue.creator} />
-                      <span className="text-soleur-text-secondary">
-                        {creatorLabel(issue.creator)}
-                      </span>
+                    <span className="text-soleur-text-secondary">
+                      {creatorLabel(issue.creator)}
                     </span>
                   </Row>
                 )}

--- a/apps/web-platform/test/components/workstream/issue-detail-sheet.test.tsx
+++ b/apps/web-platform/test/components/workstream/issue-detail-sheet.test.tsx
@@ -104,6 +104,9 @@ describe("IssueDetailSheet", () => {
     const dialog = screen.getByRole("dialog");
     expect(within(dialog).getByText("Created by")).toBeTruthy();
     expect(within(dialog).getByText("octocat")).toBeTruthy();
+    // The row shows only the username — no glyph/avatar chip in the detail sheet.
+    expect(within(dialog).queryByTitle(/^Created by/)).toBeNull();
+    expect(within(dialog).queryByText(/[👤🤖]/)).toBeNull();
   });
 
   it("renders 'Soleur · initiated by <login>' for a bot-created issue", () => {


### PR DESCRIPTION
## Summary

Per operator request: on the **issue detail** sheet, remove the little glyph/avatar chip from the "Created by" row and show **only the username**. The board card is unchanged (it keeps the compact 👤/🤖 creator chip for at-a-glance scanning); this only simplifies the detail sheet where the full label is already spelled out.

Before: `Created by   [👤 EL] Elvalio`
After:  `Created by   Elvalio`

(For a Soleur-created issue the row shows `Soleur` / `Soleur · initiated by <login>` as plain text.)

## Changelog
- Workstream issue detail sheet: the "Created by" row renders the creator label as plain text only — removed the `CreatorChip` (glyph + initials avatar) from this row.

## Test plan
- [x] Detail-sheet component tests updated: assert the row shows the username AND no longer renders a `Created by …` titled chip or a 👤/🤖 glyph (regression guard); all three label variants still render
- [x] Card creator chip unchanged (`CreatorChip` still used there); `tsc` clean

Follows PR #6253 (workstream creator attribution).

Generated with [Claude Code](https://claude.com/claude-code)