### PR TITLE
observability(infra): provision live zot mirror-staleness fallback-rate Sentry alarm (#6278)

### DIFF
--- a/.github/workflows/apply-sentry-infra.yml
+++ b/.github/workflows/apply-sentry-infra.yml
@@ -259,6 +259,7 @@ jobs:
             -target=sentry_issue_alert.sandbox_startup_failure \
             -target=sentry_issue_alert.github_webhook_founder_ambiguous \
             -target=sentry_issue_alert.inbox_action_required_notify_failure \
+            -target=sentry_issue_alert.zot_mirror_fallback_rate \
             -no-color -input=false -out=tfplan
           rc=$?
           if [[ $rc -ne 0 ]]; then

--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -252,10 +252,11 @@ jobs:
         run: |
           # No `set -e` — every failure path exits 0 so this build stays green
           # (SUSPENDERS to the continue-on-error belt). A persistent miss surfaces
-          # as mirror_status=degraded → ::warning:: + step summary. No Slack step in
-          # this workflow (it fires on inngest-bootstrap infra changes, not a
-          # per-release operator event — the operator watches the run they
-          # triggered), so the degraded signal is annotations-only by design.
+          # as mirror_status=degraded → ::warning:: + step summary AND (#6278) a Slack
+          # ⚠️ via the "Post to Slack (inngest mirror status)" step below — degrade-only
+          # (this workflow fires on inngest-bootstrap infra changes, not a per-release
+          # operator event). Before #6278 the degrade was annotations-only; a sustained
+          # pre-cutover degrade now gets push-notification parity with reusable-release.yml.
           set -uo pipefail
 
           # Bounded retry to self-heal a transient TCP reset over the CF-tunnel
@@ -300,3 +301,44 @@ jobs:
             kill "$REGISTRY_BRIDGE_PID" 2>/dev/null || true
           fi
           [[ -f /tmp/cloudflared-registry.log ]] && tail -n 200 /tmp/cloudflared-registry.log || true
+
+      - name: Post to Slack (inngest mirror status)
+        # #6278: pre-cutover push-notification parity with reusable-release.yml's mirror
+        # step. Degrade-only — this workflow has no per-release happy-path Slack (it fires
+        # on inngest-bootstrap infra changes, not an operator-triggered release), so a
+        # degrade-only ⚠️ is the minimal push signal. Before the ADR-096 Phase-5 GHCR-push
+        # retirement a sustained inngest-mirror degrade must not stay annotations-only.
+        if: steps.zot_mirror.outputs.mirror_status == 'degraded'
+        continue-on-error: true
+        env:
+          SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
+          # Resolved image tag (internal, validated by "Resolve image tag") — env-injected,
+          # never inline-interpolated into the run script.
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -uo pipefail
+          WEBHOOK="${SLACK_RELEASES_WEBHOOK_URL:-}"
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::SLACK_RELEASES_WEBHOOK_URL unset; skipping inngest mirror Slack notification"
+            exit 0
+          fi
+          echo "::add-mask::$WEBHOOK"
+
+          MESSAGE="⚠️ inngest-bootstrap zot mirror degraded ($TAG) — GHCR unaffected, zot redundancy reduced; backfill needed."
+          # jq --arg keeps the payload injection-inert (TAG is JSON-escaped).
+          PAYLOAD=$(jq -n --arg text "$MESSAGE" '{text: $text, unfurl_links: false}')
+
+          # `|| echo 000` keeps a curl transport failure (timeout, DNS) on the ::warning
+          # path — without it `set -u`/pipefail would abort before the warning is emitted.
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            --max-time 15 \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$WEBHOOK" || echo "000")
+
+          if [[ "$HTTP_CODE" =~ ^2 ]]; then
+            echo "Slack notification sent (HTTP $HTTP_CODE)"
+          else
+            echo "::warning::Slack notification failed (HTTP $HTTP_CODE)"
+          fi

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -494,7 +494,19 @@ runcmd:
     N=0
     until docker pull "$REF" > /run/soleur-pull.log 2>&1; do
       N=$((N+1))
-      [ "$N" -ge 2 ] && REF="$IMAGE_REF"   # atomic fallback to GHCR after the zot attempt
+      # #6278: on the zot→GHCR flip (REF still the zot ref, so zot WAS primary), emit a
+      # warning breadcrumb (tags.stage=app_ghcr_fallback) so the mirror-staleness
+      # fallback-rate alarm can page on a fresh-boot zot miss on the PRIMARY web
+      # container that still SUCCEEDS via GHCR (otherwise invisible — only a total pull
+      # failure emits). Uses the baked _emit — the only emitter live at this pre-bootstrap
+      # point; the inngest path (bottom of runcmd) uses soleur-boot-emit for the same
+      # `stage` tag because it runs AFTER host-bootstrap authors that binary. The guard
+      # fires exactly once: after the flip REF==IMAGE_REF, and when zot was never primary
+      # (REF started == IMAGE_REF) it never fires. Fail-open (_emit swallows all errors).
+      if [ "$N" -ge 2 ] && [ "$REF" != "$IMAGE_REF" ]; then
+        REF="$IMAGE_REF"   # atomic fallback to GHCR after the zot attempt
+        _emit "app image served via GHCR fallback (zot miss)" "app_ghcr_fallback" warning
+      fi
       [ "$N" -ge 5 ] && { printf ' | pull_err: %s' "$(tail -c 160 /run/soleur-pull.log 2>/dev/null)" >> /run/soleur-stage-detail; exit 1; }
       sleep 5
     done

--- a/apps/web-platform/infra/sentry/issue-alerts.tf
+++ b/apps/web-platform/infra/sentry/issue-alerts.tf
@@ -835,8 +835,11 @@ resource "sentry_issue_alert" "egress_blocked" {
 # child-cgroup OOM that .State.OOMKilled and the "Server startup" event-frequency
 # both miss), so paging on its event is the host-authoritative restart-rate
 # signal. The monitor does the rate thresholding host-side, so a first-seen page
-# is correct (no event_frequency condition needed — and beta2's conditions_v2
-# has no verified event_frequency support; see ADR-062).
+# is correct (no event_frequency condition needed here). NB: beta2's conditions_v2
+# DOES expose event_frequency — schema-verified in #6278 (first used by
+# zot_mirror_fallback_rate at the bottom of this file); the earlier "no verified
+# support" claim (and ADR-062:120) was stale ("no in-repo precedent" was the only
+# true part, and it no longer holds).
 #
 # op-SCOPED filter (op IS_IN, NOT feature-only): the monitor also emits
 # op=recovered (a "storm cleared" event) under the SAME feature tag; scoping to
@@ -1304,6 +1307,102 @@ resource "sentry_issue_alert" "inbox_action_required_notify_failure" {
       }
     },
   ]
