### PR TITLE
feat(workstream): 'Created by' filter — narrow the board by who created each issue

### DIFF
--- a/apps/web-platform/components/workstream/filter-bar.tsx
+++ b/apps/web-platform/components/workstream/filter-bar.tsx
@@ -225,6 +225,26 @@ export function FilterBar({
           ))}
         </Dropdown>
       ) : null}
+
+      {/* Created by — filter by who created the issue (human author / Soleur /
+          the human who initiated a Soleur-created issue). */}
+      {options.creators.length > 0 ? (
+        <Dropdown label="Created by" activeCount={filters.creators.size}>
+          {options.creators.map((c: string) => (
+            <CheckRow
+              key={`creator-${c}`}
+              label={c}
+              checked={filters.creators.has(c)}
+              onToggle={() =>
+                onChange({
+                  ...filters,
+                  creators: toggleInSet(filters.creators, c),
+                })
+              }
+            />
+          ))}
+        </Dropdown>
+      ) : null}
     </div>
   );
 }

--- a/apps/web-platform/lib/workstream.ts
+++ b/apps/web-platform/lib/workstream.ts
@@ -485,6 +485,15 @@ export function creatorLabel(creator: WorkstreamCreator): string {
   return creator.login;
 }
 
+/** The effective "created by" identity used as the CREATOR-FILTER key: the human
+ *  initiator when known, else `"Soleur"` for a bot-authored issue with no
+ *  initiator, else the human author login. So filtering by a person surfaces BOTH
+ *  the issues they opened directly AND the Soleur-created issues they initiated. */
+export function creatorFilterKey(creator: WorkstreamCreator): string {
+  if (creator.initiatorLogin) return creator.initiatorLogin;
+  return creator.isSoleur ? "Soleur" : creator.login;
+}
+
 /** First `priority/*` label (in issue order) → priority; absent → `none`. */
 export function derivePriority(labels: string[]): WorkstreamPriority {
   for (const label of labels) {
@@ -567,6 +576,8 @@ export interface WorkstreamFilters {
   unassigned: boolean;
   /** `domain/*` label values. */
   domains: Set<string>;
+  /** Creator-filter keys (`creatorFilterKey` values) — who created the issue. */
+  creators: Set<string>;
 }
 
 /** The neutral, show-everything filter state. */
@@ -578,6 +589,7 @@ export function emptyFilters(): WorkstreamFilters {
     users: new Set(),
     unassigned: false,
     domains: new Set(),
+    creators: new Set(),
   };
 }
 
@@ -605,6 +617,11 @@ export function matchesFilters(
     const hit = (i.domains ?? []).some((d) => f.domains.has(d));
     if (!hit) return false;
   }
+  // Creator (who created the issue)
+  if (f.creators.size > 0) {
+    const key = i.creator ? creatorFilterKey(i.creator) : null;
+    if (key === null || !f.creators.has(key)) return false;
+  }
   return true;
 }
 
@@ -621,7 +638,8 @@ export function hasActiveFilters(
     f.roles.size > 0 ||
     f.users.size > 0 ||
     f.unassigned ||
-    f.domains.size > 0
+    f.domains.size > 0 ||
+    f.creators.size > 0
   );
 }
 
