### PR TITLE
fix(inngest): converge #6178 probe-script delivery (webhook restart-race) + close verify false-green

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -391,8 +391,25 @@ jobs:
           # #4804). So success is NOT "the proxy responded" — it is "the state
           # JSON proves every file landed". Assert the full invariant:
           #   exit_code == 0 AND files_failed == 0 AND files_written == files_total
-          # files_total is derived from the JSON (never hardcoded to the FILE_MAP
-          # length) so the gate survives future FILE_MAP additions.
+          #                 AND files_total == EXPECTED (repo FILE_MAP length)
+          #
+          # #6178 false-green fix: the prior gate compared files_written vs the
+          # JSON's OWN files_total, which passes on a STALE status from an older,
+          # smaller FILE_MAP (a webhook restart-race left the host at 13/13 clean
+          # while the repo FILE_MAP was 15 — the gate went green while the 2
+          # cutover probe scripts were NEVER delivered). Derive the EXPECTED count
+          # from the repo's infra-config-apply.sh FILE_MAP at verify time: this
+          # still auto-tracks future FILE_MAP additions (not hardcoded) AND now
+          # catches UNDER-delivery (a host that landed fewer files than the repo
+          # expects). handler_bootstrap runs before this push and updates the host
+          # handler to the current FILE_MAP, so the count is aligned on a healthy
+          # apply.
+          EXPECTED_COUNT=$(sed -n '/^FILE_MAP=(/,/^)/p' infra-config-apply.sh | grep -cE '_B64\|')
+          if [[ ! "$EXPECTED_COUNT" =~ ^[0-9]+$ || "$EXPECTED_COUNT" -eq 0 ]]; then
+            echo "::error::Could not derive EXPECTED FILE_MAP count from infra-config-apply.sh (got '$EXPECTED_COUNT')."
+            exit 1
+          fi
+          echo "Expected delivered-file count (repo FILE_MAP): $EXPECTED_COUNT"
           EXIT_CODE=""
           FILES_FAILED=""
           FILES_WRITTEN=""
@@ -413,12 +430,13 @@ jobs:
               FILES_TOTAL=$(jq -r '.files_total' /tmp/infra-config-status-response.txt 2>/dev/null || echo "MISSING")
               if [[ "$EXIT_CODE" == "0" && "$FILES_FAILED" == "0" \
                     && "$FILES_TOTAL" != "MISSING" && "$FILES_TOTAL" != "null" \
-                    && "$FILES_WRITTEN" == "$FILES_TOTAL" ]]; then
-                echo "Infra-config apply succeeded (exit_code=0, files_written=${FILES_WRITTEN}/${FILES_TOTAL}, files_failed=0 on attempt $attempt)"
+                    && "$FILES_WRITTEN" == "$FILES_TOTAL" \
+                    && "$FILES_TOTAL" == "$EXPECTED_COUNT" ]]; then
+                echo "Infra-config apply succeeded (exit_code=0, files_written=${FILES_WRITTEN}/${FILES_TOTAL}, expected=${EXPECTED_COUNT}, files_failed=0 on attempt $attempt)"
                 cat /tmp/infra-config-status-response.txt
                 break
               fi
-              echo "Attempt $attempt: exit_code=$EXIT_CODE files_failed=$FILES_FAILED files_written=$FILES_WRITTEN files_total=$FILES_TOTAL (retrying in 5s...)"
+              echo "Attempt $attempt: exit_code=$EXIT_CODE files_failed=$FILES_FAILED files_written=$FILES_WRITTEN files_total=$FILES_TOTAL expected=$EXPECTED_COUNT (retrying in 5s...)"
             elif [[ "$HTTP_CODE" == "404" ]]; then
               echo "Attempt $attempt: infra-config-status endpoint not found (HTTP 404)"
             else
@@ -452,6 +470,11 @@ jobs:
             fi
             if [[ "$FILES_TOTAL" == "MISSING" || "$FILES_TOTAL" == "null" || "$FILES_WRITTEN" != "$FILES_TOTAL" ]]; then
               echo "::error::infra-config-apply landed-files mismatch: files_written=$FILES_WRITTEN files_total=$FILES_TOTAL (expected equal and non-null)."
+              cat /tmp/infra-config-status-response.txt >&2 2>/dev/null || true
+              exit 1
+            fi
+            if [[ "$FILES_TOTAL" != "$EXPECTED_COUNT" ]]; then
+              echo "::error::infra-config-apply UNDER-DELIVERED: host reported files_total=$FILES_TOTAL but the repo FILE_MAP expects $EXPECTED_COUNT (#6178 false-green fix — a stale/racing push left the host short of the current file set). This is NOT a pass."
               cat /tmp/infra-config-status-response.txt >&2 2>/dev/null || true
               exit 1
             fi

