### PR TITLE
fix(infra): dedicated Inngest host never booted — 5 cloud-init boot fixes + boot-observability probe (Ref #6178)

### DIFF
--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -181,7 +181,14 @@ runcmd:
   # is scoped to the ISOLATED `soleur-inngest` project's `prd` root config (a SEPARATE
   # project — NO inheritance path to soleur/prd), so a host compromise reads ONLY the
   # inngest secret set.
-  - printf 'DOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/inngest-doppler
+  # HOME is REQUIRED (#6122 boot fix — the actual dark-host boot bug, found via the #6178 boot
+  # probe): cloud-init runcmd runs with NO $HOME, and the Doppler CLI aborts with
+  # "Doppler Error: $HOME is not defined" even when DOPPLER_CONFIG_DIR is set. Without it the
+  # boot isolation self-check `doppler run` (+ its nested `doppler secrets`) and the token fetch
+  # both fail → inngest never bootstraps → the host is dark+silent+unreachable. The registry host
+  # got this fix (cloud-init-registry.yml:314-317); the inngest host never did, so it never booted.
+  # (systemd units set HOME=/root themselves, so only these cloud-init-level doppler calls need it.)
+  - printf 'HOME=/root\nDOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/inngest-doppler
   - chmod 600 /etc/default/inngest-doppler
 
   # --- #6178 boot observability: stage the Better Stack token + emit the FIRST marker ---

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -389,3 +389,13 @@ runcmd:
     fi
     trap - EXIT
     /usr/local/bin/inngest-boot-phone-home.sh bootstrap-done
+    # #6178 diag: the bootstrap `systemctl restart` returns once the process is SPAWNED, not once
+    # it is HEALTHY — so bootstrap-done does not prove inngest bound :8288. Capture the service
+    # states + loopback :8288 + the inngest-server journal tail (redacted) via the phone-home
+    # (Vector journald shipping is separately unreliable on this host, so this is the visibility).
+    set +e
+    sleep 8
+    svc="$(systemctl is-active inngest-server.service inngest-redis.service vector.service 2>&1 | tr '\n' ',')"
+    lo="$(curl -s -o /dev/null -w '%%{http_code}' --max-time 5 http://127.0.0.1:8288/ 2>&1)"
+    jl="$(journalctl -u inngest-server.service --no-pager -n 15 2>/dev/null | /usr/local/bin/inngest-redact.sh | tr '\n' '|' | head -c 400)"
+    /usr/local/bin/inngest-boot-phone-home.sh post-boot-health "svc=[$svc] lo8288=$lo jl=[$jl]"

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -302,6 +302,16 @@ runcmd:
   - id -u deploy >/dev/null 2>&1 || useradd -m -g deploy -G docker -s /bin/bash deploy
   - /usr/local/bin/inngest-boot-phone-home.sh deploy-user-ensured "$(id deploy 2>&1 | head -c 80)"
 
+  # #6178: pre-create /etc/default/inngest-server with the Doppler token so inngest-bootstrap.sh's
+  # "preserve" branch (inngest-bootstrap.sh:220) fires. The dedicated host has NO
+  # /etc/default/webhook-deploy (a web-host webhook.service file) that the bootstrap otherwise reads
+  # the token from — so without this it aborts 'webhook-deploy not found — cannot source DOPPLER_TOKEN'.
+  # Same content + umask 0137 (mode 0640) + root:deploy the bootstrap itself writes (:238-245); deploy
+  # must exist first (created above). The unit's User=deploy gets HOME=/home/deploy from systemd, so
+  # this env file carries DOPPLER_CONFIG_DIR (not HOME).
+  - ( umask 0137 && printf 'DOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/inngest-server )
+  - chown root:deploy /etc/default/inngest-server
+
   # --- Extract + run inngest-bootstrap.sh from the baked OCI image ---------------------
   # Gated on the isolation sentinel above (fail-closed). Mirrors web cloud-init.yml:642-682:
   # docker create → docker cp the script + durable-Redis assets → read INNGEST_CLI_VERSION/

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -100,7 +100,7 @@ write_files:
       [ -n "$bs_token" ] || exit 0
       host="$(hostname 2>/dev/null)"
       ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
-      detail="$(printf '%s' "$detail" | sed -E 's#(://[^:@/]+:)[^@]+(@)#\1REDACTED\2#g; s#[0-9a-f]{32,}#REDACTED#g; s#(signkey-[a-z]+-)[0-9a-f]*#\1REDACTED#g' 2>/dev/null)"
+      detail="$(printf '%s' "$detail" | sed -E 's#(://[^:@/]+:)[^@]+(@)#\1REDACTED\2#g; s#dp\.[a-z0-9]+\.[A-Za-z0-9_-]{10,}#REDACTED#g; s#[0-9a-f]{32,}#REDACTED#g; s#(signkey-[a-z]+-)[0-9a-f]*#\1REDACTED#g' 2>/dev/null)"
       payload="$(jq -nc --arg m SOLEUR_INNGEST_BOOT_STAGE --arg s "$stage" --arg d "$detail" --arg h "$host" --arg t "$ts" '{message:($m+" stage="+$s+" "+$d), marker:$m, stage:$s, detail:$d, host:$h, dt:$t, shipper:"cloud-init-phone-home"}' 2>/dev/null)"
       [ -n "$payload" ] || payload="{\"message\":\"SOLEUR_INNGEST_BOOT_STAGE stage=$stage\",\"marker\":\"SOLEUR_INNGEST_BOOT_STAGE\",\"stage\":\"$stage\",\"host\":\"$host\"}"
       curl -fsS --max-time 8 -X POST "https://s2457081.eu-fsn-3.betterstackdata.com/" -H "Authorization: Bearer $bs_token" -H "Content-Type: application/json" -d "$payload" >/dev/null 2>&1
@@ -192,12 +192,16 @@ runcmd:
   - |
     set +e
     set -a; . /etc/default/inngest-doppler; set +a
-    t="$(doppler secrets get BETTERSTACK_LOGS_TOKEN --project soleur-inngest --config prd --plain 2>/dev/null)"
+    # #6178 diag: capture WHY doppler reads fail on the host (works off-host w/ same token+env).
+    # Probe api.doppler.com reachability (DNS/connect/http) + the doppler CLI's own stderr.
+    api_probe="$(curl -sS -o /dev/null -w 'http=%%{http_code};ip=%%{remote_ip};dns=%%{time_namelookup}s;conn=%%{time_connect}s;curlrc=%%{exitcode}' --max-time 12 https://api.doppler.com/v3/me 2>&1 | head -c 160)"
+    derr="$(doppler secrets get BETTERSTACK_LOGS_TOKEN --project soleur-inngest --config prd --plain 2>&1 1>/tmp/bstok)"; drc=$?
+    t="$(cat /tmp/bstok 2>/dev/null)"; rm -f /tmp/bstok
     if [ -n "$t" ]; then
       printf '%s' "$t" > /run/inngest-bs-logs-token; chmod 600 /run/inngest-bs-logs-token 2>/dev/null
-      /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetched "arch=${inngest_cli_arch}"
+      /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetched "arch=${inngest_cli_arch} apiprobe=[$api_probe]"
     else
-      /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetch-FAILED "arch=${inngest_cli_arch}"
+      /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetch-FAILED "drc=$drc apiprobe=[$api_probe] derr=[$(printf %s "$derr" | head -c 200)]"
     fi
 
   # --- Bake scoped GHCR read-creds (#6179/#6161) --------------------------------------

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -186,6 +186,12 @@ runcmd:
     echo "$${DOPPLER_SHA256}  /tmp/doppler.tar.gz" | sha256sum -c -
     tar xzf /tmp/doppler.tar.gz -C /usr/local/bin doppler
     chmod +x /usr/local/bin/doppler
+    # #6178: the inngest-server / flip-guard / vector / cutover-flip units hardcode
+    # ExecStart=/usr/bin/doppler (inngest-bootstrap.sh:411/473/619, inngest-cutover-flip.service:19),
+    # but cloud-init installs to /usr/local/bin — so every unit died with systemd status=203/EXEC and
+    # inngest never bound :8288 (found via the post-boot-health probe). Web hosts have doppler at
+    # /usr/bin; this host did not. Symlink so the hardcoded path resolves for all units.
+    ln -sf /usr/local/bin/doppler /usr/bin/doppler
     rm /tmp/doppler.tar.gz
     command -v doppler >/dev/null 2>&1 \
       && /usr/local/bin/inngest-boot-phone-home.sh doppler-cli-installed "$(doppler --version 2>/dev/null | head -1)" \

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -23,6 +23,20 @@ packages:
 groups:
   - docker
 
+# The inngest-server systemd unit runs as User=deploy (inngest-bootstrap.sh:184/414) and the
+# bootstrap chowns /var/lib/inngest to deploy:deploy (else SQLite CANTOPEN(14)). The web hosts
+# create `deploy` in their cloud-init (cloud-init.yml:46-53); the dedicated inngest host never
+# did, so the bootstrap aborted with `chown: invalid user: 'deploy:deploy'` and inngest never
+# started (found via the #6178 boot probe, after the HOME fix). Mirror the web deploy user;
+# `- default` preserves the distro root user (+ its hcloud-injected SSH key). deploy gets a home
+# (/home/deploy) so the unit's User=deploy `doppler run` resolves $HOME at runtime.
+users:
+  - default
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    lock_passwd: true
+
 write_files:
   # SSH hardening parity with registry / git-data / the web host's minimal set.
   - path: /etc/ssh/sshd_config.d/01-hardening.conf

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -108,6 +108,34 @@ write_files:
     owner: root:root
     permissions: '0755'
 
+  # --- #6178 boot observability: value-based secret redaction for the shipped log tail ---
+  # The phone-home POST bypasses Vector's PII scrub, so any log tail it ships MUST be scrubbed
+  # here first. Pattern-masking alone is incomplete (it misses non-hex tokens / redis passwords),
+  # so this redacts by KNOWN VALUE — every enumerated inngest secret (token files + the isolated
+  # soleur-inngest/prd set) is replaced literally, catching secrets of ANY format. It uses bash
+  # quoted-pattern parameter replacement (literal, not glob) so regex/glob metachars in a secret
+  # value are matched safely.
+  # Fail-open: if Doppler is unreachable the value list degrades to the token files + the pattern
+  # backstop (never errors). Reads the tail on stdin, writes the scrubbed tail on stdout.
+  - path: /usr/local/bin/inngest-redact.sh
+    content: |
+      #!/usr/bin/env bash
+      set +e
+      data="$(cat)"
+      vals=()
+      [ -r /run/inngest-bs-logs-token ] && vals+=("$(cat /run/inngest-bs-logs-token 2>/dev/null)")
+      . /etc/default/soleur-ghcr-read 2>/dev/null; vals+=("$GHCR_READ_TOKEN")
+      . /etc/default/inngest-doppler 2>/dev/null; vals+=("$DOPPLER_TOKEN")
+      if [ -n "$DOPPLER_TOKEN" ]; then
+        while IFS= read -r v; do vals+=("$v"); done < <(doppler secrets download --no-file --format json --project soleur-inngest --config prd 2>/dev/null | jq -r 'to_entries[]|select(.key|startswith("DOPPLER_")|not)|.value' 2>/dev/null)
+      fi
+      for s in "$${vals[@]}"; do
+        [ -n "$s" ] && [ "$(printf %s "$s" | wc -c)" -ge 6 ] && data="$${data//"$s"/REDACTED}"
+      done
+      printf '%s' "$data" | sed -E 's#(://[^:@/]+:)[^@]+(@)#\1REDACTED\2#g; s#[0-9a-f]{32,}#REDACTED#g; s#[A-Za-z0-9_+/-]{40,}#REDACTED#g'
+    owner: root:root
+    permissions: '0755'
+
 runcmd:
   # Apply SSH hardening immediately.
   - systemctl restart sshd
@@ -236,7 +264,7 @@ runcmd:
     docker pull "$IREF" > /var/log/inngest-oci-pull.log 2>&1
     pull_rc=$?
     set -e
-    pull_tail="$(tail -n 8 /var/log/inngest-oci-pull.log 2>/dev/null | tr '\n' '|' || true)"
+    pull_tail="$(tail -n 8 /var/log/inngest-oci-pull.log 2>/dev/null | /usr/local/bin/inngest-redact.sh | tr '\n' '|' || true)"
     /usr/local/bin/inngest-boot-phone-home.sh oci-pull-rc-$pull_rc "$pull_tail"
     [ "$pull_rc" -eq 0 ] || { echo "FATAL: OCI pull failed rc=$pull_rc" >&2; exit "$pull_rc"; }
     EXTRACT_DIR=$(mktemp -d)
@@ -287,7 +315,7 @@ runcmd:
       bash "$EXTRACT_DIR/inngest-bootstrap.sh" > /var/log/inngest-bootstrap.log 2>&1
     boot_rc=$?
     set -e
-    boot_tail="$(tail -n 20 /var/log/inngest-bootstrap.log 2>/dev/null | tr '\n' '|' || true)"
+    boot_tail="$(tail -n 20 /var/log/inngest-bootstrap.log 2>/dev/null | /usr/local/bin/inngest-redact.sh | tr '\n' '|' || true)"
     /usr/local/bin/inngest-boot-phone-home.sh bootstrap-exit-$boot_rc "$boot_tail"
     if [ "$boot_rc" -ne 0 ]; then
       echo "FATAL: inngest bootstrap failed rc=$boot_rc (see /var/log/inngest-bootstrap.log)" >&2

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -81,6 +81,33 @@ write_files:
     owner: root:root
     permissions: '0644'
 
+  # --- #6178 boot observability: early-boot stage-marker emitter -----------------------
+  # Ships a SOLEUR_INNGEST_BOOT_STAGE marker to the Better Stack Logs HTTP ingest, INDEPENDENT
+  # of the journald->Vector shipper (which only starts LATE in the bootstrap, if at all — so a
+  # dark host that bricks BEFORE Vector is otherwise a total blind spot: no logs, deny-all-public
+  # so no SSH). URI + token mirror the vector.toml `[sinks.betterstack]` sink, so markers land in
+  # the SAME source table and are queryable via `betterstack-query.sh --grep SOLEUR_INNGEST_BOOT_STAGE`.
+  # Fail-OPEN: never blocks or fails the boot (a broken emitter must not brick the host). This POST
+  # bypasses Vector's PII scrub, so the free-form detail arg is masked here before shipping.
+  - path: /usr/local/bin/inngest-boot-phone-home.sh
+    content: |
+      #!/usr/bin/env bash
+      set +e
+      stage="$1"; detail="$2"
+      tok_file=/run/inngest-bs-logs-token
+      [ -r "$tok_file" ] || exit 0
+      bs_token="$(cat "$tok_file" 2>/dev/null)"
+      [ -n "$bs_token" ] || exit 0
+      host="$(hostname 2>/dev/null)"
+      ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+      detail="$(printf '%s' "$detail" | sed -E 's#(://[^:@/]+:)[^@]+(@)#\1REDACTED\2#g; s#[0-9a-f]{32,}#REDACTED#g; s#(signkey-[a-z]+-)[0-9a-f]*#\1REDACTED#g' 2>/dev/null)"
+      payload="$(jq -nc --arg m SOLEUR_INNGEST_BOOT_STAGE --arg s "$stage" --arg d "$detail" --arg h "$host" --arg t "$ts" '{message:($m+" stage="+$s+" "+$d), marker:$m, stage:$s, detail:$d, host:$h, dt:$t, shipper:"cloud-init-phone-home"}' 2>/dev/null)"
+      [ -n "$payload" ] || payload="{\"message\":\"SOLEUR_INNGEST_BOOT_STAGE stage=$stage\",\"marker\":\"SOLEUR_INNGEST_BOOT_STAGE\",\"stage\":\"$stage\",\"host\":\"$host\"}"
+      curl -fsS --max-time 8 -X POST "https://s2457081.eu-fsn-3.betterstackdata.com/" -H "Authorization: Bearer $bs_token" -H "Content-Type: application/json" -d "$payload" >/dev/null 2>&1
+      exit 0
+    owner: root:root
+    permissions: '0755'
+
 runcmd:
   # Apply SSH hardening immediately.
   - systemctl restart sshd
@@ -113,6 +140,18 @@ runcmd:
   - printf 'DOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/inngest-doppler
   - chmod 600 /etc/default/inngest-doppler
 
+  # --- #6178 boot observability: stage the Better Stack token + emit the FIRST marker ---
+  # Reached only if the volume mount + Doppler CLI install + scoped-token auth all succeeded,
+  # so a received `doppler-token-fetched` marker proves the boot got this far AND Doppler auth
+  # works; TOTAL marker absence localizes the failure to those earlier stages (or lost egress).
+  # 0600 in tmpfs /run (re-fetched every boot; the phone-home reads it). set +e: fail-open.
+  - |
+    set +e
+    set -a; . /etc/default/inngest-doppler; set +a
+    doppler secrets get BETTERSTACK_LOGS_TOKEN --project soleur-inngest --config prd --plain > /run/inngest-bs-logs-token 2>/dev/null
+    chmod 600 /run/inngest-bs-logs-token 2>/dev/null
+    /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetched "arch=${inngest_cli_arch}"
+
   # --- Bake scoped GHCR read-creds (#6179/#6161) --------------------------------------
   # So the cold-boot soleur-inngest-bootstrap OCI pull + cosign-verify authenticates even
   # when Doppler answers empty at the boot instant (else anonymous private pull → 401 →
@@ -133,10 +172,13 @@ runcmd:
     . /etc/default/soleur-ghcr-read 2>/dev/null || true
     for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
     if [ -n "$GHCR_READ_USER" ] && [ -n "$GHCR_READ_TOKEN" ]; then
-      printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin >/dev/null 2>&1 \
-        && echo "[inngest] ghcr login ok" || echo "[inngest] ghcr login failed (bootstrap pull may 401)"
+      if printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_READ_USER" --password-stdin >/dev/null 2>&1; then
+        echo "[inngest] ghcr login ok"; /usr/local/bin/inngest-boot-phone-home.sh ghcr-login-ok
+      else
+        echo "[inngest] ghcr login failed (bootstrap pull may 401)"; /usr/local/bin/inngest-boot-phone-home.sh ghcr-login-FAILED
+      fi
     else
-      echo "[inngest] WARN: baked GHCR creds empty — bootstrap pull may 401"
+      echo "[inngest] WARN: baked GHCR creds empty — bootstrap pull may 401"; /usr/local/bin/inngest-boot-phone-home.sh ghcr-creds-EMPTY
     fi
 
   # --- Fail-closed boot isolation self-check (mirrors registry) ------------------------
@@ -169,8 +211,10 @@ runcmd:
     CHKEOF
     then
       : > /run/soleur-inngest-doppler.ok
+      /usr/local/bin/inngest-boot-phone-home.sh isolation-check-passed
     else
       echo "[inngest] FATAL: doppler isolation self-check failed — inngest will NOT bootstrap" >&2
+      /usr/local/bin/inngest-boot-phone-home.sh isolation-check-FAILED
     fi
     set +e
 
@@ -185,7 +229,16 @@ runcmd:
     test -f /run/soleur-inngest-doppler.ok || { echo "FATAL: doppler isolation self-check did not pass — refusing to bootstrap inngest" >&2; exit 1; }
     IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.19
     for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
-    docker pull "$IREF"
+    # #6178 boot observability: bracket the OCI pull so a pull hang/401 self-reports the STAGE
+    # (pre-oci-pull with no oci-pull-rc-* = hung; oci-pull-rc-N!=0 = failed, with masked tail).
+    /usr/local/bin/inngest-boot-phone-home.sh pre-oci-pull "$IREF"
+    set +e
+    docker pull "$IREF" > /var/log/inngest-oci-pull.log 2>&1
+    pull_rc=$?
+    set -e
+    pull_tail="$(tail -n 8 /var/log/inngest-oci-pull.log 2>/dev/null | tr '\n' '|' || true)"
+    /usr/local/bin/inngest-boot-phone-home.sh oci-pull-rc-$pull_rc "$pull_tail"
+    [ "$pull_rc" -eq 0 ] || { echo "FATAL: OCI pull failed rc=$pull_rc" >&2; exit "$pull_rc"; }
     EXTRACT_DIR=$(mktemp -d)
     cleanup() { docker rm -f soleur-inngest-bootstrap-extract >/dev/null 2>&1 || true; rm -rf "$EXTRACT_DIR"; }
     trap cleanup EXIT
@@ -220,9 +273,25 @@ runcmd:
     # DOPPLER_PROJECT=soleur-inngest routes every doppler-wrapped unit (server/heartbeat/redis/
     # vector) at THIS host's ISOLATED project (AC3) — the scoped boot token can read only
     # soleur-inngest. VECTOR_CLI_ARCH (=${inngest_cli_arch}) selects the matching triple in the bootstrap map.
+    # #6178 boot observability: capture the bootstrap's combined output to a file and self-report
+    # its exit code + a masked tail. The bootstrap's own log() goes to journald->Vector, which is
+    # DOWN until the bootstrap installs+starts Vector near its end — so a mid-bootstrap failure is
+    # otherwise invisible. pre-bootstrap-run with no bootstrap-exit-* = hung; bootstrap-exit-N!=0 =
+    # the actual failure, tail masked (postgres creds / 32+hex tokens / signing keys) before ship.
+    /usr/local/bin/inngest-boot-phone-home.sh pre-bootstrap-run
+    set +e
     env "INNGEST_CLI_VERSION=$INNGEST_CLI_VERSION" "INNGEST_CLI_SHA256=$INNGEST_CLI_SHA256" \
         "INNGEST_CLI_ARCH=${inngest_cli_arch}" "SDK_URL=${sdk_url}" \
         "DOPPLER_PROJECT=soleur-inngest" \
         "VECTOR_CLI_VERSION=$VECTOR_CLI_VERSION" "VECTOR_CLI_SHA256=${vector_sha256}" "VECTOR_CLI_ARCH=${inngest_cli_arch}" \
-      bash "$EXTRACT_DIR/inngest-bootstrap.sh"
+      bash "$EXTRACT_DIR/inngest-bootstrap.sh" > /var/log/inngest-bootstrap.log 2>&1
+    boot_rc=$?
+    set -e
+    boot_tail="$(tail -n 20 /var/log/inngest-bootstrap.log 2>/dev/null | tr '\n' '|' || true)"
+    /usr/local/bin/inngest-boot-phone-home.sh bootstrap-exit-$boot_rc "$boot_tail"
+    if [ "$boot_rc" -ne 0 ]; then
+      echo "FATAL: inngest bootstrap failed rc=$boot_rc (see /var/log/inngest-bootstrap.log)" >&2
+      exit "$boot_rc"
+    fi
     trap - EXIT
+    /usr/local/bin/inngest-boot-phone-home.sh bootstrap-done

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -137,8 +137,21 @@ write_files:
     permissions: '0755'
 
 runcmd:
+  # --- #6178 boot observability: EARLIEST marker (Doppler-INDEPENDENT) -------------------
+  # First instruction. Stage the baked Better Stack token and phone home immediately. If this
+  # `runcmd-entered` marker arrives, cloud-init IS running my code AND the host can reach Better
+  # Stack — so the boot failure is whichever LATER marker is the last received. If not even this
+  # arrives, the host cannot POST at all (egress/TLS/clock skew) and the sink must be rethought.
+  # set +e: fail-open, never blocks boot.
+  - |
+    set +e
+    printf '%s' '${betterstack_logs_token}' > /run/inngest-bs-logs-token
+    chmod 600 /run/inngest-bs-logs-token 2>/dev/null
+    /usr/local/bin/inngest-boot-phone-home.sh runcmd-entered "host booted"
+
   # Apply SSH hardening immediately.
   - systemctl restart sshd
+  - /usr/local/bin/inngest-boot-phone-home.sh sshd-restarted
 
   # Mount the Redis AOF volume by id at /mnt/data (inngest-redis.conf `dir /mnt/data/redis`).
   # `nofail` so a volume hiccup does not wedge boot; the redis unit's RequiresMountsFor=
@@ -160,6 +173,9 @@ runcmd:
     tar xzf /tmp/doppler.tar.gz -C /usr/local/bin doppler
     chmod +x /usr/local/bin/doppler
     rm /tmp/doppler.tar.gz
+    command -v doppler >/dev/null 2>&1 \
+      && /usr/local/bin/inngest-boot-phone-home.sh doppler-cli-installed "$(doppler --version 2>/dev/null | head -1)" \
+      || /usr/local/bin/inngest-boot-phone-home.sh doppler-cli-install-FAILED
   # Restricted (0600 root) env file with the scoped Doppler service token — NOT world-
   # readable /etc/environment (mirrors registry's /etc/default/registry-doppler). The token
   # is scoped to the ISOLATED `soleur-inngest` project's `prd` root config (a SEPARATE
@@ -176,9 +192,13 @@ runcmd:
   - |
     set +e
     set -a; . /etc/default/inngest-doppler; set +a
-    doppler secrets get BETTERSTACK_LOGS_TOKEN --project soleur-inngest --config prd --plain > /run/inngest-bs-logs-token 2>/dev/null
-    chmod 600 /run/inngest-bs-logs-token 2>/dev/null
-    /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetched "arch=${inngest_cli_arch}"
+    t="$(doppler secrets get BETTERSTACK_LOGS_TOKEN --project soleur-inngest --config prd --plain 2>/dev/null)"
+    if [ -n "$t" ]; then
+      printf '%s' "$t" > /run/inngest-bs-logs-token; chmod 600 /run/inngest-bs-logs-token 2>/dev/null
+      /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetched "arch=${inngest_cli_arch}"
+    else
+      /usr/local/bin/inngest-boot-phone-home.sh doppler-token-fetch-FAILED "arch=${inngest_cli_arch}"
+    fi
 
   # --- Bake scoped GHCR read-creds (#6179/#6161) --------------------------------------
   # So the cold-boot soleur-inngest-bootstrap OCI pull + cosign-verify authenticates even

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -291,6 +291,17 @@ runcmd:
     fi
     set +e
 
+  # #6178: ensure the deploy user+group exist BEFORE the bootstrap chowns /var/lib/inngest to
+  # deploy:deploy. The cloud-config `users:` block above did NOT create deploy on this host (the
+  # Hetzner datasource did not apply user-data users_groups — verified: bootstrap still aborted
+  # `chown: invalid user: deploy:deploy` with the block present). Create it explicitly + idempotently
+  # in runcmd, which reliably runs before the bootstrap block below. -m → /home/deploy so the
+  # inngest-server unit's User=deploy resolves $HOME at runtime.
+  - groupadd -f docker
+  - groupadd -f deploy
+  - id -u deploy >/dev/null 2>&1 || useradd -m -g deploy -G docker -s /bin/bash deploy
+  - /usr/local/bin/inngest-boot-phone-home.sh deploy-user-ensured "$(id deploy 2>&1 | head -c 80)"
+
   # --- Extract + run inngest-bootstrap.sh from the baked OCI image ---------------------
   # Gated on the isolation sentinel above (fail-closed). Mirrors web cloud-init.yml:642-682:
   # docker create → docker cp the script + durable-Redis assets → read INNGEST_CLI_VERSION/

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -405,3 +405,11 @@ runcmd:
     lo="$(curl -s -o /dev/null -w '%%{http_code}' --max-time 5 http://127.0.0.1:8288/ 2>&1)"
     jl="$(journalctl -u inngest-server.service --no-pager -n 15 2>/dev/null | /usr/local/bin/inngest-redact.sh | tr '\n' '|' | head -c 400)"
     /usr/local/bin/inngest-boot-phone-home.sh post-boot-health "svc=[$svc] lo8288=$lo jl=[$jl]"
+    # #6178 diag: loopback :8288 is healthy but the web-host->10.0.1.40:8288 registry-probe 500s —
+    # capture the private-net readiness: self-curl the private IP, the configured 10.0.1.x NIC
+    # addr(s), what :8288 is bound to (0.0.0.0 vs 127.0.0.1), and the nftables allowlist chain.
+    priv="$(curl -s -o /dev/null -w '%%{http_code}' --max-time 5 http://10.0.1.40:8288/ 2>&1)"
+    nic="$(ip -o -4 addr show 2>/dev/null | grep -oE '10\.0\.1\.[0-9]+' | tr '\n' ',')"
+    bind="$(ss -tlnH 2>/dev/null | grep ':8288' | awk '{print $4}' | tr '\n' ',')"
+    nft="$(nft list chain inet soleur_inngest input 2>/dev/null | tr '\n' ' ' | head -c 160)"
+    /usr/local/bin/inngest-boot-phone-home.sh net-health "priv8288=$priv nic=[$nic] bind=[$bind] nft=[$nft]"

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -333,6 +333,7 @@ runcmd:
     # (pre-oci-pull with no oci-pull-rc-* = hung; oci-pull-rc-N!=0 = failed, with masked tail).
     /usr/local/bin/inngest-boot-phone-home.sh pre-oci-pull "$IREF"
     set +e
+    install -m 600 /dev/null /var/log/inngest-oci-pull.log   # 0600 pre-create so the redirect can't leave secrets world-readable
     docker pull "$IREF" > /var/log/inngest-oci-pull.log 2>&1
     pull_rc=$?
     set -e
@@ -380,6 +381,7 @@ runcmd:
     # the actual failure, tail masked (postgres creds / 32+hex tokens / signing keys) before ship.
     /usr/local/bin/inngest-boot-phone-home.sh pre-bootstrap-run
     set +e
+    install -m 600 /dev/null /var/log/inngest-bootstrap.log   # 0600 pre-create (secrets in the tail; see inngest-redact.sh)
     env "INNGEST_CLI_VERSION=$INNGEST_CLI_VERSION" "INNGEST_CLI_SHA256=$INNGEST_CLI_SHA256" \
         "INNGEST_CLI_ARCH=${inngest_cli_arch}" "SDK_URL=${sdk_url}" \
         "DOPPLER_PROJECT=soleur-inngest" \

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -653,12 +653,12 @@ runcmd:
   # fresh hosts.
   - |
     set -e
-    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.18
+    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.19
     # #6122/ADR-096: prefer zot (dark; host already logged in by soleur-host-bootstrap.sh);
     # all 3 refs follow IREF, zot miss ⇒ GHCR fallback; soleur-boot-emit records the registry.
     ZURL=$(timeout 15 doppler secrets get ZOT_REGISTRY_URL --plain --project soleur --config prd 2>/dev/null || true)
     if [ -n "$ZURL" ] && curl -s -o /dev/null --max-time 3 "http://$ZURL/v2/"; then
-      ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.18"
+      ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.19"
       if docker pull "$ZIREF"; then IREF="$ZIREF"; soleur-boot-emit inngest_zot info; else soleur-boot-emit inngest_ghcr_fallback warning; fi
     fi
     docker pull "$IREF"

--- a/apps/web-platform/infra/inngest-host.tf
+++ b/apps/web-platform/infra/inngest-host.tf
@@ -231,6 +231,14 @@ resource "hcloud_server" "inngest" {
     ghcr_read_token = var.ghcr_read_token
     # nftables allowlist for the :8288/:8289 control API — web hosts only (SEC-H2).
     web_host_private_ips = local.web_host_private_ips
+    # #6178 boot observability: bake the write-only Better Stack Logs ingest token so the
+    # earliest runcmd can emit a phone-home marker BEFORE Doppler/OCI/bootstrap — otherwise a
+    # failure in those early stages (or a Doppler-CLI-install failure) is a total blind spot on
+    # this deny-all-public host. Same low-sensitivity append-only token vector.service already
+    # uses; steady-state the marker token is re-fetched from Doppler (this baked copy is the
+    # pre-Doppler fallback). Retrievable via the host metadata API — acceptable for an ingest-only
+    # logs token on a deny-all host given the diagnosability it buys (weigh before widening use).
+    betterstack_logs_token = var.betterstack_logs_token
   }))
 
   # Deliberately NO lifecycle.ignore_changes=[user_data]. A FRESH host has no spurious diff,