@@ -663,6 +681,8 @@ export interface FilterOptions {
   users: string[];
   hasUnassigned: boolean;
   domains: string[];
+  /** Distinct creator-filter keys present in the loaded set (alphabetical). */
+  creators: string[];
 }
 
 /** Faceted filter options derived from the FULL loaded set (D3) — de-duplicated.
@@ -674,6 +694,7 @@ export function deriveFilterOptions(issues: WorkstreamIssue[]): FilterOptions {
   const roles = new Set<WorkstreamRole>();
   const users = new Set<string>();
   const domains = new Set<string>();
+  const creators = new Set<string>();
   let hasUnassigned = false;
   for (const i of issues) {
     priorities.add(i.priority);
@@ -681,6 +702,7 @@ export function deriveFilterOptions(issues: WorkstreamIssue[]): FilterOptions {
     if (i.user !== undefined) users.add(i.user.name);
     if (i.assigneeRole === null && i.user === undefined) hasUnassigned = true;
     for (const d of i.domains ?? []) domains.add(d);
+    if (i.creator !== undefined) creators.add(creatorFilterKey(i.creator));
   }
   return {
     priorities: PRIORITY_ORDER.filter((p) => priorities.has(p)),
@@ -688,6 +710,7 @@ export function deriveFilterOptions(issues: WorkstreamIssue[]): FilterOptions {
     users: [...users].sort(),
     hasUnassigned,
     domains: [...domains].sort(),
+    creators: [...creators].sort(),
   };
 }
 

--- a/apps/web-platform/test/components/workstream/filter-bar.test.tsx
+++ b/apps/web-platform/test/components/workstream/filter-bar.test.tsx
@@ -19,6 +19,7 @@ function baseOpts(): ReturnType<typeof deriveFilterOptions> {
     users: ["alice"],
     hasUnassigned: true,
     domains: ["domain/engineering", "domain/product"],
+    creators: ["Soleur", "octocat"],
   };
 }
 
@@ -33,6 +34,29 @@ describe("FilterBar", () => {
     expect(screen.getByRole("button", { name: /status/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /assignee/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /domain/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /created by/i })).toBeTruthy();
+  });
+
+  it("toggling a Created by checkbox calls onChange with that creator added", () => {
+    const onChange = vi.fn();
+    render(
+      <FilterBar options={opts()} filters={emptyFilters()} onChange={onChange} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /created by/i }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /octocat/i }));
+    const next = onChange.mock.calls[0][0] as WorkstreamFilters;
+    expect(next.creators.has("octocat")).toBe(true);
+  });
+
+  it("hides the Created by dimension when no creators are present", () => {
+    render(
+      <FilterBar
+        options={opts({ creators: [] })}
+        filters={emptyFilters()}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /created by/i })).toBeNull();
   });
 
   it("hides a dimension whose option list is empty (Domain); Status always shows", () => {

--- a/apps/web-platform/test/workstream-filters.test.ts
+++ b/apps/web-platform/test/workstream-filters.test.ts
@@ -3,6 +3,7 @@ import {
   CLOSED_STATUSES,
   COLUMN_CAP_NOTICE,
   COLUMN_RENDER_CAP,
+  creatorFilterKey,
   deriveColumn,
   deriveFilterOptions,
   emptyFilters,
@@ -13,6 +14,7 @@ import {
   matchesSearch,
   STATUS_ORDER,
   type BoardIssueInput,
+  type WorkstreamCreator,
   type WorkstreamFilters,
   type WorkstreamIssue,
 } from "@/lib/workstream";
@@ -139,6 +141,81 @@ describe("matchesFilters", () => {
     expect(matchesFilters(issue({ priority: "urgent", status: "ready" }), f)).toBe(true);
     expect(matchesFilters(issue({ priority: "urgent", status: "done" }), f)).toBe(false); // fails status
     expect(matchesFilters(issue({ priority: "low", status: "ready" }), f)).toBe(false); // fails priority
+  });
+});
+
+describe("creator filter dimension", () => {
+  const human: WorkstreamCreator = {
+    login: "octocat",
+    isSoleur: false,
+    display: { name: "octocat", initials: "OC" },
+  };
+  const soleur: WorkstreamCreator = {
+    login: "soleur-ai[bot]",
+    isSoleur: true,
+    display: { name: "Soleur", initials: "SO" },
+  };
+  const soleurInitiated: WorkstreamCreator = {
+    login: "soleur-ai[bot]",
+    isSoleur: true,
+    initiatorLogin: "harry",
+    display: { name: "harry", initials: "HA" },
+  };
+
+  it("creatorFilterKey maps to the effective creator identity", () => {
+    expect(creatorFilterKey(human)).toBe("octocat");
+    expect(creatorFilterKey(soleur)).toBe("Soleur");
+    // the human initiator wins over the bot for a Soleur-initiated issue
+    expect(creatorFilterKey(soleurInitiated)).toBe("harry");
+  });
+
+  it("matchesFilters gates on the creator key (OR within, absent = excluded)", () => {
+    const f: WorkstreamFilters = {
+      ...emptyFilters(),
+      creators: new Set(["octocat"]),
+    };
+    expect(matchesFilters(issue({ creator: human }), f)).toBe(true);
+    expect(matchesFilters(issue({ creator: soleur }), f)).toBe(false);
+    // an issue with no creator is excluded when the creator filter is active
+    expect(matchesFilters(issue({ creator: undefined }), f)).toBe(false);
+  });
+
+  it("filtering a person surfaces both direct + Soleur-initiated issues", () => {
+    const f: WorkstreamFilters = {
+      ...emptyFilters(),
+      creators: new Set(["harry"]),
+    };
+    // Soleur-created but initiated by harry
+    expect(matchesFilters(issue({ creator: soleurInitiated }), f)).toBe(true);
+    // a human "harry" author would also match (key = login)
+    expect(
+      matchesFilters(
+        issue({
+          creator: {
+            login: "harry",
+            isSoleur: false,
+            display: { name: "harry", initials: "HA" },
+          },
+        }),
+        f,
+      ),
+    ).toBe(true);
+  });
+
+  it("deriveFilterOptions collects distinct creator keys (alphabetical)", () => {
+    const opts = deriveFilterOptions([
+      issue({ creator: human }),
+      issue({ creator: soleur }),
+      issue({ creator: soleurInitiated }),
+      issue({ creator: undefined }),
+    ]);
+    expect(opts.creators).toEqual(["Soleur", "harry", "octocat"]);
+  });
+
+  it("hasActiveFilters is true when a creator is selected", () => {
+    expect(
+      hasActiveFilters({ ...emptyFilters(), creators: new Set(["Soleur"]) }, ""),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a **Created by** filter dimension to the Workstream board (the 5th filter, alongside Priority / Status / Assignee / Domain), so you can narrow the board to issues created by a specific person or by Soleur.

Follows the creator attribution shipped in PR #6253. The filter key is the *effective creator identity*: the human initiator when known, else `Soleur` for a bot-authored issue, else the human author login — so **filtering by a person surfaces both the issues they opened directly AND the Soleur-created issues they initiated**.

Mirrors the existing filter dimensions exactly: a multi-select checkbox dropdown, options derived from the loaded set (hidden when empty), OR-within / AND-across-dimensions, cleared by Reset.

## Changelog
- Workstream: new **Created by** filter dropdown — filter issues by creator (human author / `Soleur` / the human who initiated a Soleur-created issue).
- `lib/workstream.ts`: new `creators` filter dimension + `creatorFilterKey` helper, threaded through `WorkstreamFilters` / `emptyFilters` / `matchesFilters` / `hasActiveFilters` / `FilterOptions` / `deriveFilterOptions`.

## Test plan
- [x] Pure-model tests: `creatorFilterKey` (3 variants), creator match dimension (OR-within, absent-excluded), person surfaces direct + Soleur-initiated, `deriveFilterOptions.creators`, `hasActiveFilters`
- [x] FilterBar component tests: 'Created by' dropdown renders, toggles onChange, hidden when no creators
- [x] Full workstream suite green (147 tests); `tsc` clean; board needs no change (uses `emptyFilters`/`deriveFilterOptions` generically)

Generated with [Claude Code](https://claude.com/claude-code)