### PR TITLE
feat(grok): add project-level Grok Build config for Soleur plugin

### DIFF
--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -1,0 +1,57 @@
+# Project-level Grok configuration for the Soleur repository.
+#
+# This file ensures consistent behavior when using Grok Build inside this repo,
+# especially for loading the local development copy of the Soleur plugin.
+
+[plugins]
+# Load the in-repository Soleur plugin.
+# This is the Grok equivalent of `claude --plugin-dir ./plugins/soleur`.
+#
+# Two mechanisms are used for reliability:
+# 1. .grok/plugins/soleur  (symlink) — first-class project plugin location
+# 2. paths below            — additional plugin directory scan
+#
+# These ensure the *local* development copy (./plugins/soleur) wins over
+# any version installed into ~/.claude/plugins/ or ~/.grok/plugins/.
+paths = ["./plugins/soleur"]
+
+# Make sure the soleur plugin is active in this project.
+# (Global config may also list it; project settings are merged with high priority.)
+enabled = ["soleur"]
+
+# Claude Code compatibility (defaults are true, listed explicitly for clarity).
+# Grok will continue to load:
+# - Hooks, permissions, and MCP servers from .claude/settings*.json
+# - Skills and commands from .claude/skills/ and the installed Claude plugins
+# - Project rules from CLAUDE.md / CLAUDE.local.md
+[compat.claude]
+skills = true
+rules = true
+agents = true
+mcps = true
+hooks = true
+
+# Project permission policy.
+# The detailed allow/deny lists and many PreToolUse guard hooks live in
+# .claude/settings.json and .claude/settings.local.json (loaded via compat above).
+#
+# You can add native Grok permission rules here if desired. They merge with
+# the Claude sources. Example:
+#
+# [permission]
+# allow = ["Bash(safe-tool:*)"]
+# deny = ["Read(**/secrets/**)"]
+
+# Recommended default permission mode for this project (very hook-heavy).
+# PreToolUse hooks (the many gate scripts) will still run and can block actions.
+permission_mode = "always-approve"
+
+# Other project-specific tuning can be added here.
+# See the full reference: ~/.grok/docs/user-guide/05-configuration.md
+#
+# Common additions for a project like this:
+# [skills]
+# paths = ["./plugins/soleur/skills"]   # (usually not needed — the plugin paths above covers it)
+#
+# [session]
+# load_envrc = true

--- a/.grok/config.toml
+++ b/.grok/config.toml
@@ -2,6 +2,9 @@
 #
 # This file ensures consistent behavior when using Grok Build inside this repo,
 # especially for loading the local development copy of the Soleur plugin.
+#
+# Project config supports [plugins], [mcp_servers], and [permission] only.
+# See https://docs.x.ai/build/settings
 
 [plugins]
 # Load the in-repository Soleur plugin.
@@ -16,42 +19,14 @@
 paths = ["./plugins/soleur"]
 
 # Make sure the soleur plugin is active in this project.
-# (Global config may also list it; project settings are merged with high priority.)
 enabled = ["soleur"]
 
-# Claude Code compatibility (defaults are true, listed explicitly for clarity).
-# Grok will continue to load:
-# - Hooks, permissions, and MCP servers from .claude/settings*.json
-# - Skills and commands from .claude/skills/ and the installed Claude plugins
-# - Project rules from CLAUDE.md / CLAUDE.local.md
-[compat.claude]
-skills = true
-rules = true
-agents = true
-mcps = true
-hooks = true
-
-# Project permission policy.
-# The detailed allow/deny lists and many PreToolUse guard hooks live in
-# .claude/settings.json and .claude/settings.local.json (loaded via compat above).
+# Claude-compat hooks, permissions, MCP servers, and project rules load by
+# default from .claude/settings*.json, CLAUDE.md, and AGENTS.md — no project
+# [compat.*] stanza is required.
 #
-# You can add native Grok permission rules here if desired. They merge with
-# the Claude sources. Example:
+# Optional native Grok permission rules merge with Claude sources:
 #
 # [permission]
 # allow = ["Bash(safe-tool:*)"]
 # deny = ["Read(**/secrets/**)"]
-
-# Recommended default permission mode for this project (very hook-heavy).
-# PreToolUse hooks (the many gate scripts) will still run and can block actions.
-permission_mode = "always-approve"
-
-# Other project-specific tuning can be added here.
-# See the full reference: ~/.grok/docs/user-guide/05-configuration.md
-#
-# Common additions for a project like this:
-# [skills]
-# paths = ["./plugins/soleur/skills"]   # (usually not needed — the plugin paths above covers it)
-#
-# [session]
-# load_envrc = true

--- a/.grok/plugins/soleur
+++ b/.grok/plugins/soleur
@@ -1,0 +1,1 @@
+../../plugins/soleur

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,11 @@ With [Grok Build](https://docs.x.ai/build/overview), the same in-repo plugin loa
 
 ```bash
 grok inspect   # verify soleur plugin, skills, and MCP servers are discovered
+grok --trust   # first session only: trust project hooks (or run /hooks-trust in-session)
 grok           # start an interactive session
 ```
+
+Soleur is hook-heavy; without trust, PreToolUse guards from `.claude/settings.json` stay inactive.
 
 ## Contributor License Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ claude --plugin-dir ./plugins/soleur
 
 This loads the plugin directly without installation, so you can test changes immediately.
 
+With [Grok Build](https://docs.x.ai/build/overview), the same in-repo plugin loads automatically via the committed `.grok/config.toml` (project plugin path + Claude-compat hooks/MCP). From the repo root:
+
+```bash
+grok inspect   # verify soleur plugin, skills, and MCP servers are discovered
+grok           # start an interactive session
+```
+
 ## Contributor License Agreement
 
 Before your first pull request can be merged, you must sign the [Individual Contributor License Agreement](https://soleur.ai/pages/legal/individual-cla.html) (CLA). The CLA bot will prompt you automatically on your first PR.


### PR DESCRIPTION
## Summary

Adds committed Grok Build project configuration so contributors can run Soleur from this repo without `claude --plugin-dir`, mirroring the existing Claude dev workflow.

- `.grok/config.toml` — enables the in-repo `plugins/soleur` plugin via `paths` + `enabled`
- `.grok/plugins/soleur` — symlink to `../../plugins/soleur` (first-class project plugin location)
- `CONTRIBUTING.md` — Grok quickstart with `grok inspect`, first-run `grok --trust`, and interactive session

## Changelog

- Added project-level Grok Build config (`.grok/`) so the local Soleur plugin auto-loads in Grok sessions
- Documented Grok contributor onboarding in CONTRIBUTING.md

## Review

- Branch reviewed; addressed medium findings (trim unsupported project config keys, document hooks trust)

## Test plan

- [x] `grok inspect` from worktree root shows soleur plugin skills/agents/MCP discovery
- [x] Config limited to supported project sections per https://docs.x.ai/build/settings