### PR TITLE
feat(observability): ship webhook binary exec logs to Better Stack (#6178 diagnosis)

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -133,6 +133,14 @@ include_matches.SYSLOG_IDENTIFIER = [
   "inngest-wiped-volume-verify",
   "inngest-inventory",
   "git-lock-chardevice-sweep",
+  # #6178 webhook-exec diagnosis: the adnanh/webhook binary runs `-verbose`
+  # (webhook.service ExecStart) and logs each hook match + command execution + any
+  # fork/exec error to journald as SYSLOG_IDENTIFIER=webhook. Without this, a hook that
+  # returns its success code (e.g. /hooks/infra-config → 202) while its command
+  # SILENTLY fails to exec is undiagnosable off-box — exactly the state that stalled the
+  # cutover infra-config delivery (handler never ran, host stuck at 13/15). Shipping the
+  # webhook channel makes that exec failure self-report to Better Stack.
+  "webhook",
   # #6178 cutover (ADR-100): the no-SSH flip-state + guard channels. Without these the
   # `inngest-cutover-flip` marker never reaches Better Stack and the P0-2 operator gate is
   # dead (the flip oneshot has no synchronous webhook response — Better Stack is the ONLY

--- a/apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh
+++ b/apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh
@@ -73,12 +73,17 @@ assert_member() {
     fail "$label: job '$job' not found in $(basename "$file")"
     return
   fi
-  if printf '%s\n' "$block" | grep -qE '^[[:space:]]+group:[[:space:]]*web-1-swap[[:space:]]*$'; then
+  # #6178: use a here-string, NOT `printf "$block" | grep -q`. Under `set -o pipefail`
+  # a matching `grep -q` closes the pipe early → printf gets SIGPIPE (141) → the pipeline
+  # exits non-zero even on a MATCH → the `if` spuriously takes the else branch. The race
+  # only bites LARGE blocks (printf still writing when grep exits), so it flaked on the
+  # big pipeline-fix `apply` job in CI while passing locally. A here-string has no pipe.
+  if grep -qE '^[[:space:]]+group:[[:space:]]*web-1-swap[[:space:]]*$' <<<"$block"; then
     pass
   else
     fail "$label: job '$job' missing job-level concurrency.group: web-1-swap"
   fi
-  if printf '%s\n' "$block" | grep -qE '^[[:space:]]+cancel-in-progress:[[:space:]]*false[[:space:]]*$'; then
+  if grep -qE '^[[:space:]]+cancel-in-progress:[[:space:]]*false[[:space:]]*$' <<<"$block"; then
     pass
   else
     fail "$label: job '$job' missing cancel-in-progress: false"
@@ -132,7 +137,7 @@ fi
 routine_apply_block="$(job_block "$APPLY_INFRA_WF" "apply")"
 if [ -z "$routine_apply_block" ]; then
   fail "routine 'apply' job not found in apply-web-platform-infra.yml — negative assertion cannot run (extractor regressed or job renamed)"
-elif printf '%s\n' "$routine_apply_block" | grep -qE '^[[:space:]]+group:[[:space:]]*web-1-swap[[:space:]]*$'; then
+elif grep -qE '^[[:space:]]+group:[[:space:]]*web-1-swap[[:space:]]*$' <<<"$routine_apply_block"; then
   fail "routine 'apply' job in apply-web-platform-infra.yml is enrolled in web-1-swap (over-serialization trap)"
 else
   pass

--- a/apps/web-platform/test/infra/vector-pii-scrub.test.sh
+++ b/apps/web-platform/test/infra/vector-pii-scrub.test.sh
@@ -402,6 +402,15 @@ EXPECTED_TAGS=$(
     grep -hoP '^\s*(readonly\s+)?LOG_TAG="\K[^"]+' "$f"
   done | sort -u
 )
+# #6178: some legitimate SYSLOG_IDENTIFIER entries come from a systemd UNIT's binary
+# writing to stdout — NOT from a `logger -t` call in infra/*.sh — so they are not
+# derivable above. webhook.service runs `/usr/local/bin/webhook -verbose` with no
+# SyslogIdentifier override, so systemd tags its stdout SYSLOG_IDENTIFIER=webhook (the
+# binary basename). Fold these into EXPECTED so AC3 still enforces logger-tag lockstep
+# (a new/removed logger tag not mirrored here fails CI) without flagging the binary
+# channel. Keep this list to genuine unit-binary identifiers, not a drift-guard bypass.
+SYSTEMD_UNIT_IDENTIFIERS="webhook"
+EXPECTED_TAGS=$(printf '%s\n%s\n' "$EXPECTED_TAGS" "$SYSTEMD_UNIT_IDENTIFIERS" | grep -v '^$' | sort -u)
 # Array entries are quoted strings on their own lines inside the include_matches
 # block; pull the bare tag from each.
 ACTUAL_TAGS=$(echo "$HOST_SCRIPTS_BLOCK" | grep -oP '^\s*"\K[a-z0-9-]+(?="\s*,?\s*$)' | sort -u)


### PR DESCRIPTION
## Summary

Adds `SYSLOG_IDENTIFIER=webhook` to vector's `host_scripts_journald` allowlist so the adnanh/webhook binary's own logs reach Better Stack.

## Why

The cutover infra-config delivery is stalled: `/hooks/infra-config` returns its `202` success code but the handler command **silently fails to exec** — the host has been stuck at 13/15 files since July 5, no handler markers appear, and I've ruled out (via a complete, correct 15-field manual POST) payload size, missing fields, and terraform specifics. The webhook binary runs `-verbose` and logs each hook match + command execution + fork/exec error as identifier `webhook`, but that channel was never shipped, so the failure is invisible off-box.

Confirmed the `host_scripts_journald` source *does* ship from web hosts (live `ci-deploy` markers present), so this will capture the webhook channel.

## Rollout

`vector.toml` is baked into the `soleur-inngest-bootstrap` OCI image, so this needs a new tag (`vinngest-v1.1.20`) built + deployed to the web hosts, then the cloud-init pin bumped. Once shipping, I force an infra-config push and read the exec error.

Refs #6178.