### PR TITLE
feat(dashboard): "new version" badge on the Releases nav item

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -23,6 +23,7 @@ import { NAV_ITEMS, ADMIN_NAV_ITEMS } from "@/components/command-palette/nav-ite
 import { InboxNavBadge } from "@/components/dashboard/inbox-nav-badge";
 import { ConversationsNavBadge } from "@/components/dashboard/conversations-nav-badge";
 import { WorkstreamNavBadge } from "@/components/dashboard/workstream-nav-badge";
+import { ReleasesNavBadge } from "@/components/dashboard/releases-nav-badge";
 import { ShortcutsProvider } from "@/components/command-palette/use-shortcuts";
 import {
   isApplePlatform as detectApplePlatform,
@@ -491,7 +492,7 @@ export default function DashboardLayout({
                 data-tour-id={RELEASES_HREF}
                 title={collapsed ? "Releases" : undefined}
                 aria-current={releasesActive ? "page" : undefined}
-                className={`flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
+                className={`relative flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors ${
                   releasesActive
                     ? "bg-soleur-bg-surface-2 text-soleur-text-primary"
                     : "text-soleur-text-muted hover:bg-soleur-bg-surface-2/60 hover:text-soleur-text-secondary"
@@ -499,6 +500,11 @@ export default function DashboardLayout({
               >
                 <RocketIcon className="h-4 w-4 shrink-0" />
                 <span className={`overflow-hidden whitespace-nowrap ${collapsed ? "md:hidden" : ""}`}>Releases</span>
+                {/* "New version published" cue — a calm gold dot when a web-v*
+                    release newer than this device's last-seen tag has shipped
+                    (feat-releases-nav-badge). Mounted inside the layout's
+                    <SWRConfig> so its fetch dedups with the Releases surface. */}
+                <ReleasesNavBadge collapsed={collapsed} />
               </Link>
               <a
                 href="https://soleur-ai.betteruptime.com/"

--- a/apps/web-platform/components/dashboard/inbox-nav-badge.tsx
+++ b/apps/web-platform/components/dashboard/inbox-nav-badge.tsx
@@ -16,7 +16,7 @@
 import useSWR from "swr";
 import { fetchMergedInbox } from "@/components/inbox/inbox-surface";
 import { swrKeys } from "@/lib/swr-config";
-import { NavCountBadge } from "@/components/dashboard/nav-count-badge";
+import { NavCountBadge, NavDotBadge } from "@/components/dashboard/nav-count-badge";
 import { warnSilentFallback } from "@/lib/client-observability";
 import {
   countOutstandingActionRequired,
@@ -61,17 +61,11 @@ export function InboxNavBadge({ collapsed }: { collapsed: boolean }) {
 
   // No decisions pending, but unread updates → a calm gold dot (no number).
   if (hasUnreadFyi(data)) {
-    return collapsed ? (
-      <span
-        data-testid="inbox-nav-badge-dot-collapsed"
-        aria-hidden="true"
-        className="pointer-events-none absolute right-1.5 top-1.5 hidden h-2 w-2 rounded-full bg-soleur-accent-gold-fill ring-2 ring-soleur-bg-surface-1 md:block"
-      />
-    ) : (
-      <span
-        data-testid="inbox-nav-badge-dot"
-        aria-label="New updates in your inbox"
-        className="ml-auto h-2 w-2 shrink-0 rounded-full bg-soleur-accent-gold-fill"
+    return (
+      <NavDotBadge
+        collapsed={collapsed}
+        testId="inbox-nav-badge-dot"
+        label="New updates in your inbox"
       />
     );
   }

--- a/apps/web-platform/components/dashboard/nav-count-badge.tsx
+++ b/apps/web-platform/components/dashboard/nav-count-badge.tsx
@@ -103,3 +103,37 @@ export function NavCountBadge({
     </>
   );
 }
+
+/**
+ * Presentational "calm gold dot" — a numberless FYI cue for nav items that have
+ * something new but nothing to count (unread inbox updates, a newly-published
+ * release). Gold is used here (unlike NavCountBadge's neutral pill) because a
+ * dot can't be confused with the active-state bar. Renders the trailing dot
+ * expanded/mobile, and a ringed corner dot when collapsed — exactly one paints
+ * per viewport via `md:` toggles, mirroring NavCountBadge's two-form rule.
+ */
+export function NavDotBadge({
+  collapsed,
+  testId,
+  label,
+}: {
+  collapsed: boolean;
+  /** Base test id; the collapsed corner variant appends `-collapsed`. */
+  testId: string;
+  /** Accessible name for the expanded dot; composes with the nav label. */
+  label: string;
+}) {
+  return collapsed ? (
+    <span
+      data-testid={`${testId}-collapsed`}
+      aria-hidden="true"
+      className="pointer-events-none absolute right-1.5 top-1.5 hidden h-2 w-2 rounded-full bg-soleur-accent-gold-fill ring-2 ring-soleur-bg-surface-1 md:block"
+    />
+  ) : (
+    <span
+      data-testid={testId}
+      aria-label={label}
+      className="ml-auto h-2 w-2 shrink-0 rounded-full bg-soleur-accent-gold-fill"
+    />
+  );
+}

--- a/apps/web-platform/components/dashboard/releases-nav-badge.tsx
+++ b/apps/web-platform/components/dashboard/releases-nav-badge.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+// Releases left-nav "new version" badge (feat-releases-nav-badge). The Releases
+// feed is Soleur's own web-v* GitHub releases (user-independent), so there is no
+// per-account read state — "new version published" is a per-DEVICE signal: the
+// newest tag differs from the last one this browser looked at (see
+// lib/releases-seen). Reuses the Releases surface's shared SWR key + fetcher so
+// the badge and the list are fed by ONE request (free dedup, ADR-067) and can
+// never disagree about what "latest" is.
+//
+// Honesty contract (mirrors inbox-nav-badge): a loading/errored fetch NEVER
+// renders a false signal — COLD (undefined data) omits entirely. States:
+//   - no local record yet → SEED silently to latest, no dot (first-load contract)
+//   - latest tag !== last seen → a calm gold dot ("New version published")
+//   - else → omit
+// A calm dot (no number) matches the read-only informational nature of the tab;
+// releases are FYI, never an action count.
+
+import { useEffect } from "react";
+import useSWR from "swr";
+import { fetchReleases } from "@/components/releases/releases-surface";
+import { swrKeys } from "@/lib/swr-config";
+import { warnSilentFallback } from "@/lib/client-observability";
+import { NavDotBadge } from "@/components/dashboard/nav-count-badge";
+import {
+  isNewerReleaseTag,
+  seedReleasesSeenIfEmpty,
+  useLastSeenReleaseTag,
+} from "@/lib/releases-seen";
+import type { ReleaseCard } from "@/server/release-notes";
+
+export function ReleasesNavBadge({ collapsed }: { collapsed: boolean }) {
+  const { data } = useSWR<ReleaseCard[]>(
+    swrKeys.releasesList(),
+    fetchReleases,
+    {
+      onError: (err) =>
+        warnSilentFallback(err, {
+          feature: "releases-nav-badge",
+          op: "count-fetch",
+        }),
+    },
+  );
+  const lastSeen = useLastSeenReleaseTag();
+
+  // The server returns newest-first, so index 0 is the true latest.
+  const latestTag = data?.[0]?.tag;
+
+  // First-load contract: no record on this device → seed silently to the current
+  // latest so the dot only ever fires on a version published AFTER now. Runs as
+  // an effect (not during render); the write-time-guarded seed can never clobber
+  // an existing record, so a transient null snapshot can't suppress a real dot.
+  useEffect(() => {
+    if (latestTag && lastSeen === null) seedReleasesSeenIfEmpty(latestTag);
+  }, [latestTag, lastSeen]);
+
+  // COLD (undefined data, incl. a hard-failed first load): omit — never a false dot.
+  // No local record yet: seeding above suppresses the dot until the next publish.
+  if (!latestTag || lastSeen === null) return null;
+
+  // Only a STRICTLY newer version paints the dot — inequality alone would fire on
+  // a rollback (a yanked release regressing the newest tag), which isn't "new".
+  if (!isNewerReleaseTag(latestTag, lastSeen)) return null;
+
+  // A newer version shipped → a calm gold dot (no number), reusing the shared
+  // NavDotBadge so it reads identically to the inbox FYI dot.
+  return (
+    <NavDotBadge
+      collapsed={collapsed}
+      testId="releases-nav-badge-dot"
+      label="New version published"
+    />
+  );
+}

--- a/apps/web-platform/components/releases/releases-surface.tsx
+++ b/apps/web-platform/components/releases/releases-surface.tsx
@@ -10,8 +10,9 @@
 // revalidation, StaleRefreshBar when a background refresh fails while stale data
 // is shown, ErrorCard only on the cold (`!data && error`) failure.
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
+import { markReleasesSeen } from "@/lib/releases-seen";
 import { ErrorCard } from "@/components/ui/error-card";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import { RefreshShimmer } from "@/components/ui/refresh-shimmer";
@@ -61,6 +62,13 @@ export function ReleasesSurface() {
   // The server returns newest-first, so the true latest is index 0 — pin the
   // "Latest" badge to its tag so it stays correct under any sort/filter.
   const latestTag = releases?.[0]?.tag;
+
+  // Viewing this feed clears the nav "new version" dot: record the latest tag as
+  // seen on this device (feat-releases-nav-badge). Idempotent — no-ops when the
+  // value is unchanged, so it won't churn on re-render.
+  useEffect(() => {
+    if (latestTag) markReleasesSeen(latestTag);
+  }, [latestTag]);
 
   const visible = useMemo(() => {
     const all = releases ?? [];

--- a/apps/web-platform/lib/releases-seen.ts
+++ b/apps/web-platform/lib/releases-seen.ts
@@ -1,0 +1,116 @@
+"use client";
+
+// Device-local "last seen release" tracker (feat-releases-nav-badge). The
+// Releases feed is Soleur's OWN web-v* GitHub releases — user-independent — so
+// there is no per-account "read" state to hang a badge off. "New version"
+// is therefore a per-device signal: we remember the newest tag this browser has
+// looked at and dot the nav when a newer one ships. Deliberately localStorage,
+// NOT server/account state, mirroring keyboard-shortcuts-toggle's reasoning (a
+// per-device affordance, not a synced preference).
+//
+// First-load contract: a browser with NO record is SEEDED silently to the
+// current latest (no dot). The user asked to know when a NEW version is
+// published — i.e. one shipped after now — so an existing user is not nagged
+// about a release they may already know about. The dot appears only on the
+// NEXT publish after the seed.
+
+import { useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "soleur:releases:last-seen-tag";
+export const RELEASES_SEEN_CHANGED_EVENT = "soleur:releases-seen-changed";
+
+/** Read the last-seen release tag, or null (no record / SSR / storage blocked). */
+export function readLastSeenReleaseTag(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    // Private-mode / disabled storage: treat as "no record" rather than throw.
+    return null;
+  }
+}
+
+/**
+ * Persist `tag` as the newest release this device has seen and notify any live
+ * subscriber in THIS document (storage events do not fire in the same document
+ * that wrote the value). No-ops when the value is unchanged so a re-render loop
+ * can't churn the store. This is the "clear the dot" primitive — it overwrites
+ * ANY prior value, so it must only be called when the user has genuinely seen
+ * the feed (never on a passive first-load seed — use seedReleasesSeenIfEmpty).
+ */
+export function markReleasesSeen(tag: string): void {
+  if (typeof window === "undefined" || !tag) return;
+  try {
+    if (window.localStorage.getItem(STORAGE_KEY) === tag) return;
+    window.localStorage.setItem(STORAGE_KEY, tag);
+  } catch {
+    return;
+  }
+  window.dispatchEvent(new Event(RELEASES_SEEN_CHANGED_EVENT));
+}
+
+/**
+ * First-load seed: record `tag` as seen ONLY when this device has no record
+ * yet. Distinct from markReleasesSeen so the passive seed can never clobber a
+ * real last-seen value (which would silently suppress a legitimate "new version"
+ * dot). The "already have a record" check is at WRITE time, so it is robust even
+ * if a caller fires it during a transient render where a reactive snapshot still
+ * reads null (e.g. if an SSR/SWR fallback for the feed is added later).
+ */
+export function seedReleasesSeenIfEmpty(tag: string): void {
+  if (typeof window === "undefined" || !tag) return;
+  try {
+    if (window.localStorage.getItem(STORAGE_KEY) !== null) return;
+    window.localStorage.setItem(STORAGE_KEY, tag);
+  } catch {
+    return;
+  }
+  window.dispatchEvent(new Event(RELEASES_SEEN_CHANGED_EVENT));
+}
+
+// Parse a `web-vX.Y.Z` tag to a comparable tuple, or null for anything that
+// doesn't match (draft/oddly-tagged releases).
+function parseWebVersion(tag: string): [number, number, number] | null {
+  const m = /^web-v(\d+)\.(\d+)\.(\d+)/.exec(tag);
+  return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : null;
+}
+
+/**
+ * True when `candidate` is a STRICTLY newer web release than `baseline`. Used to
+ * gate the "new version" dot on real forward progress, so a yanked/deleted
+ * release regressing the newest tag can't paint a false dot on a rollback. When
+ * either tag isn't a parseable `web-v*` version, fall back to plain inequality
+ * so a non-standard tag still nudges rather than silently going dark.
+ */
+export function isNewerReleaseTag(candidate: string, baseline: string): boolean {
+  const c = parseWebVersion(candidate);
+  const b = parseWebVersion(baseline);
+  if (!c || !b) return candidate !== baseline;
+  for (let i = 0; i < 3; i++) {
+    if (c[i] !== b[i]) return c[i] > b[i];
+  }
+  return false;
+}
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener(RELEASES_SEEN_CHANGED_EVENT, onChange);
+  // Cross-tab: a write in another tab fires `storage` here.
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(RELEASES_SEEN_CHANGED_EVENT, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
+
+/**
+ * Reactive read of the last-seen tag. Re-renders when this device (or another
+ * tab) marks a release seen. SSR/first-client snapshot is `null` (matches the
+ * server render), then the real value resolves post-hydration.
+ */
+export function useLastSeenReleaseTag(): string | null {
+  return useSyncExternalStore(
+    subscribe,
+    readLastSeenReleaseTag,
+    () => null,
+  );
+}

--- a/apps/web-platform/test/releases-nav-badge.test.tsx
+++ b/apps/web-platform/test/releases-nav-badge.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import type { ReleaseCard } from "@/server/release-notes";
+
+// The badge derives "new version" from the SAME shared SWR key the Releases
+// surface uses (swrKeys.releasesList()), so we drive it by controlling useSWR's
+// return, plus a device-local last-seen tag in localStorage. Contract: seed
+// silently on first load (no dot), gold dot only when the latest tag differs
+// from the last-seen one, and NEVER a false signal on a cold/errored fetch.
+const useSWRMock = vi.fn();
+vi.mock("swr", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("swr")>();
+  return { ...actual, default: (...args: unknown[]) => useSWRMock(...args) };
+});
+
+const STORAGE_KEY = "soleur:releases:last-seen-tag";
+
+function card(tag: string): ReleaseCard {
+  return {
+    tag,
+    title: tag,
+    bodyMarkdown: "notes",
+    publishedAt: "2026-07-01T00:00:00.000Z",
+    htmlUrl: `https://example.test/${tag}`,
+    securitySensitive: false,
+    bump: "minor",
+  };
+}
+
+// Newest-first, matching the server contract (index 0 = latest).
+function feed(...tags: string[]): ReleaseCard[] {
+  return tags.map(card);
+}
+
+beforeEach(() => {
+  useSWRMock.mockReset();
+  window.localStorage.clear();
+});
+afterEach(() => cleanup());
+
+async function renderBadge(collapsed = false) {
+  const { ReleasesNavBadge } = await import(
+    "@/components/dashboard/releases-nav-badge"
+  );
+  return render(<ReleasesNavBadge collapsed={collapsed} />);
+}
+
+describe("ReleasesNavBadge (new version published)", () => {
+  it("keys the SAME shared SWR tuple the Releases surface uses (dedup)", async () => {
+    useSWRMock.mockReturnValue({ data: feed("web-v1.0.0"), error: undefined });
+    await renderBadge();
+    const { swrKeys } = await import("@/lib/swr-config");
+    expect(useSWRMock.mock.calls[0]![0]).toEqual(swrKeys.releasesList());
+  });
+
+  it("seeds silently on first load (no record) — no dot, latest recorded", async () => {
+    useSWRMock.mockReturnValue({ data: feed("web-v1.2.0"), error: undefined });
+    await renderBadge();
+    // No dot for an existing user's first-ever load...
+    expect(
+      screen.queryByTestId("releases-nav-badge-dot"),
+    ).not.toBeInTheDocument();
+    // ...but the current latest is now seeded as seen.
+    await waitFor(() =>
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe("web-v1.2.0"),
+    );
+  });
+
+  it("shows a gold dot when a newer tag than last-seen has shipped", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "web-v1.2.0");
+    useSWRMock.mockReturnValue({
+      data: feed("web-v1.3.0", "web-v1.2.0"),
+      error: undefined,
+    });
+    await renderBadge();
+    const dot = screen.getByTestId("releases-nav-badge-dot");
+    expect(dot).toHaveAccessibleName("New version published");
+    expect(dot.className).toContain("bg-soleur-accent-gold-fill");
+  });
+
+  it("omits on a rollback — a regressed latest tag is not 'newer' than last-seen", async () => {
+    // Device already saw web-v1.3.0; a yank makes the feed's newest web-v1.2.0.
+    window.localStorage.setItem(STORAGE_KEY, "web-v1.3.0");
+    useSWRMock.mockReturnValue({
+      data: feed("web-v1.2.0", "web-v1.1.0"),
+      error: undefined,
+    });
+    await renderBadge();
+    expect(
+      screen.queryByTestId("releases-nav-badge-dot"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits when the latest tag equals the last-seen tag", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "web-v1.3.0");
+    useSWRMock.mockReturnValue({
+      data: feed("web-v1.3.0", "web-v1.2.0"),
+      error: undefined,
+    });
+    await renderBadge();
+    expect(
+      screen.queryByTestId("releases-nav-badge-dot"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("omits on a COLD fetch (data undefined) — never a false dot", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "web-v1.2.0");
+    useSWRMock.mockReturnValue({ data: undefined, error: new Error("502") });
+    await renderBadge();
+    expect(
+      screen.queryByTestId("releases-nav-badge-dot"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the collapsed corner dot variant with a rail-matching ring", async () => {
+    window.localStorage.setItem(STORAGE_KEY, "web-v1.2.0");
+    useSWRMock.mockReturnValue({
+      data: feed("web-v1.3.0"),
+      error: undefined,
+    });
+    await renderBadge(true);
+    const dot = screen.getByTestId("releases-nav-badge-dot-collapsed");
+    expect(dot.className).toMatch(/ring-soleur-bg-surface-1/);
+    expect(dot).toHaveAttribute("aria-hidden", "true");
+  });
+});


### PR DESCRIPTION
## What

Adds a calm gold dot to the **Releases** sidebar item — visually identical to the existing Inbox FYI dot — when Soleur has published a `web-v*` release newer than the one this browser last viewed. Opening the Releases feed clears it.

Requested by the operator: *"a badge already exists on the inbox tab; add it to the releases tab too, to know when there's a new version published."*

## How

The Releases feed is Soleur's own **account-independent** GitHub releases, so there's no per-account read-state to hang a badge off. "New version" is therefore a **per-device** signal, tracked in `localStorage` (the same boundary as `keyboard-shortcuts-toggle`) and read reactively via `useSyncExternalStore` so the sidebar and the page (and other tabs) stay in sync.

- `lib/releases-seen.ts` *(new)* — device-local last-seen-tag store: `seedReleasesSeenIfEmpty` (write-guarded first-load seed), `markReleasesSeen` (clear-on-view), `isNewerReleaseTag` (strict `web-vX.Y.Z` compare), and the `useLastSeenReleaseTag` hook.
- `components/dashboard/releases-nav-badge.tsx` *(new)* — reuses the Releases surface's shared SWR key (`swrKeys.releasesList()`) so badge and list can never disagree about "latest" (ADR-067 dedup).
- `components/dashboard/nav-count-badge.tsx` — extracts the shared **`NavDotBadge`** primitive.
- `components/dashboard/inbox-nav-badge.tsx` — now consumes `NavDotBadge` (removes the duplicated dot markup).
- `components/releases/releases-surface.tsx` — marks latest seen on view → clears the dot.
- `app/(dashboard)/layout.tsx` — mounts the badge in the footer Releases link (`relative` added for the collapsed corner-dot anchor).

## Honesty contract (mirrors inbox-nav-badge)

- Cold/errored fetch → **no dot** (never a false signal).
- First-ever load with no record → **seeded silently**, no dot; the dot fires only on a version published *after* now.
- Rollback (a yanked release regressing the newest tag) → gated out by the **strict version compare**, not plain inequality.

## Testing

- `test/releases-nav-badge.test.tsx` *(new, 7 cases)* — shared-key dedup, silent seed, newer→dot, rollback→no-dot, equal→no-dot, cold→no-dot, collapsed variant.
- Full affected suite green: `releases-nav-badge` + `inbox-nav-badge` + `releases-surface` + `conversations/workstream-nav-badge` = 37 passing. `tsc` clean on changed files.

## Review

Two-agent pre-ship review — **no P1/P2**. Agent-native parity: **PASS** (feed is fully agent-reachable; only the ephemeral read-cue is device-local by design). Architecture: 3 P3s, all applied (write-guarded seed, strict-newer compare, `NavDotBadge` extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)