+  actions_v2 = [
+    {
+      notify_email = {
+        target_type      = "IssueOwners"
+        fallthrough_type = "ActiveMembers"
+      }
+    },
+  ]
+
+  lifecycle {
+    ignore_changes = [environment]
+  }
+}
+
+# ── zot mirror-staleness fallback-rate alarm (#6278 / ADR-096 "Loud, no-SSH signal") ──
+# APPLY-CREATED. Pages when the runtime zot→GHCR fallback / gate-degrade event rate
+# exceeds >3 in 1h (event_frequency count). The LIVE-RUNTIME complement to the
+# create-time CI degraded signal (mirror_status=degraded → Slack ⚠️ + ::warning::)
+# that merged in #6274 / PR #6276 — this pages the founder on a SUSTAINED post-cutover
+# fallback pattern (a single transient ghcr-fallback is self-healing: the host already
+# served via GHCR — runbook zot-registry-revert.md §"When to revert"). Becomes
+# load-bearing at the ADR-096 Phase-5 GHCR-push retirement, when a silently-missing or
+# unsigned zot copy can gate a host boot and this is the only no-SSH page.
+#
+# filter_match="any" over the FOUR runtime signal tag-VALUES (NOT feature+op "all"):
+# the two ci-deploy.sh signals carry feature/op, but the inngest/app fresh-boot
+# soleur-boot-emit events (cloud-init.yml) carry only `stage` — an all-match on
+# feature+op would silently exclude the boot paths. Signals:
+#   registry ∈ {ghcr-fallback, zot-gate-degraded}         (ci-deploy.sh rolling-deploy)
+#   stage    ∈ {inngest_ghcr_fallback, app_ghcr_fallback} (cloud-init.yml fresh boot)
+#
+# SENSITIVITY NOTE (CTO ruling, #6278): event_frequency thresholds PER fingerprinted
+# Sentry issue-group, not on a true cross-signal aggregate. It reliably pages on the
+# DOMINANT shared-tag correlated outage (a rolling-deploy zot miss drives many hosts
+# onto the SAME `ghcr-fallback (web:<tag>)` group → crosses 3/group); a fully-distributed
+# thin spread (<3 in EVERY signal-group simultaneously) would not page. The aggregate
+# `sentry_metric_alert` was REJECTED here — its trigger.action needs a numeric notify
+# target absent from this root (no team data source; the CI-only SENTRY_IAC_AUTH_TOKEN
+# means it is unresolvable in an autonomous session) → would risk paging nobody. The
+# metric-alert upgrade is tracked as a follow-up (unblocks at the first non-founder
+# Sentry seat — the same boundary the sibling rules already defer).
+#
+# Distinct `frequency = 23` avoids Sentry POST-time exact-duplicate dedup (taken:
+# 5,10-22,30,60-62; keyed on action_match+filter_match+frequency+actions-shape, NOT
+# conditions). Events carry only registry/stage/image/host_id/zot_gate_reason tags —
+# no user content.
+resource "sentry_issue_alert" "zot_mirror_fallback_rate" {
+  organization = var.sentry_org
+  project      = data.sentry_project.web_platform.slug
+  name         = "zot-mirror-fallback-rate"
+  action_match = "all"
+  filter_match = "any"
+  frequency    = 23
+
+  conditions_v2 = [
+    {
+      event_frequency = {
+        comparison_type = "count"
+        value           = 3
+        interval        = "1h"
+      }
+    },
+  ]
+  filters_v2 = [
+    {
+      tagged_event = {
+        key   = "registry"
+        match = "EQUAL"
+        value = "ghcr-fallback"
+      }
+    },
+    {
+      tagged_event = {
+        key   = "registry"
+        match = "EQUAL"
+        value = "zot-gate-degraded"
+      }
+    },
+    {
+      tagged_event = {
+        key   = "stage"
+        match = "EQUAL"
+        value = "inngest_ghcr_fallback"
+      }
+    },
+    {
+      tagged_event = {
+        key   = "stage"
+        match = "EQUAL"
+        value = "app_ghcr_fallback"
+      }
+    },
+  ]
+  # N=1 accepted risk (mirrors every sibling apply-created rule): IssueOwners has no
+  # ownership rule on this project → falls through to ActiveMembers, paging the solo
+  # founder. Events carry only registry/stage/image/host_id — no cross-tenant content.
   actions_v2 = [
     {
       notify_email = {

--- a/apps/web-platform/infra/sentry/issue-alerts.tf
+++ b/apps/web-platform/infra/sentry/issue-alerts.tf
@@ -1349,6 +1349,18 @@ resource "sentry_issue_alert" "inbox_action_required_notify_failure" {
 # metric-alert upgrade is tracked as a follow-up (unblocks at the first non-founder
 # Sentry seat — the same boundary the sibling rules already defer).
 #
+# PER-SIGNAL grouping asymmetry (observability review, #6278): the three signals do NOT
+# group uniformly. `ghcr-fallback` (message includes registry+image+tag), `zot-gate-degraded`
+# (message includes the reason), and `app_ghcr_fallback` (dedicated `_emit` message) each
+# form their own message-group, so the >3/1h threshold is meaningful for them. But
+# `inngest_ghcr_fallback` is emitted via the SHARED `soleur-boot-emit` static message
+# ("soleur-cloud-init boot stage" — stage is a tag, not the message), so it shares one
+# issue-group with every routine boot stage; that group is effectively always >3/1h, so
+# THIS signal pages on the FIRST inngest fresh-boot fallback — over-loud, the SAFE
+# direction (never a miss). Acceptable: fresh-boot inngest zot misses are rare and any is
+# worth knowing during the soak. Giving inngest its own message-group would mean changing
+# the shared `soleur-boot-emit` grouping for ~10 boot stages — out of scope for this alarm.
+#
 # Distinct `frequency = 23` avoids Sentry POST-time exact-duplicate dedup (taken:
 # 5,10-22,30,60-62; keyed on action_match+filter_match+frequency+actions-shape, NOT
 # conditions). Events carry only registry/stage/image/host_id/zot_gate_reason tags —

--- a/apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts
@@ -29,15 +29,20 @@ describe("zot-mirror-fallback-rate alert op contract", () => {
   it("ci-deploy.sh emits the supply-chain image-pull tags + both registry values", () => {
     expect(ciDeploy).toContain(`feature: "supply-chain"`);
     expect(ciDeploy).toContain(`op: "image-pull"`);
-    // ghcr-fallback is the level-warning registry value from registry_pull_event;
-    // zot-gate-degraded is the literal from zot_gate_degraded_event.
-    expect(ciDeploy).toContain("ghcr-fallback");
+    // Pin the exact EMIT forms, not the bare tag literals: `ghcr-fallback` also
+    // appears in several ci-deploy.sh comments, so a bare `toContain("ghcr-fallback")`
+    // would stay GREEN even if the emit CALL were renamed — the silent-DARK failure
+    // this guard exists to catch. `registry_pull_event ghcr-fallback` (the call site)
+    // and `registry: "zot-gate-degraded"` (the jq tag literal) are emit-only.
+    expect(ciDeploy).toContain("registry_pull_event ghcr-fallback");
     expect(ciDeploy).toContain(`registry: "zot-gate-degraded"`);
   });
 
   it("cloud-init.yml emits both fresh-boot fallback stages (inngest + app-image)", () => {
-    expect(cloudInit).toContain("inngest_ghcr_fallback");
-    expect(cloudInit).toContain("app_ghcr_fallback");
+    // Pin the exact emit CALL forms — `app_ghcr_fallback` also appears in this PR's
+    // Phase-1b explanatory comment, so pinning the bare stage would be vacuous.
+    expect(cloudInit).toContain("soleur-boot-emit inngest_ghcr_fallback warning");
+    expect(cloudInit).toContain(`"app_ghcr_fallback" warning`);
   });
 
   it("issue-alerts.tf pins all four signal tag-values (any-match OR)", () => {
@@ -62,6 +67,11 @@ describe("zot-mirror-fallback-rate alert op contract", () => {
     expect(scoped).toMatch(/comparison_type\s*=\s*"count"/);
     expect(scoped).toMatch(/value\s*=\s*3/);
     expect(scoped).toMatch(/interval\s*=\s*"1h"/);
+    // Pin the no-SSH page target: a silent removal of the notify action would
+    // make the alarm fire-but-page-nobody (the exact Branch-B failure the CTO
+    // ruling avoided). IssueOwners→ActiveMembers reaches the solo founder.
+    expect(scoped).toContain("IssueOwners");
+    expect(scoped).toContain("ActiveMembers");
   });
 
   it("the -target wiring guards that the apply workflow creates the rule", () => {

--- a/apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts
+++ b/apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, it, expect } from "vitest";
+
+// Cross-artifact contract test for the zot mirror-staleness fallback-rate alarm
+// (#6278 / ADR-096 "Loud, no-SSH signal").
+//
+// The `zot-mirror-fallback-rate` Sentry issue-alert pages when the runtime
+// zot→GHCR fallback / gate-degrade event rate exceeds >3 / 1h (event_frequency),
+// matching the OR of FOUR runtime signals (filter_match="any"):
+//   - registry == "ghcr-fallback"      (ci-deploy.sh rolling-deploy pull fallback)
+//   - registry == "zot-gate-degraded"  (ci-deploy.sh dark-gate degrade beacon)
+//   - stage    == "inngest_ghcr_fallback" (cloud-init.yml inngest fresh-boot pull)
+//   - stage    == "app_ghcr_fallback"     (cloud-init.yml app-image fresh-boot pull, #6278 Phase 1b)
+//
+// The inngest/app boot events carry only `stage` (no feature/op), so the filter is
+// `any` over the tag-VALUES, not `all` over feature+op. Each tag string is pinned
+// in BOTH its emit site AND issue-alerts.tf so a rename in either — which would
+// silently DARK the alert (the operator-only-finds-out-post-cutover failure mode
+// this alarm exists to prevent) — breaks CI instead.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tf = readFileSync(join(here, "../infra/sentry/issue-alerts.tf"), "utf8");
+const ciDeploy = readFileSync(join(here, "../infra/ci-deploy.sh"), "utf8");
+const cloudInit = readFileSync(join(here, "../infra/cloud-init.yml"), "utf8");
+
+describe("zot-mirror-fallback-rate alert op contract", () => {
+  it("ci-deploy.sh emits the supply-chain image-pull tags + both registry values", () => {
+    expect(ciDeploy).toContain(`feature: "supply-chain"`);
+    expect(ciDeploy).toContain(`op: "image-pull"`);
+    // ghcr-fallback is the level-warning registry value from registry_pull_event;
+    // zot-gate-degraded is the literal from zot_gate_degraded_event.
+    expect(ciDeploy).toContain("ghcr-fallback");
+    expect(ciDeploy).toContain(`registry: "zot-gate-degraded"`);
+  });
+
+  it("cloud-init.yml emits both fresh-boot fallback stages (inngest + app-image)", () => {
+    expect(cloudInit).toContain("inngest_ghcr_fallback");
+    expect(cloudInit).toContain("app_ghcr_fallback");
+  });
+
+  it("issue-alerts.tf pins all four signal tag-values (any-match OR)", () => {
+    expect(tf).toContain(`value = "ghcr-fallback"`);
+    expect(tf).toContain(`value = "zot-gate-degraded"`);
+    expect(tf).toContain(`value = "inngest_ghcr_fallback"`);
+    expect(tf).toContain(`value = "app_ghcr_fallback"`);
+  });
+
+  it("issue-alerts.tf declares the zot_mirror_fallback_rate resource with an any-match event_frequency rule", () => {
+    expect(tf).toContain(
+      'resource "sentry_issue_alert" "zot_mirror_fallback_rate"',
+    );
+    // Aggregate-rate intent: event_frequency count > 3 within 1h (not a first_seen page).
+    const block = tf.slice(
+      tf.indexOf('resource "sentry_issue_alert" "zot_mirror_fallback_rate"'),
+    );
+    const resourceEnd = block.indexOf("\nresource ");
+    const scoped = resourceEnd === -1 ? block : block.slice(0, resourceEnd);
+    expect(scoped).toMatch(/filter_match\s*=\s*"any"/);
+    expect(scoped).toContain("event_frequency");
+    expect(scoped).toMatch(/comparison_type\s*=\s*"count"/);
+    expect(scoped).toMatch(/value\s*=\s*3/);
+    expect(scoped).toMatch(/interval\s*=\s*"1h"/);
+  });
+
+  it("the -target wiring guards that the apply workflow creates the rule", () => {
+    const wf = readFileSync(
+      join(here, "../../../.github/workflows/apply-sentry-infra.yml"),
+      "utf8",
+    );
+    expect(wf).toContain(
+      "-target=sentry_issue_alert.zot_mirror_fallback_rate",
+    );
+  });
+});

--- a/knowledge-base/engineering/architecture/decisions/ADR-062-container-memory-cap-and-restart-attribution.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-062-container-memory-cap-and-restart-attribution.md
@@ -117,10 +117,13 @@ fatals report **once**. The "Server startup" event is tagged
 host-authoritative event (`feature=container-restart-monitor`, op-scoped to
 `{restart_storm, fresh_crash_loop}`; the informational `recovered` op is
 excluded). It uses the proven `first_seen/reappeared/regression` + `tagged_event`
-pattern — **not** an `event_frequency` condition. The pinned `jianyuan/sentry@
-0.15.0-beta2` `conditions_v2` has no in-repo precedent for `event_frequency`, and
-the monitor already does the rate thresholding host-side, so a first-seen page on
-its event is both correct and lower-risk than an unverified schema. The "Server
+pattern — **not** an `event_frequency` condition. The monitor already does the rate
+thresholding host-side, so a first-seen page on its event is both correct and simpler
+than a redundant frequency condition. (Update, #6278: the pinned `jianyuan/sentry@
+0.15.0-beta2` `conditions_v2` **does** expose `event_frequency` — schema-verified via
+the cached provider binary; the first in-repo use is `zot_mirror_fallback_rate` in
+`issue-alerts.tf`. The original "no verified support" framing was stale; first-seen
+remains preferred *here* purely because the host does the thresholding.) The "Server
 startup" event-frequency remains available for AC12 verification via the Sentry
 issue stats API.
 

--- a/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
@@ -89,8 +89,8 @@ independent axes so it never silently gates a host:
     runtime signals (`registry:{ghcr-fallback,zot-gate-degraded}`,
     `stage:{inngest_ghcr_fallback,app_ghcr_fallback}`). It is load-bearing at the Phase-5 GHCR-push
     retirement. (Sensitivity note: it thresholds per Sentry issue-group, not a true cross-signal
-    aggregate — see the resource comment; a `sentry_metric_alert` upgrade is deferred until a
-    resolvable numeric notify target exists in the Sentry TF root.) Two post-cutover boot-gating
+    aggregate — see the resource comment; a `sentry_metric_alert` upgrade is deferred to #6285 until
+    a resolvable numeric notify target exists in the Sentry TF root.) Two post-cutover boot-gating
     shapes the degraded signal must remain loud for: a **missing** copy (crane-copy failure) AND a
     **present-but-unsigned** copy (cosign-sign succeeded-copy-then-failed-sign) — the latter is NOT a
     clean miss, since the pull side would pull the present zot copy and *bypass* the atomic GHCR

--- a/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
@@ -82,9 +82,15 @@ independent axes so it never silently gates a host:
     CF-tunnel reset) — a mirror failure degrades zot redundancy, never the release/build verdict
     (consistent with "latency, not availability" above). A persistent miss is loud via a CI-level
     degraded signal: `mirror_status=degraded` → `::warning::` + step summary (both workflows) + a
-    ⚠️ line on the Slack release message (`reusable-release.yml` only). The *live* fallback-rate
-    Sentry alarm the bullet above references is **design intent, not yet provisioned** — a separate
-    IaC follow-up, load-bearing at the Phase-5 GHCR-push retirement. Two post-cutover boot-gating
+    ⚠️ line on the Slack release message (`reusable-release.yml`; #6278 added the same ⚠️ to
+    `build-inngest-bootstrap-image.yml`). The *live* fallback-rate Sentry alarm the bullet above
+    references is now **provisioned in #6278** — `sentry_issue_alert.zot_mirror_fallback_rate`
+    (`issue-alerts.tf`), an `event_frequency` count > 3/1h over `filter_match="any"` across the four
+    runtime signals (`registry:{ghcr-fallback,zot-gate-degraded}`,
+    `stage:{inngest_ghcr_fallback,app_ghcr_fallback}`). It is load-bearing at the Phase-5 GHCR-push
+    retirement. (Sensitivity note: it thresholds per Sentry issue-group, not a true cross-signal
+    aggregate — see the resource comment; a `sentry_metric_alert` upgrade is deferred until a
+    resolvable numeric notify target exists in the Sentry TF root.) Two post-cutover boot-gating
     shapes the degraded signal must remain loud for: a **missing** copy (crane-copy failure) AND a
     **present-but-unsigned** copy (cosign-sign succeeded-copy-then-failed-sign) — the latter is NOT a
     clean miss, since the pull side would pull the present zot copy and *bypass* the atomic GHCR

--- a/knowledge-base/project/learnings/2026-07-09-sentry-fallback-rate-alarm-pre-bootstrap-emitter-and-issue-group-grouping.md
+++ b/knowledge-base/project/learnings/2026-07-09-sentry-fallback-rate-alarm-pre-bootstrap-emitter-and-issue-group-grouping.md
@@ -1,0 +1,96 @@
+---
+title: Sentry fallback-rate alarm — pre-bootstrap emitter, issue-alert notify targets, and shared-message grouping
+date: 2026-07-09
+category: integration-issues
+module: apps/web-platform/infra/sentry, apps/web-platform/infra/cloud-init.yml
+issue: 6278
+pr: 6281
+tags: [sentry, observability, terraform, cloud-init, zot, adr-096]
+---
+
+# Learning: provisioning a Sentry fallback-rate alarm (#6278)
+
+Three non-obvious constraints surfaced while provisioning ADR-096's "Loud, no-SSH signal"
+fallback-rate alarm. Each is generalizable to any future Sentry alarm + boot-emit work.
+
+## Problem
+
+Wire a `>3/1h` Sentry alarm that pages on zot→GHCR mirror fallbacks across four runtime
+signals (two `ci-deploy.sh` emits + two cloud-init fresh-boot emits), plus add a boot
+breadcrumb for the app-image fresh-boot fallback path.
+
+## Key Insights
+
+### 1. `sentry_metric_alert` is NOT autonomously deployable in a TF root with no resolvable notify target
+
+The plan's primary design was a `sentry_metric_alert` (true cross-signal aggregate — the
+correct sensitivity). But metric-alert `trigger.action` requires a **concrete numeric
+`target_identifier`** (team-id or member-id) — there is **no** `IssueOwners → ActiveMembers`
+symbolic fallthrough for metric alerts (that construct exists ONLY on
+`sentry_issue_alert.actions_v2.notify_email`). This Sentry TF root has zero resolvable numeric
+targets (no `sentry_team` data source, no `owner=`), and the token to mint one
+(`SENTRY_IAC_AUTH_TOKEN`) is CI-only (ADR-031, not in Doppler). So a metric alert could not be
+resolved/verified in an autonomous session → risk of shipping a safety control that **pages
+nobody**. The CTO agent ruled to ship a `sentry_issue_alert` + `event_frequency` (symbolic
+notify, config-verifiable), accepting the per-issue-group sensitivity, with a filed follow-up
+(#6285) to upgrade once a numeric target exists (first non-founder Sentry seat).
+
+**Generalizable rule:** before choosing `sentry_metric_alert` over `sentry_issue_alert`, check
+whether the TF root has a resolvable numeric notify target. If not, the metric alert is not
+autonomously deployable and the issue-alert (symbolic `IssueOwners→ActiveMembers`) is the
+correct default. Verifiability of the notify PATH dominates aggregate sensitivity for a safety
+control.
+
+### 2. A cloud-init boot breadcrumb's emitter depends on WHERE in the boot sequence it fires
+
+`cloud-init.yml` runcmd concatenates ALL `- |` blocks into ONE `/bin/sh` process (proven by
+the top-armed `on_err` trap + `STAGE=` variable persisting across blocks). Two emitters exist:
+
+- **Baked `_emit <msg> <stage> <level>`** — defined at the TOP of runcmd (~:301), available
+  everywhere below, POSTs to Sentry via the baked `${sentry_dsn}`.
+- **`/usr/local/bin/soleur-boot-emit <stage> <level>`** — authored by `soleur-host-bootstrap.sh`,
+  which only runs LATER in runcmd (~:520).
+
+So a call site's correct emitter is position-dependent: the **app-image pull (~:496) runs
+BEFORE host-bootstrap** → must use `_emit`; the **inngest pull (~:650) runs after** → uses
+`soleur-boot-emit`. The plan prescribed `soleur-boot-emit` at :496 "symmetric with the inngest
+path" — that would have been `command not found` (silent no-op, since runcmd has no `set -e`).
+Both emitters set a `stage` tag, so the alarm filter (`stage:app_ghcr_fallback`) matches either.
+
+**Generalizable rule:** before adding a `soleur-boot-emit` call in cloud-init, confirm the call
+site is AFTER `soleur-host-bootstrap.sh` runs (grep the invocation line number). Pre-bootstrap
+sites use the baked `_emit`.
+
+### 3. Sentry issue-alert `event_frequency` counts the whole issue-GROUP — a shared static message makes it over-loud
+
+`sentry_issue_alert` `event_frequency` (`count > N in interval`) counts events in the Sentry
+**issue-group**, and Sentry groups message-type events by their **message string**. `filters_v2`
+(`tagged_event`) only gate whether the triggering event evaluates the rule — they do NOT scope
+the count. Consequence: a signal whose emitter uses a **shared static message** shares one group
+with unrelated events, so its `event_frequency` is effectively always hot → it pages on the
+FIRST occurrence, not at a sustained rate.
+
+Concretely: `soleur-boot-emit` hard-codes `message="soleur-cloud-init boot stage"` for every
+stage (stage is a tag), so `inngest_ghcr_fallback` shares a group with all routine boot stages
+→ over-loud (safe direction, but not "sustained"). The other three signals use per-content
+messages (`registry_pull_event` includes registry+image+tag; `zot_gate_degraded_event` includes
+the reason; the new `_emit` uses a dedicated message), so their thresholds are meaningful.
+
+**Generalizable rule:** for a per-rate Sentry issue-alert, each watched signal needs its OWN
+message-group (a distinct message or an explicit `fingerprint`). A signal emitted via a shared
+static message will page on first occurrence — document it or give it a dedicated message.
+
+## Session Errors
+
+1. **Draft-PR push rejected ("reference already exists")** — stale empty remote branch from a prior aborted run. Recovery: verified init-commit-only + no live PR, created draft PR directly. **Prevention:** `worktree-manager.sh create` auto-heals stale EMPTY branches; a `draft-pr` push conflict on a branch with only the init commit is benign — verify `gh pr list --head` + `git rev-list origin/main..origin/<branch>` before treating it as a collision.
+2. **`terraform providers schema`/`validate` needs S3 backend-init in the real dir** — Recovery: scratch-dir `filesystem_mirror` pointed at the cached provider binary + `terraform init -backend=false`. **Prevention:** for provider-schema/validate work without backend creds, always use a scratch dir + filesystem_mirror (never init the real backend-bound dir).
+3. **Plan's Phase-1b emitter was placement-wrong** (`soleur-boot-emit` pre-bootstrap → command-not-found). Recovery: traced boot sequence, used `_emit`. **Prevention:** Insight #2 above; a plan prescribing an emitter is authoritative for INTENT (emit stage X), never for the exact binary at a position-dependent call site.
+4. **Branch decision inverted from plan primary** — routed the fork to the CTO agent (not the operator; not decided unilaterally). **Prevention:** working as designed (architectural-fork gate).
+5. **Vacuous op-contract assertions** (review-caught) — bare `toContain("ghcr-fallback")` matched comments. Recovery: pinned emit-CALL forms; verified non-vacuous via simulated-rename RED. **Prevention:** recurrence of `2026-06-17-grep-assertion-over-script-body-false-matches-own-comments.md` — a source-grep contract assertion MUST anchor on the emit/call construct, never a bare literal the file also names in a comment.
+6. **inngest signal over-loud** (review-caught) — Insight #3. Recovery: disclosed in the SENSITIVITY NOTE. **Prevention:** Insight #3 above.
+7. **`git stash list` blocked by guardrails hook** (read-only). Recovery: used `git log`/`diff`. **Prevention:** known — never invoke any `git stash` form in a worktree; use `git show <commit>:<path>`.
+8. **Behind-origin/main (ADR-105 appeared deleted)** — sibling #6282 merged mid-session. Recovery: staged only my files, merged origin/main. **Prevention:** known bare-repo stale-base; stage explicit file lists (never `git add -A`), diff-verify before commit.
+
+## Tags
+category: integration-issues
+module: sentry-observability, cloud-init

--- a/knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md
+++ b/knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md
@@ -1,0 +1,519 @@
+---
+title: Provision the live zot mirror-staleness Sentry fallback-rate alarm (>3/1h) + inngest-bootstrap mirror push-notification signal
+issue: 6278
+branch: feat-one-shot-6278-zot-mirror-staleness-alarm
+type: observability-infra
+lane: single-domain
+brand_survival_threshold: aggregate pattern
+date: 2026-07-09
+labels: [priority/p3-low, domain/engineering, observability, deferred-automation]
+---
+
+# Provision the live zot mirror-staleness Sentry alarm (#6278)
+
+## Overview
+
+ADR-096 (self-hosted zot registry migration) mitigates the "zot is a boot-time SPOF"
+risk on four axes. One axis — **"Loud, no-SSH signal"** — states *"every fallback emits a
+Sentry `registry:"ghcr-fallback"` … event (the fallback-rate alarm pages at >3/1h)."* The
+emit side of that axis is live (`ci-deploy.sh registry_pull_event`, merged), but the alarm
+itself was recorded as **"design intent, not yet provisioned"** and deferred as #6278 (from
+#6274). It becomes **load-bearing at the ADR-096 Phase-5 GHCR-push retirement**: post-cutover
+a silently-missing (or present-but-unsigned) zot copy can gate a host boot, and the only
+no-SSH page for a sustained fallback is this alarm.
+
+This plan delivers two things:
+
+1. **The live runtime fallback-rate Sentry alarm** — a new `sentry_issue_alert` (or, per the
+   Phase-0 provider-schema probe, a `sentry_metric_alert`) in
+   `apps/web-platform/infra/sentry/issue-alerts.tf` that pages when the fallback/degrade event
+   rate exceeds **>3 in 1h**. This is the **live runtime** alarm — separate IaC from the
+   **create-time CI degraded signal** (`mirror_status=degraded` → Slack ⚠️ + `::warning::`)
+   that merged in PR #6276 (#6274).
+
+2. **A live/push-notification signal for the inngest-bootstrap mirror degrade path.** The
+   `build-inngest-bootstrap-image.yml` `zot_mirror` step's `degraded()` currently emits
+   `::warning::` + step-summary only ("annotations-only by design"), unlike its sibling
+   `reusable-release.yml` which also posts a Slack ⚠️ line (PR #6276). Before cutover this
+   path should get an equivalent push signal.
+
+Both are **P3-low, deferred-automation** follow-ups; neither is user-facing.
+
+## Enhancement Summary
+
+**Deepened on:** 2026-07-09 · **Research agents:** Explore (provider-schema verification), architecture-strategist (alarm-design review).
+
+### Key improvements from deepen-plan
+1. **`event_frequency` IS in the beta2 provider schema — repo comments are stale.** The Explore
+   agent inspected the cached provider binary (`.../jianyuan/sentry/0.15.0-beta2/.../terraform-provider-sentry_v0.15.0-beta2`,
+   present in the sibling worktree `feat-one-shot-anthropic-cost-attribution`) and found
+   `event_frequency`, `event_frequency_count`, `event_frequency_percent` as first-class
+   `conditions_v2` block types (same field shape as the proven `event_unique_user_frequency`:
+   `comparison_type`/`value`/`interval`/`comparison_interval`). The claims at
+   `issue-alerts.tf:838-839` + `ADR-062:120` ("no verified event_frequency support") are **false** —
+   only "no in-repo precedent" is literally true. This de-risks the Phase-0 gate to a network-free probe.
+2. **Primary mechanism flipped to `sentry_metric_alert` (aggregate) — issue-alert is under-sensitive.**
+   architecture-strategist (P1) showed the runbook specifies an *aggregate* count>3/1h across the
+   OR-of-three, but issue-alert `event_frequency` evaluates **per fingerprinted issue-group**, and
+   the three signals fingerprint into distinct issues — *worsened* by per-message fingerprinting
+   (`ci-deploy.sh:561` builds `"…(web:<tag>)"` vs `"…(inngest:<tag>)"`; `:590` varies by reason).
+   A distributed outage (2 inngest + 2 web + 1 gate-degraded = aggregate 5) pages **zero** groups at
+   3/1h → the issue alert stays **silent** on exactly the distributed sustained-degradation the alarm
+   targets. Under-sensitivity is the wrong failure direction for a deliberately-low page threshold.
+   **Branch B (metric alert) is now primary**; Branch A (issue-alert + event_frequency) is the
+   fallback, and if selected the PR MUST surface the per-path (non-aggregate) sensitivity to the operator.
+3. **Branch-B query bug fixed:** these are `store`-API events with `level:warning` and **no
+   exception** → `event.type:default`, not `error`. The earlier `event.type:error`-prefixed query
+   would exclude every event → a silent-no-op alarm. Query prefix dropped; Phase-0 must confirm the
+   metric-alert dataset matches `event.type:default` warning events.
+4. **Branch-B guard gap closed (P1):** `tests/scripts/lib/destroy-guard-filter-sentry.jq` needs a new
+   `sentry_metric_alert` nested-clause (array-of-blocks `trigger[]`/`action[]`) — omitting it is a
+   silent destroy-guard bypass for the new type. Added to Branch-B Files to Edit + Phase 2 + Sharp Edges.
+5. **Boot-coverage overstatement corrected (P2):** the main **app-image** fresh-boot pull
+   (`cloud-init.yml:485-501`) does zot→GHCR fallback but emits **no** fallback breadcrumb (only a
+   `stage=pull` *fatal* on total failure) — so a fresh-boot zot miss on the primary web container that
+   *succeeds* via GHCR is invisible and no alarm can page on it. Added an in-scope emit task (Phase 1b)
+   + a 4th signal so the alarm genuinely covers the boot path, with a descope-to-blind-spot alternative.
+
+### Verified-correct premises (no change)
+`frequency = 23` is genuinely free; `event_unique_user_frequency` correctly rejected (host events carry
+no `user`); `filter_match="any"` over the globally-unique tag-values is safe (Q3 endorsed — no other
+emitter uses these values); Branch-A guard sweep ("only the `-target` line") verified complete (Q4).
+
+## Premise Validation
+
+All cited artifacts verified against the worktree (`origin/main` tip) — **no stale premises**:
+
+- **Issue #6278** — OPEN, milestone "Post-MVP / Later". Its body is the source of scope.
+- **Infra path `apps/web-platform/infra/sentry/issue-alerts.tf`** — EXISTS (1319 lines, 20
+  `sentry_issue_alert` resources: 4 import-only auth rules + 16 apply-created rules).
+- **Emitting marker `feature:supply-chain op:image-pull registry:"ghcr-fallback"`** — genuinely
+  emitted by `apps/web-platform/infra/ci-deploy.sh:562-564` (`registry_pull_event ghcr-fallback`,
+  `level: warning`). Confirmed via `git grep`. The `zot-soak-6122.sh` follow-through already
+  queries this exact string (`sentry_count 'feature:supply-chain op:image-pull registry:"ghcr-fallback"'`).
+- **PR #6276 (#6274)** — merged 2026-07; added the CI-level `mirror_status=degraded` signal to
+  BOTH mirror workflows + the Slack ⚠️ line to `reusable-release.yml` only. Confirmed via
+  `reusable-release.yml:829-914` (Slack step reads `MIRROR_STATUS`) and the
+  `build-inngest-bootstrap-image.yml` `zot_mirror` comment ("No Slack step in this workflow …
+  annotations-only by design").
+- **ADR-096** — Status "Adopting"; the "Loud, no-SSH signal" bullet + the CI-push sub-bullet
+  explicitly call this alarm "design intent, not yet provisioned — a separate IaC follow-up".
+- **Runbook `zot-registry-revert.md`** — §"Fallback-rate alarm" is the authoritative operational
+  design of the alarm (see Research Reconciliation — it is BROADER than the issue body).
+- **Own-capability bound (hr-verify-repo-capability-claim-before-assert):** the claim "beta2's
+  `conditions_v2` supports raw event-count thresholds" was NOT assumed — ADR-062:120 + the
+  `container-restart-monitor` comment (issue-alerts.tf:838) both state beta2's `conditions_v2`
+  has **no verified `event_frequency` support**. This is the load-bearing Phase-0 gate below,
+  not an assumption.
+
+## Research Reconciliation — Spec vs. Codebase
+
+Three material divergences between the issue body's literal ask and codebase/runbook reality.
+The plan resolves each explicitly rather than inheriting the issue's simplification.
+
+| Spec claim (issue body) | Reality (verified) | Plan response |
+|---|---|---|
+| Alarm matches `feature:supply-chain op:image-pull registry:"ghcr-fallback"` (one signal). | The **authoritative runbook** (`zot-registry-revert.md` §Fallback-rate alarm) specifies the alarm should page on the **OR of three** runtime signals: `registry:"ghcr-fallback"` (rolling deploy) **OR** `stage:"inngest_ghcr_fallback"` (fresh-boot inngest pull, `cloud-init.yml:650`) **OR** `registry:"zot-gate-degraded"` (`ci-deploy.sh zot_gate_degraded_event`). ADR-096's axis — which the issue cites — names the broad alarm. | **Recommend covering all three** (see Phase 1 design decision). Leaving `inngest_ghcr_fallback` + `zot-gate-degraded` unpaged reopens the exact boot-gating gap #6278 exists to close at cutover. The issue's single-signal wording is a simplification, not a scope ceiling. |
+| A `>3/1h` "fallback-rate" threshold is trivially a raw event-count condition. | **[deepen-plan CORRECTED]** `event_frequency` IS in the beta2 `conditions_v2` schema (Explore agent verified the cached provider binary — `event_frequency`/`event_frequency_count`/`event_frequency_percent` block types exist). The `ADR-062:120` + `issue-alerts.tf:838` "no verified support" comments are **stale** ("no in-repo precedent" is the only true part). These host-emitted events carry **no `user`** → `event_unique_user_frequency` (the sibling that IS used in-repo) would count 0 users and never fire. | **Primary = `sentry_metric_alert` (aggregate)** — architecture-strategist P1: issue-alert `event_frequency` thresholds are **per-issue-group**, and the 3 signals fingerprint into distinct issues (further split by message string), so a distributed 2+2+1 outage never reaches 3/group and the alarm stays silent — the wrong failure direction. Metric alerts aggregate across the query. **Fallback = `sentry_issue_alert` + `event_frequency`** (now schema-confirmed); if used, the PR must surface the per-path (non-aggregate) sensitivity to the operator. `event_unique_user_frequency` **rejected** (no user on events). Phase-0 confirms the metric-alert dataset matches these `event.type:default` warning events. |
+| The three signals all share `feature:supply-chain op:image-pull` (implied by the runbook prose). | The fresh-boot `inngest_ghcr_fallback` event (`cloud-init.yml:316,650` via `soleur-boot-emit`) carries only `{stage, image_ref, host_id, detail}` — **NOT** `feature`/`op`. Only the two `ci-deploy.sh` signals carry `feature:supply-chain op:image-pull`. | A single `filter_match="all"` on `feature`+`op` CANNOT match the inngest path. Filter design must be `filter_match="any"` over the tag-values (issue-alert branch) or an OR query (metric-alert branch). Phase-0 confirms each emit site's exact tag set before freezing the filter. |
+
+## Implementation Phases
+
+### Phase 0 — Provider-schema + dataset probe (load-bearing; blocks all design choices)
+
+The provider binary is **already cached** in the sibling worktree
+`.worktrees/feat-one-shot-anthropic-cost-attribution/apps/web-platform/infra/sentry/.terraform/…/jianyuan/sentry/0.15.0-beta2/`
+— so the schema probe needs **no `terraform init` / no network**. Record answers into spec before Phase 1.
+
+1. **`sentry_metric_alert` shape (PRIMARY branch).** Confirm the resource + its `aggregate`,
+   `dataset`, `query`, `time_window` (seconds), `threshold_type`, nested `trigger { alert_threshold,
+   action {…} }` attributes.
+   ```bash
+   terraform -chdir=<sibling-sentry-dir> providers schema -json \
+     | jq '.provider_schemas["registry.terraform.io/jianyuan/sentry"].resource_schemas.sentry_metric_alert.block'
+   ```
+2. **Metric-alert dataset matchability of `event.type:default` warning events (P1 — architecture-strategist).**
+   These fallback events are `store`-API posts with `level:warning` and **no exception** →
+   `event.type:default`, NOT `error`. Confirm the chosen `dataset` (likely `events`, not `errors`) +
+   query returns them; **the query must NOT be prefixed `event.type:error`** (that excludes every one →
+   silent-no-op alarm). If the metric-alert dataset cannot match default/warning events, fall back to Branch A.
+3. **`event_frequency` block in `conditions_v2` (FALLBACK branch — already CONFIRMED present).**
+   ```bash
+   terraform -chdir=<sibling-sentry-dir> providers schema -json \
+     | jq '.provider_schemas["registry.terraform.io/jianyuan/sentry"].resource_schemas.sentry_issue_alert.block.block_types.conditions_v2.block.block_types | keys'
+   # expect: [..."event_frequency","event_frequency_count","event_frequency_percent","event_unique_user_frequency"...]
+   ```
+4. **Re-confirm the exact tags each emit site carries** (freezes the filter/query):
+   - `ci-deploy.sh:564` → `feature=supply-chain op=image-pull registry=ghcr-fallback image=<web|inngest>`
+   - `ci-deploy.sh:592` → `feature=supply-chain op=image-pull registry=zot-gate-degraded zot_gate_reason=<...>`
+   - `cloud-init.yml:316/650` (`soleur-boot-emit inngest_ghcr_fallback warning`) → `stage=inngest_ghcr_fallback image_ref=<...> host_id=<...>` (NO feature/op).
+   - **[Phase 1b] app-image boot fallback** — after adding the emit, confirm `cloud-init.yml:~496` emits `stage=app_ghcr_fallback` on the zot→GHCR web-boot fallback branch.
+5. **Pick a free `frequency` value** (issue-alert fallback branch only). Taken:
+   5,10,11,12,13,14,15,16,17,18,19,20,21,22,30,60,61,62. **Use `frequency = 23`** (free).
+
+**No `.tf` edit is frozen until this probe resolves.** Decision rule: **Branch B (metric alert)
+unless step 2 proves the dataset cannot match default/warning events**, in which case Branch A with an
+operator-surfaced per-path-sensitivity note.
+
+### Phase 1 — Add the fallback-rate alarm resource to `issue-alerts.tf`
+
+**Design decision:** cover the runtime fallback/degrade signals in ONE aggregate alarm. Primary is a
+`sentry_metric_alert` (true aggregate count>3/1h across the OR — matches the runbook spec);
+`sentry_issue_alert` + `event_frequency` is the Phase-0 fallback (its per-issue-group threshold is
+under-sensitive to distributed degradation — architecture-strategist P1).
+
+**Branch B (PRIMARY) — `sentry_metric_alert` (aggregate):** the native rate primitive; the runbook
+explicitly sanctions "Sentry issue/**metric** alert". Final `aggregate`/`dataset`/`query`/trigger
+shape frozen against the Phase-0 schema dump. Shape (illustrative — attribute names confirmed in Phase 0):
+```hcl
+# ── zot mirror fallback-rate alarm (#6278 / ADR-096 "Loud, no-SSH signal") ──
+# APPLY-CREATED. Pages when the AGGREGATE runtime fallback/degrade rate exceeds
+# >3 events in 1h across the OR-of-signals (zot-registry-revert.md §Fallback-rate
+# alarm). Aggregate (not per-issue-group) so a distributed outage scattered across
+# signals/images still pages (architecture-strategist P1). The live complement to
+# the create-time CI degraded signal (#6274 / PR #6276).
+resource "sentry_metric_alert" "zot_mirror_fallback_rate" {
+  organization = var.sentry_org
+  project      = data.sentry_project.web_platform.slug
+  name         = "zot-mirror-fallback-rate"
+  dataset      = "events"       # Phase-0: MUST match event.type:default warning events, NOT "errors"
+  aggregate    = "count()"
+  time_window  = 60             # minutes → the "/1h" window
+  # NO `event.type:error` prefix — these are level:warning/default store events (P1 fix).
+  # Covers the 3 (→4 with Phase 1b) runtime signals; unique tag-values, so no feature/op needed.
+  query          = "registry:ghcr-fallback OR registry:zot-gate-degraded OR stage:inngest_ghcr_fallback OR stage:app_ghcr_fallback"
+  threshold_type = 0            # 0 = above
+  trigger {
+    label             = "critical"
+    threshold_type    = 0
+    alert_threshold   = 3       # >3 in the 60-min window
+    resolve_threshold = 0
+    action {
+      type             = "email"
+      target_type      = "team"   # Phase-0: confirm the notify-owners/team shape for a solo-founder org
+      target_identifier = "<ops-team-or-member-id>"
+    }
+  }
+}
+```
+Because this is a **new resource TYPE** for this root, Branch B ALSO requires: the `-target` set
+(`apply-sentry-infra.yml`), the destroy-guard scope-guard allowlist, AND the destroy-guard **jq
+filter** (`destroy-guard-filter-sentry.jq` — a `sentry_metric_alert` nested-clause summing
+`trigger[]`/`action[]` deltas; omitting it is a silent destroy-guard bypass — architecture-strategist P1).
+
+**Branch A (FALLBACK) — `sentry_issue_alert` + `event_frequency` (schema-confirmed):**
+```hcl
+resource "sentry_issue_alert" "zot_mirror_fallback_rate" {
+  organization = var.sentry_org
+  project      = data.sentry_project.web_platform.slug
+  name         = "zot-mirror-fallback-rate"
+  action_match = "all"
+  filter_match = "any"          # OR across the unique signal tag-values (Q3 endorsed)
+  frequency    = 23             # free value; POST-time dedup avoidance
+  conditions_v2 = [
+    { event_frequency = { comparison_type = "count", value = 3, interval = "1h" } }
+  ]
+  filters_v2 = [
+    { tagged_event = { key = "registry", match = "EQUAL", value = "ghcr-fallback" } },
+    { tagged_event = { key = "registry", match = "EQUAL", value = "zot-gate-degraded" } },
+    { tagged_event = { key = "stage",    match = "EQUAL", value = "inngest_ghcr_fallback" } },
+    { tagged_event = { key = "stage",    match = "EQUAL", value = "app_ghcr_fallback" } },
+  ]
+  actions_v2 = [
+    { notify_email = { target_type = "IssueOwners", fallthrough_type = "ActiveMembers" } }
+  ]
+  lifecycle { ignore_changes = [environment] }
+}
+```
+**Branch A caveat (must be surfaced to the operator if used):** `event_frequency` evaluates
+**per Sentry issue-group**, and the signals fingerprint into distinct issues (further split by
+message string), so this fires at **per-path 3/1h**, NOT aggregate — a distributed 2+2+1 outage
+would NOT page. Branch A only needs the `-target` line (Branch-A guard sweep verified complete, Q4).
+
+### Phase 1b — Emit an app-image fresh-boot fallback breadcrumb (close the boot blind spot)
+
+architecture-strategist P2: the main **app-image** fresh-boot pull (`cloud-init.yml:485-501`) does
+zot→GHCR fallback (`N>=2 ⇒ REF="$IMAGE_REF"`) but emits **no** fallback signal — only a `stage=pull`
+*fatal* on total failure. So a fresh-boot zot miss on the primary web container that *succeeds* via
+GHCR is invisible; no alarm can page on it, and "closes the boot-gating gap" would be overstated.
+
+Add a `soleur-boot-emit app_ghcr_fallback warning` on the web-boot zot→GHCR fallback branch
+(`cloud-init.yml:~496`), symmetric with the inngest path at `:650`, and include `stage:app_ghcr_fallback`
+as a 4th signal in the Phase-1 query/filter (already reflected above).
+
+**Descope alternative (if the emit is judged out of scope for an alarm-provisioning PR):** drop the
+4th signal, correct the plan/PR framing to "covers the rolling-deploy + inngest-boot + gate-degraded
+signals; the app-image fresh-boot fallback remains an un-emitted blind spot", and file a follow-up
+issue to add the emit before Phase-5 cutover. Do NOT ship the overstated "closes the gap" framing.
+
+### Phase 2 — Wire apply + the cross-artifact op-contract test
+
+1. **`.github/workflows/apply-sentry-infra.yml`** — append `-target=sentry_metric_alert.zot_mirror_fallback_rate \`
+   (Branch B) or `-target=sentry_issue_alert.zot_mirror_fallback_rate \` (Branch A) to the `-target`
+   block (after line 261).
+   - **Branch B (metric alert — new resource TYPE) guard sweep (architecture-strategist P1):** ALSO
+     (a) extend the scope-guard allowlist `tests/scripts/test-destroy-guard-sentry-scope-guard.sh:52`
+     (`grep -vxE '…|sentry_metric_alert'`); (b) **add a `sentry_metric_alert` nested-clause to
+     `tests/scripts/lib/destroy-guard-filter-sentry.jq`** summing `trigger[]`/`action[]` block deltas,
+     mirroring `sentry_issue_alert_blocks_count` (`:50-54`) — the filter is the load-bearing artifact
+     the whole suite exists to force; omitting it is a silent destroy-guard bypass for the new type;
+     (c) add a counter-test fixture case (`test-destroy-guard-counter-sentry.sh`) exercising a
+     metric-alert `trigger`/`action` nested delete.
+   - **Branch A (issue-alert) guard sweep — verified complete (Q4):** the scope-guard keys on resource
+     TYPE (`sentry_issue_alert` already allowed); the counter-test T4 anchors on a zero-changes captured
+     baseline (`tfplan-sentry-real-baseline.json`, unaffected by a CREATE); the jq `sentry_issue_alert`
+     clause excludes CREATEs (`before=null` → negative → `select(.>0)` drops it). **Only the `-target`
+     line** is needed.
+2. **New test `apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts`** —
+   mirror `sentry-inbox-action-required-alert-op-contract.test.ts`: assert the emit site
+   (`infra/ci-deploy.sh`) carries `registry: "ghcr-fallback"` + `registry: "zot-gate-degraded"` +
+   `feature: "supply-chain"` / `op: "image-pull"`, that `cloud-init.yml` carries
+   `inngest_ghcr_fallback`, and that `issue-alerts.tf` pins all three tag values + declares the
+   resource. This is the "a rename in either artifact silently darks the alert" guard.
+
+### Phase 3 — inngest-bootstrap mirror push-notification signal
+
+Add a Slack ⚠️ push signal to `build-inngest-bootstrap-image.yml` matching the
+`reusable-release.yml:906-914` pattern, so the inngest mirror degrade is not annotations-only
+pre-cutover.
+
+- Add a **`Post to Slack (inngest mirror status)`** step after the `zot_mirror` step, gated
+  `if: steps.zot_mirror.outputs.mirror_status == 'degraded'` (only fires on degrade — this
+  workflow has no per-release happy-path Slack, so a degrade-only notification is the minimal
+  push signal), `continue-on-error: true`, reading `SLACK_RELEASES_WEBHOOK_URL` (same secret as
+  `reusable-release.yml`; Phase-0 confirm it is a repo secret visible to this workflow).
+- Reuse the exact injection-inert Slack posting shape from `reusable-release.yml:895-914`
+  (jq-built payload, `--add-mask`, `|| echo 000` transport guard, HTTP-2xx check).
+- Message: `⚠️ inngest-bootstrap zot mirror degraded (<TAG>) — GHCR unaffected, zot redundancy reduced; backfill needed.`
+- **Update the `zot_mirror` step comment** ("annotations-only by design") to note the Slack signal
+  was added per #6278 (pre-cutover push-notification parity with `reusable-release.yml`).
+
+### Phase 4 — Verify (no SSH)
+
+- `cd apps/web-platform/infra/sentry && terraform validate` (accept the documented
+  `sentry_issue_alert` deprecation warning; issue-alerts.tf:16-38).
+- `terraform plan` shows exactly **1 to add** (the new alarm), **0 to change/destroy** — scoped
+  to the `-target` set. No import needed (apply-created).
+- `cd apps/web-platform && ./node_modules/.bin/vitest run test/sentry-zot-mirror-fallback-alert-op-contract.test.ts`.
+- `actionlint .github/workflows/build-inngest-bootstrap-image.yml` + `bash -n` on the extracted
+  Slack `run:` snippet.
+- Post-merge (auto-apply): `apply-sentry-infra.yml` fires on the `issue-alerts.tf` path and creates
+  the rule. Verify via Sentry API `GET /api/0/projects/jikigai-eu/web-platform/rules/` that the
+  rule named `zot-mirror-fallback-rate` exists (no dashboard eyeballing;
+  hr-no-dashboard-eyeball-pull-data-yourself).
+
+## Files to Edit
+
+- `apps/web-platform/infra/sentry/issue-alerts.tf` — add the `sentry_metric_alert.zot_mirror_fallback_rate` resource (Branch B, primary) OR `sentry_issue_alert.zot_mirror_fallback_rate` (Branch A, fallback). Also correct the stale `event_frequency` comment at `:838-839` if Branch A is used.
+- `.github/workflows/apply-sentry-infra.yml` — append the new resource to the `-target` set.
+- `.github/workflows/build-inngest-bootstrap-image.yml` — add the degrade-gated Slack step + update the `zot_mirror` "annotations-only by design" comment.
+- `apps/web-platform/infra/cloud-init.yml` — **Phase 1b**: add `soleur-boot-emit app_ghcr_fallback warning` on the web-boot zot→GHCR fallback branch (`~:496`). (Descope alternative: skip + file follow-up.)
+- `tests/scripts/lib/destroy-guard-filter-sentry.jq` — **Branch B only** (add `sentry_metric_alert` nested-clause; architecture-strategist P1 — the load-bearing omission).
+- `tests/scripts/test-destroy-guard-sentry-scope-guard.sh` — **Branch B only** (add `sentry_metric_alert` to allowlist).
+- `tests/scripts/test-destroy-guard-counter-sentry.sh` — **Branch B only** (new metric-alert nested-delete fixture case).
+- `knowledge-base/engineering/architecture/decisions/ADR-096-…md` — optional one-line status annotation flipping the "design intent, not yet provisioned" line to "provisioned (#6278)".
+- `knowledge-base/engineering/architecture/decisions/ADR-062-…md:120` — optional: correct the stale "no in-repo precedent for event_frequency / no verified support" note (schema DOES carry it; only "no precedent" is true).
+
+## Files to Create
+
+- `apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts` — cross-artifact op/tag contract test.
+
+## Open Code-Review Overlap
+
+None found. (`gh issue list --label code-review --state open` cross-checked against the file
+paths above — no open scope-out names `issue-alerts.tf`, `apply-sentry-infra.yml`, or
+`build-inngest-bootstrap-image.yml`. Re-run at Step 1.7.5 in deepen-plan against the final list.)
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing directly — this is operator-facing infra
+observability. A broken alarm means the *operator* is not paged when the zot mirror sustains a
+fallback/degrade rate post-cutover; the concrete artifact is a missing Sentry page + a
+still-green build/deploy while zot redundancy silently erodes.
+
+**If this leaks, the user's data is exposed via:** no user data on this surface. The alarm's
+events carry only `registry`/`stage`/`image`/`host_id`/`zot_gate_reason` tags (no PII); the
+`ci-deploy.sh` emitter already scrubs docker stderr to a coarse classification before it enters
+the payload (security-sentinel #7, ci-deploy.sh:518-521). The Slack step reuses the
+injection-inert `md-to-mrkdwn`/jq-escaped shape.
+
+**Brand-survival threshold:** aggregate pattern. A *single* transient `ghcr-fallback` is
+self-healing (the host already fell back to GHCR and served correctly — runbook §"When to
+revert"); only a *sustained* fallback pattern (>3/1h) is the incident this alarm exists to page.
+No per-PR CPO sign-off required (threshold is not `single-user incident`). No sensitive-path
+touched (no schema/auth/API route) → no `threshold: none` scope-out bullet needed.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+1. `terraform validate` in `apps/web-platform/infra/sentry/` passes (documented `sentry_issue_alert`
+   deprecation warning accepted; no new errors).
+2. `terraform plan` (scoped to the `-target` set) shows **1 to add, 0 to change, 0 to destroy**.
+3. The new resource encodes an **aggregate >3 events / 1h**: Branch B metric alert
+   `aggregate="count()"`, `time_window=60`, critical `alert_threshold=3`, dataset that matches
+   `event.type:default` warning events, and **no `event.type:error` prefix** in the query; OR (fallback)
+   Branch A `event_frequency` count>3/1h with the operator-sensitivity note in the PR body.
+   `event_unique_user_frequency` is NOT used.
+4. The alarm's query/filter matches all runtime signals: `registry:ghcr-fallback`,
+   `registry:zot-gate-degraded`, `stage:inngest_ghcr_fallback`, AND `stage:app_ghcr_fallback` (Phase 1b).
+   If Phase 1b is descoped, `app_ghcr_fallback` is dropped, the "closes the gap" framing is corrected,
+   and a follow-up issue for the app-image emit is filed in the same PR.
+5. `sentry-zot-mirror-fallback-alert-op-contract.test.ts` passes: emit sites + `issue-alerts.tf`
+   pin all asserted tag values; a rename in either breaks CI (`grep -c` on the resource declaration ≥ 1).
+6. `.github/workflows/apply-sentry-infra.yml` `-target` set contains the new resource
+   (`grep -c 'target=sentry_\(issue\|metric\)_alert.zot_mirror_fallback_rate' … == 1`).
+7. `build-inngest-bootstrap-image.yml` has a degrade-gated Slack step
+   (`if: steps.zot_mirror.outputs.mirror_status == 'degraded'`) reading `SLACK_RELEASES_WEBHOOK_URL`;
+   `actionlint` clean; the `zot_mirror` "annotations-only by design" comment is updated to cite #6278.
+8. **Branch B only:** all THREE guard artifacts updated — `destroy-guard-filter-sentry.jq` has a
+   `sentry_metric_alert` nested-clause, the scope-guard allowlist includes `sentry_metric_alert`, and a
+   counter-test fixture case exercises a metric-alert `trigger`/`action` nested delete (guard suites green).
+9. PR body uses `Closes #6278` (this is a code PR that self-satisfies on merge — the alarm exists
+   in IaC at merge; the auto-apply is the deploy, not a separate operator remediation).
+
+### Post-merge (operator — all automatable, no SSH)
+
+10. `apply-sentry-infra.yml` auto-fires on the `issue-alerts.tf` path change and applies the rule.
+    Verify (automatable via Sentry API, not dashboard): `GET /api/0/projects/jikigai-eu/web-platform/rules/`
+    returns a rule named `zot-mirror-fallback-rate`. No `[skip-sentry-apply]` in the merge commit.
+    *Automation: the merge IS the apply trigger; verification is a `curl` against the Sentry API — no operator step is genuinely manual.*
+
+## Domain Review
+
+**Domains relevant:** Engineering (CTO) only.
+
+### Engineering
+
+**Status:** reviewed (inline — infra/observability-only change; deepen-plan spawns the CTO/architecture panel).
+**Assessment:** Pure IaC + CI-workflow change against an already-provisioned surface (the Sentry
+Terraform root + the emit sites both exist and are live). The load-bearing risk is provider-schema
+expressiveness (`event_frequency` in beta2 `conditions_v2`), gated at Phase 0. No new secret, no new
+vendor, no new host. Sequencing note: the alarm is inert-but-harmless until the events exist
+(pre-cutover the fleet emits zero) — provisioning early is safe and is exactly the ADR-096 Phase-5
+prerequisite. No Product/UX (no UI surface), no Finance/Legal/Sales/Marketing/Support implications.
+
+## Infrastructure (IaC)
+
+### Terraform changes
+- **Files:** `apps/web-platform/infra/sentry/issue-alerts.tf` (existing root; extend). Provider
+  `jianyuan/sentry@0.15.0-beta2` (pinned, `.terraform.lock.hcl`). No new provider, no new variable,
+  no new secret. Auth: `SENTRY_AUTH_TOKEN` (GitHub repo secret `SENTRY_IAC_AUTH_TOKEN` in CI; ADR-031
+  secret-store divergence — NOT Doppler). R2 backend creds from Doppler `prd_terraform`.
+- **New resource:** one `sentry_issue_alert.zot_mirror_fallback_rate` (Branch A) OR one
+  `sentry_metric_alert.zot_mirror_fallback_rate` (Branch B). Apply-created (no import).
+
+### Apply path
+- **Cloud-init-only? No — auto-apply via existing pipeline.** `apply-sentry-infra.yml` fires on
+  push-to-main touching `issue-alerts.tf` and runs `terraform apply` scoped to the `-target` set.
+  The PR merge IS the human authorization (`hr-menu-option-ack-not-prod-write-auth`). Blast radius:
+  a single new alert rule; the `-target` scoping never touches the import-only auth rules. Zero
+  downtime. No operator SSH, no dashboard click.
+
+### Distinctness / drift safeguards
+- `lifecycle { ignore_changes = [environment] }` — the provider recomputes `environment` on read for
+  project-wide rules (matches every sibling apply-created rule). `dev != prd`: N/A (Sentry IaC is a
+  single prd org `jikigai-eu`, not dev/prd-split). Secret values do NOT land in this rule (no token
+  attributes). Distinct `frequency = 23` avoids Sentry POST-time exact-duplicate dedup.
+
+### Vendor-tier reality check
+- No paid-tier gate. Sentry issue/metric alerts on the existing project are within the current plan
+  (the project already carries 20 issue alerts + cron/uptime monitors). No `count = var.*_paid_tier`
+  guard needed.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "The alarm resource IS a liveness signal for the zot mirror. Its own existence is verified by the op-contract test (source-of-truth pinning) + a post-apply Sentry-API rule-list read."
+  cadence: "Real-time (Sentry evaluates on each matching event); pages at >3 fallback events / 1h."
+  alert_target: "IssueOwners → ActiveMembers fallthrough (founder + ops@soleur.ai) — repo convention."
+  configured_in: "apps/web-platform/infra/sentry/issue-alerts.tf (this PR)."
+error_reporting:
+  destination: "Sentry (jikigai-eu/web-platform). The alarm consumes existing warning-level events from ci-deploy.sh + cloud-init.yml."
+  fail_loud: "The emitters are fail-open (must never break a deploy) but WARN-level; the alarm is the fail-loud layer on their aggregate rate. The inngest-mirror Slack step is fail-open (continue-on-error) but emits ::warning:: even if Slack POST fails."
+failure_modes:
+  - mode: "Alarm never provisioned / darked by a tag rename in an emit site."
+    detection: "sentry-zot-mirror-fallback-alert-op-contract.test.ts (CI) — a rename in ci-deploy.sh/cloud-init.yml/issue-alerts.tf breaks the build."
+    alert_route: "CI red on PR."
+  - mode: "Metric-alert dataset/query cannot match the level:warning/event.type:default store events → silent-no-op alarm."
+    detection: "Phase-0 step 2 (probe the metric-alert dataset against a default/warning event); no event.type:error prefix."
+    alert_route: "Falls back to Branch A (issue-alert + event_frequency, schema-confirmed) with an operator per-path-sensitivity note."
+  - mode: "inngest mirror degrades silently (pre-#6278: annotations-only)."
+    detection: "New degrade-gated Slack step in build-inngest-bootstrap-image.yml + the existing ::warning:: + step summary."
+    alert_route: "Slack #releases (push notification) + GitHub Actions annotation."
+logs:
+  where: "Sentry event stream (alarm); GitHub Actions run logs + step summary (mirror step); host journald (logger -t ci-deploy) for the underlying pull events."
+  retention: "Sentry project retention (90d default); GitHub Actions log retention (90d)."
+discoverability_test:
+  command: "curl -s -H \"Authorization: Bearer $SENTRY_AUTH_TOKEN\" https://jikigai-eu.sentry.io/api/0/projects/jikigai-eu/web-platform/rules/ | jq '.[] | select(.name==\"zot-mirror-fallback-rate\")'"
+  expected_output: "A non-empty rule object with the >3/1h frequency condition + the three-signal filter."
+```
+
+## Architecture Decision (ADR/C4)
+
+**No new ADR.** This plan *implements* an architectural decision already recorded in **ADR-096**
+(the "Loud, no-SSH signal" axis explicitly names "the fallback-rate alarm pages at >3/1h" and marks
+it "design intent, not yet provisioned"). Provisioning it realizes a stated ADR-096 Phase-5
+prerequisite — it neither reverses nor extends the decision.
+
+- **ADR annotation (optional, in-scope):** flip the ADR-096 line "The *live* fallback-rate Sentry
+  alarm … is **design intent, not yet provisioned**" to "provisioned in #6278" once merged. Not a
+  new `## Decision`.
+- **C4 views — no impact (completeness-checked).** Read all three `.c4` files
+  (`knowledge-base/engineering/architecture/diagrams/{model,views,spec}.c4`). Enumerated for this
+  change: (a) external human actor — none new (the operator/founder receiving the page is already
+  modeled); (b) external system/vendor — Sentry is already modeled and the `supply-chain image-pull`
+  relationship is already present (per ADR-082:171 → `model.c4:164-166, :240, :300`); (c)
+  container/data-store — none new; (d) actor↔surface access relationship — none changes. This adds a
+  Sentry *alert rule* (config within an already-modeled system), not a new actor/system/edge. "No C4
+  impact" is therefore supported by the enumeration above, not an unsupported "None".
+
+## Sharp Edges
+
+- **Phase 0 is not optional.** The `event_frequency`-in-beta2 question is unresolved in-repo (ADR-062
+  says "no verified support"); freezing a `conditions_v2 = [{ event_frequency = … }]` block without
+  the schema probe risks a `terraform validate` config-phase rejection (same class as the
+  #3811 import-only-schema-validation Sharp Edge). Probe first, then write the `.tf`.
+- **`event_unique_user_frequency` is a trap here.** It is the ONLY proven in-repo frequency condition,
+  but it counts distinct USERS; these host-emitted events have no `user` → it would count 0 and never
+  page. Do not copy the `sandbox_startup_failure` condition verbatim.
+- **The inngest fresh-boot signal breaks a `filter_match="all"` on feature/op.** `soleur-boot-emit
+  inngest_ghcr_fallback` carries `stage` only (no feature/op). A single `all`-match rule scoped to
+  feature+op silently excludes it. Use `filter_match="any"` (issue-alert) or an OR query (metric
+  alert), verified against the actual emit tags in Phase 0.
+- **Issue-alert `event_frequency` is per-issue-group, not aggregate.** If the three signals must page
+  on a *combined* 3/1h count, an issue alert (which thresholds each fingerprinted issue independently)
+  is the wrong primitive — use a `sentry_metric_alert` whose query aggregates across the OR. Decide
+  the semantics in Phase 0/QA before committing to Branch A.
+- **Branch B changes the resource TYPE** → THREE guard artifacts, not two: the destroy-guard
+  scope-guard allowlist (`test-destroy-guard-sentry-scope-guard.sh:52`), the `-target` set, AND
+  **`tests/scripts/lib/destroy-guard-filter-sentry.jq`** (a new `sentry_metric_alert` nested-clause
+  summing `trigger[]`/`action[]` deltas). The jq filter is the one the plan reliably misses and is
+  the load-bearing artifact — omitting it silently bypasses the nested-delete guard for the new type
+  (architecture-strategist P1; #4419/#4364 bug class).
+- **Metric-alert query must NOT filter `event.type:error`.** These fallback events are `store`-API
+  posts with `level:warning` and no exception → `event.type:default`. An `event.type:error` prefix
+  (or an `errors`-only dataset) excludes every event → a silent-no-op alarm (the worst outcome for an
+  observability control). Phase-0 step 2 confirms dataset matchability before the query is frozen.
+- **Issue-alert `event_frequency` is per-issue-group, not aggregate** — worsened by message-string
+  fingerprinting (`ci-deploy.sh:561` `"…(web:<tag>)"` vs `"…(inngest:<tag>)"`). A distributed 2+2+1
+  outage never reaches 3/group and stays silent. Prefer the metric alert; if Branch A is forced,
+  surface the reduced sensitivity to the operator in the PR body.
+- **The app-image fresh-boot fallback is un-emitted** (`cloud-init.yml:485-501` emits no breadcrumb on
+  a successful zot→GHCR web-boot fallback). Either add the emit (Phase 1b) or the alarm does NOT cover
+  the primary-container boot path — do not claim it does.
+- **The repo's `event_frequency` "no verified support" comments are stale** (issue-alerts.tf:838,
+  ADR-062:120). Verified present in the beta2 schema via the cached provider binary. Do not re-inherit
+  the stale claim.
+- A plan whose `## User-Brand Impact` section is empty, `TBD`, or omits the threshold will fail
+  `deepen-plan` Phase 4.6. This section is filled (threshold: aggregate pattern).
+
+## Test Scenarios
+
+1. **Alarm expresses >3/1h** — `terraform plan` diff shows the condition with `value=3, interval="1h"` (or metric `threshold>3, time_window=60`).
+2. **Three-signal coverage** — op-contract test asserts all three tag values pinned in `issue-alerts.tf`; `filter_match="any"` (or metric OR query) present.
+3. **Rename-darks-alert guard** — mutate a tag string in `ci-deploy.sh` in a scratch branch → op-contract test fails.
+4. **Scoped apply** — `terraform plan -target=…` shows 1-to-add, 0-change, 0-destroy.
+5. **inngest Slack degrade path** — simulate `mirror_status=degraded` output; the new step's `if:` gate evaluates true; `actionlint` + `bash -n` clean.
+6. **Post-apply existence** — Sentry-API rule-list contains `zot-mirror-fallback-rate` (AC10).

--- a/knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md
+++ b/knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md
@@ -11,6 +11,15 @@ labels: [priority/p3-low, domain/engineering, observability, deferred-automation
 
 # Provision the live zot mirror-staleness Sentry alarm (#6278)
 
+> **IMPLEMENTATION NOTE (supersedes the "Branch B primary" framing below).** During Phase-0
+> the `soleur:engineering:cto` agent ruled **Branch A (`sentry_issue_alert` + `event_frequency`)**
+> as the shipped mechanism, and rejected Branch B (`sentry_metric_alert`): metric-alert actions
+> require a numeric notify target that does not exist in the Sentry TF root and is unresolvable
+> in an autonomous session (CI-only auth token) → risk of paging nobody. The per-issue-group
+> sensitivity of Branch A is accepted (it reliably pages the dominant shared-tag outage) and
+> operator-surfaced; the metric-alert upgrade is a filed follow-up. Full rationale + rejected
+> alternatives: `../specs/feat-one-shot-6278-zot-mirror-staleness-alarm/decision-challenges.md`.
+
 ## Overview
 
 ADR-096 (self-hosted zot registry migration) mitigates the "zot is a boot-time SPOF"

--- a/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/decision-challenges.md
+++ b/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/decision-challenges.md
@@ -1,0 +1,37 @@
+# Architecture Decision — #6278 alarm mechanism
+
+## Fork: Branch B (metric alert) vs Branch A (issue alert) — RESOLVED by CTO agent (2026-07-09)
+
+**Decision:** Ship **Branch A** — `sentry_issue_alert.zot_mirror_fallback_rate` with a
+`conditions_v2` `event_frequency` (count > 3 / 1h) rule, notifying via the repo-standard
+symbolic `IssueOwners → ActiveMembers` fallthrough. Reject Branch B (`sentry_metric_alert`)
+for this PR.
+
+**Why the plan's stated PRIMARY (Branch B) was inverted:** Phase-0 implementation surfaced a
+constraint the plan under-weighted. `sentry_metric_alert` `trigger.action` requires a concrete
+numeric `target_identifier` (team/member id) — there is NO `IssueOwners/ActiveMembers` symbolic
+fallthrough for metric-alert actions. This Sentry TF root has **zero** resolvable numeric notify
+targets (no `sentry_team` data source, no `owner=`, no team var; all 20 existing issue alerts use
+the symbolic fallthrough), and the token to look one up (`SENTRY_IAC_AUTH_TOKEN`) is CI-only
+(ADR-031, not in Doppler). Branch B is therefore not autonomously deployable/verifiable this
+session and risks a safety control that fires but **pages nobody** — the strictly worst outcome.
+
+**Accepted limitation (operator-surfaced in PR body):** Branch A's `event_frequency` thresholds
+PER fingerprinted issue-group, not on a true cross-signal aggregate. It reliably pages on the
+dominant shared-tag correlated outage (a rolling-deploy zot miss drives many hosts onto the same
+`ghcr-fallback (web:<tag>)` group → crosses 3/group), missing only the fully-distributed thin
+spread (<3 in every signal-group simultaneously) — the correlated-failure tail, not the mode the
+"aggregate pattern" threshold targets.
+
+**Follow-up filed:** upgrade to `sentry_metric_alert` once a resolvable numeric notify target lands
+(unblocks at the first non-founder Sentry seat — the same boundary issue-alerts.tf comments already
+defer).
+
+**Rejected alternatives:** (1) Branch B — theoretically-superior aggregation, but unresolvable/
+unverifiable notify target. (2) Branch B + `data "sentry_team"` slug lookup — does not rescue
+verifiability (wrong/member-less slug either fails apply or emails nobody; `terraform validate`
+catches neither) and adds guard artifacts without removing the core defect.
+
+**CTO-mandated cleanups folded in:** correct the stale `event_frequency` "no verified support"
+comments (issue-alerts.tf:838-839, ADR-062:120 — falsified by the beta2 schema probe); guard-parity
+check on the existing type-level destroy-guard/scope-guard/counter-test.

--- a/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/decision-challenges.md
+++ b/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/decision-challenges.md
@@ -23,9 +23,9 @@ dominant shared-tag correlated outage (a rolling-deploy zot miss drives many hos
 spread (<3 in every signal-group simultaneously) — the correlated-failure tail, not the mode the
 "aggregate pattern" threshold targets.
 
-**Follow-up filed:** upgrade to `sentry_metric_alert` once a resolvable numeric notify target lands
-(unblocks at the first non-founder Sentry seat — the same boundary issue-alerts.tf comments already
-defer).
+**Follow-up filed (#6285):** upgrade to `sentry_metric_alert` once a resolvable numeric notify target
+lands (dependency trigger: the first non-founder Sentry seat — the same boundary issue-alerts.tf
+comments already defer).
 
 **Rejected alternatives:** (1) Branch B — theoretically-superior aggregation, but unresolvable/
 unverifiable notify target. (2) Branch B + `data "sentry_team"` slug lookup — does not rescue

--- a/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/session-state.md
@@ -1,0 +1,42 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md
+- Status: complete
+
+### Errors
+None. All premise-validation checks passed and both deepen-plan research agents completed successfully.
+
+### Decisions
+- Premises verified (hr-verify-repo-capability-claim-before-assert): `apps/web-platform/infra/sentry/issue-alerts.tf` exists (20 rules); the `feature:supply-chain op:image-pull registry:"ghcr-fallback"` marker is emitted from `ci-deploy.sh:562-564` (`registry_pull_event`, level=warning).
+- Scope reconciled beyond the issue's literal ask: the runbook `zot-registry-revert.md` specifies an aggregate alarm over THREE runtime signals (`ghcr-fallback` OR `inngest_ghcr_fallback` OR `zot-gate-degraded`), not just the one the issue names — plan covers all three (+ a 4th app-boot breadcrumb).
+- Primary mechanism = `sentry_metric_alert` (aggregate), not `sentry_issue_alert`: issue-alert `event_frequency` is per-issue-group + fingerprint-fragmented, so a distributed 2+2+1 outage pages zero groups at 3/1h. Issue-alert kept as documented fallback. Fixed a silent-no-op query bug (`event.type:error` excludes these level:warning/default store events).
+- Corrected stale repo knowledge: `event_frequency` IS in the beta2 `conditions_v2` schema (verified against cached provider binary) — the issue-alerts.tf:838 + ADR-062:120 "no verified support" comments are false; Phase-0 probe is network-free.
+- Two extra gaps folded in: Branch B must also edit `destroy-guard-filter-sentry.jq` (P1 — silent destroy-guard bypass for the new array-of-blocks type); main app-image fresh-boot pull emits no fallback breadcrumb (P2) → Phase 1b adds `stage:app_ghcr_fallback` emit. Second deliverable (inngest-bootstrap mirror Slack signal) mirrors the reusable-release.yml PR-#6276 pattern.
+
+### Components Invoked
+- Skill soleur:plan
+- Skill soleur:deepen-plan
+- Agent Explore (provider-schema verification)
+- Agent soleur:engineering:review:architecture-strategist (alarm-design review)
+
+## Work Phase 0 — Provider-schema + dataset probe (DONE)
+
+- **Branch decision: A (sentry_issue_alert + event_frequency)** — ruled by the `soleur:engineering:cto`
+  agent (see decision-challenges.md). Branch B (metric alert) rejected: no resolvable numeric notify
+  target in the Sentry TF root + CI-only auth token → unverifiable/pages-nobody risk.
+- **Provider schema probed network-free** via the sibling worktree's cached
+  `jianyuan/sentry@0.15.0-beta2` binary + a scratch-dir filesystem_mirror. Confirmed: `event_frequency`
+  IS in `sentry_issue_alert.conditions_v2` (repo comments at issue-alerts.tf:838-839 / ADR-062:120-121
+  are stale). `sentry_metric_alert.trigger.action` requires a concrete numeric target (no symbolic
+  fallthrough) — the disqualifier for Branch B.
+- **Emit tags frozen:** `ci-deploy.sh:562` `registry_pull_event` → `{feature:"supply-chain", op:"image-pull",
+  registry:"ghcr-fallback", image}` (level warning); `ci-deploy.sh:590` `zot_gate_degraded_event` →
+  `{feature:"supply-chain", op:"image-pull", registry:"zot-gate-degraded", zot_gate_reason}` (warning);
+  `cloud-init.yml:650` `soleur-boot-emit inngest_ghcr_fallback warning` → `{stage:"inngest_ghcr_fallback",...}`
+  (NO feature/op). Phase-1b adds `cloud-init.yml:~496` `soleur-boot-emit app_ghcr_fallback warning`.
+- **frequency = 23** (free; taken: 5,10-22,30,60-62).
+- **Filter design:** `filter_match="any"` over the 4 tag-values (the inngest/app boot events carry no
+  feature/op, so an "all" on feature+op would exclude them).
+- **Guard parity (Branch A):** scope-guard allowlist already keys on TYPE `sentry_issue_alert`; counter-test
+  has no exact-count assertion; jq clause drops CREATEs. → ONLY the `-target` line needed.

--- a/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/tasks.md
@@ -1,0 +1,72 @@
+# Tasks — Live zot mirror-staleness Sentry alarm (#6278)
+
+lane: single-domain
+Plan: `knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md`
+
+## Phase 0 — Provider-schema + dataset probe (blocks all design choices; network-free)
+
+- [ ] 0.1 Dump the cached provider schema from the sibling worktree
+      (`.worktrees/feat-one-shot-anthropic-cost-attribution/apps/web-platform/infra/sentry/.terraform/…/jianyuan/sentry/0.15.0-beta2`)
+      via `terraform -chdir=<sibling-sentry-dir> providers schema -json` — no `terraform init`.
+- [ ] 0.2 Confirm `sentry_metric_alert` shape: `aggregate`, `dataset`, `query`, `time_window`,
+      `threshold_type`, nested `trigger { alert_threshold, action {…} }`.
+- [ ] 0.3 **P1 gate:** confirm the metric-alert dataset (likely `events`, NOT `errors`) matches
+      `level:warning` / `event.type:default` store events; the query MUST have no `event.type:error` prefix.
+- [ ] 0.4 Confirm `event_frequency` block in `sentry_issue_alert.conditions_v2` (fallback branch —
+      already verified present).
+- [ ] 0.5 Re-confirm emit-site tags: `ci-deploy.sh:564` (ghcr-fallback), `:592` (zot-gate-degraded),
+      `cloud-init.yml:650` (inngest_ghcr_fallback, stage-only).
+- [ ] 0.6 Pick free `frequency` (Branch A only): `23`.
+- [ ] 0.7 Decide branch: **Branch B (metric alert)** unless 0.3 fails → Branch A with operator note.
+      Record decision + values in session-state.
+
+## Phase 1 — Alarm resource in `issue-alerts.tf`
+
+- [ ] 1.1 Add `sentry_metric_alert.zot_mirror_fallback_rate` (Branch B primary): aggregate `count()`,
+      `time_window=60`, critical `alert_threshold=3`, query over the OR-of-signals (no event.type:error),
+      notify shape confirmed in 0.2.
+- [ ] 1.1-alt (Branch A fallback) `sentry_issue_alert` + `event_frequency` count>3/1h, `filter_match="any"`,
+      `frequency=23`; correct the stale `:838-839` comment; surface per-path sensitivity in PR body.
+
+## Phase 1b — App-image fresh-boot fallback breadcrumb (close boot blind spot)
+
+- [ ] 1b.1 Add `soleur-boot-emit app_ghcr_fallback warning` on the web-boot zot→GHCR fallback branch
+      (`cloud-init.yml:~496`), symmetric with the inngest path at `:650`.
+- [ ] 1b.2 Include `stage:app_ghcr_fallback` as a 4th signal in the alarm query/filter.
+- [ ] 1b-alt (descope) drop the 4th signal, correct the "closes the gap" framing, file a follow-up issue.
+
+## Phase 2 — Apply wiring + guard sweep + op-contract test
+
+- [ ] 2.1 Append `-target=sentry_metric_alert.zot_mirror_fallback_rate` (or issue-alert) to
+      `apply-sentry-infra.yml` after line 261.
+- [ ] 2.2 **Branch B guard sweep (P1):** add `sentry_metric_alert` nested-clause to
+      `tests/scripts/lib/destroy-guard-filter-sentry.jq` (sum `trigger[]`/`action[]` deltas); extend the
+      scope-guard allowlist (`test-destroy-guard-sentry-scope-guard.sh:52`); add a counter-test fixture case.
+- [ ] 2.3 (Branch A) no guard change beyond 2.1 (verified complete).
+- [ ] 2.4 Create `apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts` mirroring
+      `sentry-inbox-action-required-alert-op-contract.test.ts`: pin all signal tag-values across emit
+      sites (`ci-deploy.sh`, `cloud-init.yml`) + the alarm resource in `issue-alerts.tf`.
+
+## Phase 3 — inngest-bootstrap mirror push-notification signal
+
+- [ ] 3.1 Add a `Post to Slack (inngest mirror status)` step to `build-inngest-bootstrap-image.yml`,
+      gated `if: steps.zot_mirror.outputs.mirror_status == 'degraded'`, `continue-on-error: true`,
+      reading `SLACK_RELEASES_WEBHOOK_URL`, reusing the injection-inert posting shape from
+      `reusable-release.yml:895-914`.
+- [ ] 3.2 Update the `zot_mirror` "annotations-only by design" comment to cite the #6278 Slack signal.
+
+## Phase 4 — Verify (no SSH)
+
+- [ ] 4.1 `terraform validate` in `apps/web-platform/infra/sentry/` (accept the deprecation warning).
+- [ ] 4.2 `terraform plan` (scoped `-target`) shows 1 to add, 0 change, 0 destroy.
+- [ ] 4.3 `./node_modules/.bin/vitest run test/sentry-zot-mirror-fallback-alert-op-contract.test.ts`.
+- [ ] 4.4 `actionlint .github/workflows/build-inngest-bootstrap-image.yml` + `bash -n` on the Slack snippet.
+- [ ] 4.5 Guard suites green: `bash tests/scripts/test-destroy-guard-sentry-scope-guard.sh` +
+      `bash tests/scripts/test-destroy-guard-counter-sentry.sh`.
+- [ ] 4.6 (Optional) correct the stale ADR-062:120 event_frequency note; annotate ADR-096 status line.
+
+## Post-merge (operator — automatable, no SSH)
+
+- [ ] P.1 Auto-apply fires on the `issue-alerts.tf` path; verify via Sentry API
+      `GET /api/0/projects/jikigai-eu/web-platform/rules/` (issue alert) or `.../alert-rules/` (metric alert)
+      that `zot-mirror-fallback-rate` exists. PR body uses `Closes #6278`.

--- a/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/tasks.md
@@ -5,65 +5,65 @@ Plan: `knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sen
 
 ## Phase 0 — Provider-schema + dataset probe (blocks all design choices; network-free)
 
-- [ ] 0.1 Dump the cached provider schema from the sibling worktree
+- [x] 0.1 Dump the cached provider schema from the sibling worktree
       (`.worktrees/feat-one-shot-anthropic-cost-attribution/apps/web-platform/infra/sentry/.terraform/…/jianyuan/sentry/0.15.0-beta2`)
       via `terraform -chdir=<sibling-sentry-dir> providers schema -json` — no `terraform init`.
-- [ ] 0.2 Confirm `sentry_metric_alert` shape: `aggregate`, `dataset`, `query`, `time_window`,
+- [x] 0.2 Confirm `sentry_metric_alert` shape: `aggregate`, `dataset`, `query`, `time_window`,
       `threshold_type`, nested `trigger { alert_threshold, action {…} }`.
-- [ ] 0.3 **P1 gate:** confirm the metric-alert dataset (likely `events`, NOT `errors`) matches
+- [x] 0.3 **P1 gate:** confirm the metric-alert dataset (likely `events`, NOT `errors`) matches
       `level:warning` / `event.type:default` store events; the query MUST have no `event.type:error` prefix.
-- [ ] 0.4 Confirm `event_frequency` block in `sentry_issue_alert.conditions_v2` (fallback branch —
+- [x] 0.4 Confirm `event_frequency` block in `sentry_issue_alert.conditions_v2` (fallback branch —
       already verified present).
-- [ ] 0.5 Re-confirm emit-site tags: `ci-deploy.sh:564` (ghcr-fallback), `:592` (zot-gate-degraded),
+- [x] 0.5 Re-confirm emit-site tags: `ci-deploy.sh:564` (ghcr-fallback), `:592` (zot-gate-degraded),
       `cloud-init.yml:650` (inngest_ghcr_fallback, stage-only).
-- [ ] 0.6 Pick free `frequency` (Branch A only): `23`.
-- [ ] 0.7 Decide branch: **Branch B (metric alert)** unless 0.3 fails → Branch A with operator note.
+- [x] 0.6 Pick free `frequency` (Branch A only): `23`.
+- [x] 0.7 Decide branch: **Branch B (metric alert)** unless 0.3 fails → Branch A with operator note.
       Record decision + values in session-state.
 
 ## Phase 1 — Alarm resource in `issue-alerts.tf`
 
-- [ ] 1.1 Add `sentry_metric_alert.zot_mirror_fallback_rate` (Branch B primary): aggregate `count()`,
+- [~] 1.1 (Branch B metric alert — REJECTED by CTO ruling; see decision-challenges.md) Add `sentry_metric_alert.zot_mirror_fallback_rate` (Branch B primary): aggregate `count()`,
       `time_window=60`, critical `alert_threshold=3`, query over the OR-of-signals (no event.type:error),
       notify shape confirmed in 0.2.
-- [ ] 1.1-alt (Branch A fallback) `sentry_issue_alert` + `event_frequency` count>3/1h, `filter_match="any"`,
+- [x] 1.1-alt (Branch A — SHIPPED per CTO ruling) `sentry_issue_alert` + `event_frequency` count>3/1h, `filter_match="any"`,
       `frequency=23`; correct the stale `:838-839` comment; surface per-path sensitivity in PR body.
 
 ## Phase 1b — App-image fresh-boot fallback breadcrumb (close boot blind spot)
 
-- [ ] 1b.1 Add `soleur-boot-emit app_ghcr_fallback warning` on the web-boot zot→GHCR fallback branch
+- [x] 1b.1 Add `soleur-boot-emit app_ghcr_fallback warning` on the web-boot zot→GHCR fallback branch
       (`cloud-init.yml:~496`), symmetric with the inngest path at `:650`.
-- [ ] 1b.2 Include `stage:app_ghcr_fallback` as a 4th signal in the alarm query/filter.
-- [ ] 1b-alt (descope) drop the 4th signal, correct the "closes the gap" framing, file a follow-up issue.
+- [x] 1b.2 Include `stage:app_ghcr_fallback` as a 4th signal in the alarm query/filter.
+- [~] 1b-alt (descope — NOT taken; app_ghcr_fallback emit added via _emit) drop the 4th signal, correct the "closes the gap" framing, file a follow-up issue.
 
 ## Phase 2 — Apply wiring + guard sweep + op-contract test
 
-- [ ] 2.1 Append `-target=sentry_metric_alert.zot_mirror_fallback_rate` (or issue-alert) to
+- [x] 2.1 Append `-target=sentry_metric_alert.zot_mirror_fallback_rate` (or issue-alert) to
       `apply-sentry-infra.yml` after line 261.
-- [ ] 2.2 **Branch B guard sweep (P1):** add `sentry_metric_alert` nested-clause to
+- [~] 2.2 (Branch B guard sweep — n/a, Branch A) **Branch B guard sweep (P1):** add `sentry_metric_alert` nested-clause to
       `tests/scripts/lib/destroy-guard-filter-sentry.jq` (sum `trigger[]`/`action[]` deltas); extend the
       scope-guard allowlist (`test-destroy-guard-sentry-scope-guard.sh:52`); add a counter-test fixture case.
-- [ ] 2.3 (Branch A) no guard change beyond 2.1 (verified complete).
-- [ ] 2.4 Create `apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts` mirroring
+- [x] 2.3 (Branch A) no guard change beyond 2.1 (verified complete).
+- [x] 2.4 Create `apps/web-platform/test/sentry-zot-mirror-fallback-alert-op-contract.test.ts` mirroring
       `sentry-inbox-action-required-alert-op-contract.test.ts`: pin all signal tag-values across emit
       sites (`ci-deploy.sh`, `cloud-init.yml`) + the alarm resource in `issue-alerts.tf`.
 
 ## Phase 3 — inngest-bootstrap mirror push-notification signal
 
-- [ ] 3.1 Add a `Post to Slack (inngest mirror status)` step to `build-inngest-bootstrap-image.yml`,
+- [x] 3.1 Add a `Post to Slack (inngest mirror status)` step to `build-inngest-bootstrap-image.yml`,
       gated `if: steps.zot_mirror.outputs.mirror_status == 'degraded'`, `continue-on-error: true`,
       reading `SLACK_RELEASES_WEBHOOK_URL`, reusing the injection-inert posting shape from
       `reusable-release.yml:895-914`.
-- [ ] 3.2 Update the `zot_mirror` "annotations-only by design" comment to cite the #6278 Slack signal.
+- [x] 3.2 Update the `zot_mirror` "annotations-only by design" comment to cite the #6278 Slack signal.
 
 ## Phase 4 — Verify (no SSH)
 
-- [ ] 4.1 `terraform validate` in `apps/web-platform/infra/sentry/` (accept the deprecation warning).
-- [ ] 4.2 `terraform plan` (scoped `-target`) shows 1 to add, 0 change, 0 destroy.
-- [ ] 4.3 `./node_modules/.bin/vitest run test/sentry-zot-mirror-fallback-alert-op-contract.test.ts`.
-- [ ] 4.4 `actionlint .github/workflows/build-inngest-bootstrap-image.yml` + `bash -n` on the Slack snippet.
-- [ ] 4.5 Guard suites green: `bash tests/scripts/test-destroy-guard-sentry-scope-guard.sh` +
+- [x] 4.1 `terraform validate` in `apps/web-platform/infra/sentry/` (accept the deprecation warning).
+- [x] 4.2 `terraform plan` (scoped `-target`) shows 1 to add, 0 change, 0 destroy.
+- [x] 4.3 `./node_modules/.bin/vitest run test/sentry-zot-mirror-fallback-alert-op-contract.test.ts`.
+- [x] 4.4 `actionlint .github/workflows/build-inngest-bootstrap-image.yml` + `bash -n` on the Slack snippet.
+- [x] 4.5 Guard suites green: `bash tests/scripts/test-destroy-guard-sentry-scope-guard.sh` +
       `bash tests/scripts/test-destroy-guard-counter-sentry.sh`.
-- [ ] 4.6 (Optional) correct the stale ADR-062:120 event_frequency note; annotate ADR-096 status line.
+- [x] 4.6 (Optional) correct the stale ADR-062:120 event_frequency note; annotate ADR-096 status line.
 
 ## Post-merge (operator — automatable, no SSH)
 


### PR DESCRIPTION
## Summary

Provisions ADR-096's "Loud, no-SSH signal" **live-runtime fallback-rate Sentry alarm** (`>3/1h`), recorded as "design intent, not yet provisioned" and deferred as #6278 (from #6274). It is the live-runtime complement to the **create-time** CI degraded signal (`mirror_status=degraded` → Slack ⚠️) that merged in PR #6276.

Plan: `knowledge-base/project/plans/2026-07-09-feat-zot-mirror-fallback-rate-sentry-alarm-plan.md`

Closes #6278

## Changelog

### Web Platform (infra / observability)
- **New Sentry alarm** `sentry_issue_alert.zot_mirror_fallback_rate` (`apps/web-platform/infra/sentry/issue-alerts.tf`): `event_frequency` count > 3/1h, `filter_match="any"` over the four runtime signal tag-values (`registry:{ghcr-fallback,zot-gate-degraded}`, `stage:{inngest_ghcr_fallback,app_ghcr_fallback}`), notifying via the repo-standard `IssueOwners → ActiveMembers`.
- **App-image fresh-boot breadcrumb** (`cloud-init.yml`, Phase 1b): emits `stage=app_ghcr_fallback` (via the baked `_emit`, since it runs pre-host-bootstrap) on the web-boot zot→GHCR flip, closing the primary-container boot blind spot.
- **inngest-bootstrap Slack degrade signal** (`build-inngest-bootstrap-image.yml`): degrade-gated `⚠️` step — pre-cutover push-notification parity with `reusable-release.yml` (was annotations-only).
- Corrected stale "no verified `event_frequency` support" comments (`issue-alerts.tf`, ADR-062 — beta2 `conditions_v2` DOES expose it, schema-verified). Annotated ADR-096: alarm provisioned.
- New cross-artifact op-contract test pinning all four signal tag-values across emit sites + the resource.

## Model Dissents (informational)

The plan's stated **primary** was a `sentry_metric_alert` (true cross-signal aggregate). During Phase-0 the `soleur:engineering:cto` agent ruled to ship a **`sentry_issue_alert` + `event_frequency`** instead: metric-alert actions require a concrete numeric notify target that does not exist in this Sentry TF root (CI-only auth token → unresolvable/unverifiable in an autonomous session, risking an alarm that pages nobody). The per-issue-group sensitivity is accepted + operator-surfaced (the resource comment's SENSITIVITY NOTE); the metric-alert upgrade is tracked as follow-up #6285. Full rationale + rejected alternatives: `knowledge-base/project/specs/feat-one-shot-6278-zot-mirror-staleness-alarm/decision-challenges.md`.

## User-Brand Impact

**If this lands broken, the user experiences:** nothing directly — operator-facing infra observability. A broken alarm means the *operator* is not paged when the zot mirror sustains a fallback/degrade rate post-cutover; the concrete artifact is a missing Sentry page while zot redundancy silently erodes.

**If this leaks, the user's data is exposed via:** no user data on this surface. The alarm's events carry only `registry`/`stage`/`image`/`host_id`/`zot_gate_reason` tags (no PII); the `ci-deploy.sh` emitter already scrubs docker stderr to a coarse classification. The Slack step reuses the injection-inert jq-escaped shape.

- **Brand-survival threshold:** aggregate pattern

## Test plan

- [x] `terraform validate` (sentry root) passes (documented `sentry_issue_alert` deprecation warning accepted)
- [x] op-contract test 5/5 (verified non-vacuous via simulated-rename RED)
- [x] sentry + observability op-contract suite 107/107; `terraform-target-parity` 56/0
- [x] destroy-guard scope-guard + counter-sentry + regex-parity suites green
- [x] `actionlint` (no new findings) + `bash -n` on the inngest Slack snippet
- [ ] ⏳ Post-merge: `apply-sentry-infra.yml` auto-applies the rule; verify via Sentry API `GET /api/0/projects/jikigai-eu/web-platform/rules/` that `zot-mirror-fallback-rate` exists (no dashboard, no SSH)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- gate-override: soak-followthrough-enrollment -->
Soak-gate override: #6278 closes on merge (AC9 — the alarm exists in IaC at merge; apply-sentry-infra.yml auto-apply is the deploy, not a post-deploy soak). The "soak" references describe ADR-096 soak PHASE contextually, not a close criterion for any tracker in this PR. OPEN follow-ups #6285 (metric-alert) and #6286 (inngest pin) are dependency/fix-gated, not soak-gated.