### PR DESCRIPTION
## Summary
The dedicated Inngest host (`10.0.1.40`, #6178 ADR-100 cutover) had **never booted successfully** — it was silent (no logs, deny-all-public/no-SSH), so the failures were invisible. This PR adds a cloud-init **boot-observability probe** that made the boot self-report, and fixes the **5 pre-existing config gaps** it surfaced. The host now boots healthy: inngest/redis/vector active, `:8288` bound + reachable, on the dark backend, Vector shipping.

**Why merge now:** the running host at `10.0.1.40` was provisioned from this branch; `main` still has the broken cloud-init, so this reconciles that drift and prevents regression on any future re-provision from `main`.

## The 5 boot fixes (each was a hard failure)
1. **`HOME=/root`** in the cloud-init doppler env (#6122 class) — cloud-init runcmd has no `$HOME`; the Doppler CLI aborts `$HOME is not defined`, failing the isolation self-check + token fetch → inngest never bootstraps. The registry host had this fix; the inngest host never did.
2. **`deploy` user** — the bootstrap runs inngest as `User=deploy` and chowns `/var/lib/inngest` to `deploy:deploy` (SQLite CANTOPEN otherwise). Created via cloud-config `users:` **and** an explicit `runcmd` `useradd` (the cloud-config `users:` block did not apply on this Hetzner host).
3. **`/etc/default/inngest-server` token file** — the bootstrap sourced `/etc/default/webhook-deploy` (a web-host file that doesn't exist here). Pre-create the token file so the "preserve" branch fires.
4. **`/usr/bin/doppler` symlink** — the systemd units hardcode `ExecStart=/usr/bin/doppler` but cloud-init installs to `/usr/local/bin` → every unit died `status=203/EXEC`. Symlink resolves it.
5. (Prereq) dark `INNGEST_POSTGRES_URI` seeded out-of-band (soleur-dev session pooler) — not in this diff, but part of the same unblock.

## Boot-observability probe (the permanent value)
`/usr/local/bin/inngest-boot-phone-home.sh` ships `SOLEUR_INNGEST_BOOT_STAGE` markers straight to the Better Stack Logs HTTP ingest — **independent of the journald→Vector shipper** (which only starts late in the bootstrap, if at all). Markers bracket every stage (doppler token fetch, GHCR login, isolation check, OCI pull rc, bootstrap exit+tail, post-boot service health, private-net readiness). Value-based secret redaction (`inngest-redact.sh`) scrubs the shipped log tail since this POST bypasses Vector's PII scrub. Queryable via `betterstack-query.sh --grep SOLEUR_INNGEST_BOOT_STAGE`.

## ⚠️ Review item — baked logs token
To emit the **earliest** marker *before* Doppler/OCI (so a pre-Doppler failure isn't a blind spot on a deny-all host), the write-only `BETTERSTACK_LOGS_TOKEN` is baked into `user_data` (retrievable via the host metadata API). It's an append-only logs-ingest token on a deny-all-public host, and it's the same token `vector.service` already uses — but this is a conscious tradeoff worth a reviewer's sign-off. Easy to drop if you'd rather the earliest markers wait for Doppler.

## Tests
- `apps/web-platform/infra/inngest-host.test.sh` — 16 passed, 0 failed
- `terraform validate` — success; cloud-init YAML + all embedded shell scripts pass `bash -n`; templatefile `${}`/`%{}` escaping verified

## Scope / follow-up
Ref #6178 (does **not** close it). This lands Step 1 (healthy dark host). The Phase-2 flip sequence (op=execute → web-2 quiesce → flip-arm → app-repoint → op=rearm → op=verify) remains and is blocked by two separate issues (EMAXCONNSESSION scan-burst; web→dedicated registry-probe 500) tracked for a follow-up session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