--- a/apps/web-platform/infra/push-infra-config.sh
+++ b/apps/web-platform/infra/push-infra-config.sh
@@ -18,13 +18,21 @@ set -euo pipefail
 # REDEPLOY NONCE (#6178, 2026-07-10). deploy_pipeline_fix.triggers_replace hashes
 # THIS file's content (server.tf), so bumping the nonce forces terraform to recreate
 # the terraform_data and re-run this push — re-delivering EVERY webhook-managed file.
-# Bumped because a prior push left the host with a hooks.json advertising the
-# inngest-registry-probe / inngest-doublefire-probe hooks while their scripts were
-# never installed (infra-config-status showed 13 files, both probes absent) — webhook
-# fork/exec'd a missing /usr/local/bin/inngest-registry-probe.sh and returned an empty
-# HTTP 500, fast-failing the cutover op=verify gate. The repo is lockstep; state/host
-# had drifted, so a content-hash bump is the sanctioned re-delivery lever.
-#   redeploy-nonce: 6178-deliver-missing-cutover-probes-1
+# THIS file is NOT hashed by infra_config_handler_bootstrap, so bumping the nonce
+# re-runs ONLY the push (deploy_pipeline_fix) and does NOT restart the webhook —
+# which is the whole point of nonce-2 below.
+#
+# nonce-1 (probes absent, 13-file host): recreated BOTH deploy_pipeline_fix AND
+# handler_bootstrap in one apply. handler_bootstrap `systemctl restart webhook`
+# (server.tf) completed ~10ms BEFORE deploy_pipeline_fix's push fired, so the push
+# RACED the webhook restart: it got HTTP 202 from the restarting webhook but the
+# async handler exec was disrupted — no files written, infra-config-status stayed
+# stale (13/13). The new 15-entry handler + fresh hooks.json DID land via
+# handler_bootstrap's SSH path, so the host is now primed for a clean push.
+# nonce-2 changes ONLY this file → recreates ONLY deploy_pipeline_fix → the push
+# runs against the now-stable webhook + current handler/hooks.json → delivers all
+# 15 files (incl. the two cutover probes) in a single non-racing push.
+#   redeploy-nonce: 6178-deliver-missing-cutover-probes-2
 for var in WEBHOOK_SECRET CF_ACCESS_ID CF_ACCESS_SECRET APP_DOMAIN_BASE INFRA_DIR HOOKS_JSON_B64; do
   if [[ -z "${!var:-}" ]]; then
     echo "ERROR: required env var $var is missing or empty" >&2


### PR DESCRIPTION
## Summary

Follow-up to #6311. Fixes the actual reason the two cutover probe scripts never reached the host, and closes the verify false-green that hid it. Touches two files: the push script and the apply/verify workflow.

## Root cause: webhook restart-race

#6311's apply recreated two terraform_data resources in one run — the HTTPS push and the SSH handler-bootstrap. The handler-bootstrap restarts the webhook as its last step; that restart completed at 17:34:50.72, and the push fired **10ms later** (17:34:50.73). The push **raced the restart** — it got HTTP 202 from the restarting webhook, but the async handler exec was disrupted, so no files were written and the host status stayed stale at **13/13** (July-5). The new 15-entry handler + fresh hooks config *did* land via the SSH path, so the host is primed; the push just needs a clean, non-racing re-run.

## Fix

- **`push-infra-config.sh`** — bump the redeploy nonce to `-2`. This file is hashed **only** by the push resource, **not** by the handler-bootstrap resource, so this apply recreates **only the push** (no webhook restart). The push runs against the now-stable webhook + current handler/config and delivers all 15 files (incl. both probes) in one shot.
- **`apply-deploy-pipeline-fix.yml`** — close the verify false-green. It compared `files_written` vs the status JSON's *own* `files_total`, which passes on a stale status from an older/smaller file set (exactly how 13/13 went green while 2 scripts were missing). Now derive `EXPECTED_COUNT` from the repo's handler file-map at verify time — still auto-tracks future additions, but now **catches under-delivery** — and fail loud unless `files_total == EXPECTED_COUNT`.

## Verification plan (post-merge)
Merge fires `apply-deploy-pipeline-fix` → the push re-runs against the stable webhook → host lands 15/15 → hardened verify passes. Then I trigger the registry-probe directly and expect `registry_empty` (function_count=0) instead of the empty-500.

Refs #6178. No flip sequence involved.