### PR TITLE
docs(adr): propose ADR-110 harness semantic model-tier map

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-110-harness-semantic-model-tier-map.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-110-harness-semantic-model-tier-map.md
@@ -1,0 +1,56 @@
+# ADR-110: Harness semantic model-tier map (Claude Code + Grok Build)
+
+- **Status:** Proposed
+- **Date:** 2026-07-10
+- **Issue:** [#6316](https://github.com/jikig-ai/soleur/issues/6316)
+- **Relates to:** [ADR-053](ADR-053-per-call-model-tiering-for-workflow-subagent-spawns.md) (workflow pin semantics), [ADR-089](ADR-089-freeze-lock-shared-state-substrate.md) (cross-harness shared substrate), [ADR-083](ADR-083-scoped-strong-model-consult-at-decision-gates.md) (strong-tier consult), #6314 (Grok Build project config)
+
+## Context
+
+Soleur's interactive plugin runs under multiple agent harnesses. Claude Code is the primary target; Grok Build now loads the same in-repo plugin via `.grok/config.toml` (#6314). The Model Selection Policy (ADR-053) tiers cost at workflow spawn sites using **harness-native enum aliases** (`'sonnet'`, `'haiku'`, `'fable'`) and agent frontmatter pins (`model: haiku` on five research agents). Those aliases are Anthropic-specific — Grok sessions cannot resolve them, so mechanical workflow steps (classify, fetch, commit-message) either fail or fall back unpredictably.
+
+ADR-053 deliberately chose harness aliases over concrete IDs for workflow pins (zero repo maintenance on Anthropic model deprecation; silent retargeting risk accepted). That tradeoff is harness-local. A second harness requires a **semantic** tier layer that each vendor maps independently, without scattering `if (grok)` across 94 skills.
+
+**Surfaces that stay vendor-specific (not migrated):**
+
+- GitHub Actions `claude-code-action` `--model claude-*` pins (server automation; hard-fail loudly at retirement — ADR-053 surface table)
+- Web-platform Inngest cron literals and `MODEL_PRICING` (billing constants; #5106 registry consolidation track)
+- `model-launch-review` Anthropic release checklist (extend separately for Grok tier table freshness)
+
+## Decision
+
+1. **Introduce four semantic tiers** for plugin spawn sites: `cheap`, `standard`, `strong`, `inherit`. Names describe **cost/role**, not vendor SKUs (ADR-053 mechanical vs judgment split preserved).
+
+2. **One resolver module** at `plugins/soleur/lib/harness-model-map.ts` maps semantic tier → harness spawn value. Harness detection is centralized (env markers + config presence); skills and workflows call the resolver — never branch on vendor inline.
+
+3. **Workflow pins migrate** from `'sonnet'`/`'haiku'` to `'standard'`/`'cheap'` at the 12 ADR-053 allowlisted call sites. Resolution happens in the workflow `agent()` wrapper immediately before spawn (single choke point per workflow runtime).
+
+4. **Research agent frontmatter** migrates from `model: haiku` to `model: cheap` once the harness accepts semantic tiers in Task/Agent spawn; until then, spawning skills pass `cheap` explicitly via the resolver at the call site.
+
+5. **`workflow-model-pins.test.ts` allowlist** tracks semantic tiers. A parity test asserts every tier resolves to a non-empty harness value for both `claude` and `grok` fixture maps.
+
+6. **Tier tables are versioned config**, not memory. Initial Grok mappings are placeholders validated against `grok inspect` / official xAI docs at implementation time. `model-launch-review` (or a sibling audit row) gains a Grok tier-table freshness check on each xAI model release.
+
+### Initial tier map (illustrative — implementation PR validates against live docs)
+
+| Semantic | ADR-053 role | Claude Code | Grok Build |
+|---|---|---|---|
+| `cheap` | Mechanical fan-out | `haiku` | fast/cheap Grok model (TBD at implementation) |
+| `standard` | Classify, parse, cluster | `sonnet` | `grok-build` or successor (TBD) |
+| `strong` | ADR-083 scoped consult only | `fable` (fallback `opus`) | reasoning-tier model (TBD) |
+| `inherit` | Judgment, operator agency | session model | session model |
+
+## Consequences
+
+- **Positive:** Grok and Claude operators get the same Soleur workflows; ADR-053 cost tiering semantics survive harness switches; one file to update per vendor model generation bump (tier table, not 12 call sites).
+- **Negative / accepted:** Loses ADR-053's "zero repo maintenance" property for Anthropic-only alias retargeting — tier tables must be updated when vendors rename tiers (mitigated by audit skill). Resolver adds a small indirection layer workflows must import.
+- **Migration:** Two PRs — (1) ADR + spec + resolver scaffold, (2) workflow/agent migration + tests. No big-bang: resolver can pass through unrecognized tiers during rollout.
+
+## Alternatives considered
+
+| Alternative | Rejected because |
+|---|---|
+| Keep Anthropic aliases; document Grok as best-effort | Mechanical steps break or cost-spike under Grok — violates harness-agnostic positioning (#6314 intent). |
+| Concrete model IDs in workflow pins | ADR-053 rejected this for Claude (hard-fail vs silent retargeting); doubles maintenance across harnesses. |
+| Per-harness workflow copies | 12× duplication; drift guaranteed (opposite of ADR-089 substrate pattern). |
+| Session-relative tiers | ADR-053 rejected — non-deterministic cost contract; runtime lacks relative tier API. |

--- a/knowledge-base/engineering/architecture/decisions/ADR-110-harness-semantic-model-tier-map.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-110-harness-semantic-model-tier-map.md
@@ -19,7 +19,7 @@ ADR-053 deliberately chose harness aliases over concrete IDs for workflow pins (
 
 ## Decision
 
-1. **Introduce four semantic tiers** for plugin spawn sites: `cheap`, `standard`, `strong`, `inherit`. Names describe **cost/role**, not vendor SKUs (ADR-053 mechanical vs judgment split preserved).
+1. **Introduce five semantic tiers** for plugin spawn sites: `cheap`, `standard`, `strong`, `advisor`, `inherit`. Names describe **cost/role**, not vendor SKUs (ADR-053 mechanical vs judgment split preserved). **`advisor` is not a general upgrade tier** — it maps to Fable only at the two ADR-083 gates (`plan` Step 4.5, `ship` Phase 5.5). **`strong` maps to Opus** for judgment-heavy never-downgrade paths (review/security/legal/C-suite agents, `agent-native-audit` scoring upgrade precedent) — distinct from the token-frugal scoped consult.
 
 2. **One resolver module** at `plugins/soleur/lib/harness-model-map.ts` maps semantic tier → harness spawn value. Harness detection is centralized (env markers + config presence); skills and workflows call the resolver — never branch on vendor inline.
 
@@ -33,12 +33,15 @@ ADR-053 deliberately chose harness aliases over concrete IDs for workflow pins (
 
 ### Initial tier map (illustrative — implementation PR validates against live docs)
 
-| Semantic | ADR-053 role | Claude Code | Grok Build |
+| Semantic | ADR-053 / policy role | Claude Code | Grok Build |
 |---|---|---|---|
-| `cheap` | Mechanical fan-out | `haiku` | fast/cheap Grok model (TBD at implementation) |
-| `standard` | Classify, parse, cluster | `sonnet` | `grok-build` or successor (TBD) |
-| `strong` | ADR-083 scoped consult only | `fable` (fallback `opus`) | reasoning-tier model (TBD) |
-| `inherit` | Judgment, operator agency | session model | session model |
+| `cheap` | Mechanical fan-out (workflow pins) | `haiku` | fast/cheap Grok model (TBD) |
+| `standard` | Classify, parse, cluster (workflow pins) | `sonnet` | `grok-build` or successor (TBD) |
+| `strong` | Never-downgrade judgment (review/security/legal/C-suite agents; `agent-native-audit` scoring upgrade) | `opus` | top reasoning model (TBD) |
+| `advisor` | ADR-083 scoped consult **only** — `plan` Step 4.5 + `ship` Phase 5.5; curated payload, not transcript | `fable` (fallback `opus`) | advisor-tier model (TBD; fallback to `strong` map) |
+| `inherit` | Judgment steps + operator session agency | session model | session model |
+
+Workflow pins (`workflow-model-pins.test.ts`) migrate only `cheap` / `standard` — never `strong`, `advisor`, or `inherit` (existing invariant). `advisor` resolves through the resolver at the two SKILL.md gate spawns; `strong` applies where agents or crons explicitly upgrade to Opus-class judgment.
 
 ## Consequences
 

--- a/knowledge-base/project/specs/feat-harness-model-map/spec.md
+++ b/knowledge-base/project/specs/feat-harness-model-map/spec.md
@@ -14,7 +14,9 @@ tags:
 
 ## Goal
 
-Make Soleur's workflow model pins and research-agent overrides work under **both** Claude Code and Grok Build by resolving semantic tiers (`cheap`, `standard`, `strong`, `inherit`) through a single plugin module.
+Make Soleur's workflow model pins and research-agent overrides work under **both** Claude Code and Grok Build by resolving semantic tiers (`cheap`, `standard`, `strong`, `advisor`, `inherit`) through a single plugin module.
+
+**Tier semantics (corrected):** `strong` → Opus-class judgment (never-downgrade agents, scoring upgrades). `advisor` → Fable-class scoped consult **only** at the two ADR-083 gates (`plan` Step 4.5, `ship` Phase 5.5), with Opus fallback — Fable is not a general-purpose tier.
 
 ## Non-goals
 
@@ -25,7 +27,7 @@ Make Soleur's workflow model pins and research-agent overrides work under **both
 ## User stories
 
 1. **As a Grok contributor**, when I run `/review` or `/drain-labeled-backlog`, mechanical subagent steps use an appropriate cheap Grok model, not a Claude alias that the harness ignores.
-2. **As a Claude contributor**, existing cost tiering behavior is unchanged — `cheap` resolves to `haiku`, `standard` to `sonnet`.
+2. **As a Claude contributor**, existing cost tiering behavior is unchanged — `cheap` → `haiku`, `standard` → `sonnet`, `strong` → `opus`, `advisor` → `fable` (Opus fallback at the two gates only).
 3. **As a maintainer**, when xAI or Anthropic ships a new model generation, I update one tier table row per semantic tier, not 12 workflow files.
 
 ## Implementation plan
@@ -46,7 +48,8 @@ Make Soleur's workflow model pins and research-agent overrides work under **both
 | Pin migration | 8 workflow files, 12 call sites | Per `workflow-model-pins.test.ts` allowlist |
 | Allowlist test update | `workflow-model-pins.test.ts` | Semantic tier names + parity test |
 | Research agents | 5 `engineering/research/*` agents | `haiku` → `cheap` when spawn API supports it |
-| AGENTS.md | Model Selection Policy section | Document semantic tiers; deprecate vendor alias prose |
+| AGENTS.md | Model Selection Policy section | Document semantic tiers; clarify `strong`=Opus vs `advisor`=Fable (ADR-083 only) |
+| plan/ship SKILL.md gates | Step 4.5 / Phase 5.5 spawns | Use `advisor` tier via resolver (not raw `fable`) |
 
 ### PR 3 — Audit extension (optional follow-up)
 
@@ -57,10 +60,12 @@ Make Soleur's workflow model pins and research-agent overrides work under **both
 
 ```typescript
 type Harness = "claude" | "grok" | "unknown";
-type SemanticTier = "cheap" | "standard" | "strong" | "inherit";
+type SemanticTier = "cheap" | "standard" | "strong" | "advisor" | "inherit";
 
 function detectHarness(env: NodeJS.ProcessEnv): Harness;
 function resolveModelTier(tier: SemanticTier, harness: Harness): string;
+/** `resolveAdvisorTier` — fable primary, strong (opus) fallback per ADR-083 */
+function resolveAdvisorTier(harness: Harness): string;
 ```
 
 Detection order (implementation PR validates):
@@ -75,7 +80,8 @@ Detection order (implementation PR validates):
 |---|---|---|
 | cheap | `haiku` | non-empty Grok fast model |
 | standard | `sonnet` | non-empty Grok build model |
-| strong | `fable` | non-empty Grok reasoning model |
+| strong | `opus` | non-empty Grok top reasoning model |
+| advisor | `fable` (fallback `opus`) | advisor model (fallback: `strong` map) |
 | inherit | `inherit` | `inherit` |
 
 ## Risks

--- a/knowledge-base/project/specs/feat-harness-model-map/spec.md
+++ b/knowledge-base/project/specs/feat-harness-model-map/spec.md
@@ -1,0 +1,84 @@
+---
+title: Harness semantic model-tier map
+status: draft
+closes: "#6316"
+adr: ADR-110
+domain: engineering
+tags:
+  - harness
+  - grok
+  - model-tiering
+---
+
+# Spec: Harness semantic model-tier map
+
+## Goal
+
+Make Soleur's workflow model pins and research-agent overrides work under **both** Claude Code and Grok Build by resolving semantic tiers (`cheap`, `standard`, `strong`, `inherit`) through a single plugin module.
+
+## Non-goals
+
+- Migrating `claude-code-action` CI workflows to Grok
+- Changing web-platform Inngest cron model literals or `MODEL_PRICING`
+- Auto-detecting operator billing plan or API key vendor
+
+## User stories
+
+1. **As a Grok contributor**, when I run `/review` or `/drain-labeled-backlog`, mechanical subagent steps use an appropriate cheap Grok model, not a Claude alias that the harness ignores.
+2. **As a Claude contributor**, existing cost tiering behavior is unchanged — `cheap` resolves to `haiku`, `standard` to `sonnet`.
+3. **As a maintainer**, when xAI or Anthropic ships a new model generation, I update one tier table row per semantic tier, not 12 workflow files.
+
+## Implementation plan
+
+### PR 1 — Planning (this PR)
+
+- ADR-110 (Proposed)
+- This spec
+- Issue #6316
+
+### PR 2 — Resolver + migration
+
+| Task | File(s) | Notes |
+|---|---|---|
+| Resolver module | `plugins/soleur/lib/harness-model-map.ts` | `detectHarness()`, `resolveModelTier(tier)` |
+| Unit tests | `plugins/soleur/test/harness-model-map.test.ts` | Fixture maps for `claude` + `grok`; unknown tier throws |
+| Workflow wrapper | each `*.workflow.js` `agent()` helper | Resolve semantic tier before `opts.model` reaches harness |
+| Pin migration | 8 workflow files, 12 call sites | Per `workflow-model-pins.test.ts` allowlist |
+| Allowlist test update | `workflow-model-pins.test.ts` | Semantic tier names + parity test |
+| Research agents | 5 `engineering/research/*` agents | `haiku` → `cheap` when spawn API supports it |
+| AGENTS.md | Model Selection Policy section | Document semantic tiers; deprecate vendor alias prose |
+
+### PR 3 — Audit extension (optional follow-up)
+
+- `model-launch-review/scripts/audit-models.sh` — add Grok tier-table staleness row
+- Or new `harness-model-audit` skill subcommand
+
+## Harness detection (resolver contract)
+
+```typescript
+type Harness = "claude" | "grok" | "unknown";
+type SemanticTier = "cheap" | "standard" | "strong" | "inherit";
+
+function detectHarness(env: NodeJS.ProcessEnv): Harness;
+function resolveModelTier(tier: SemanticTier, harness: Harness): string;
+```
+
+Detection order (implementation PR validates):
+
+1. `env.CLAUDECODE` set → `claude`
+2. `env.GROK_SESSION` or Grok-specific marker (confirm against Grok docs at implementation) → `grok`
+3. `unknown` → pass `inherit` through; log warning for non-inherit tiers
+
+## Test matrix
+
+| Tier | Claude fixture | Grok fixture |
+|---|---|---|
+| cheap | `haiku` | non-empty Grok fast model |
+| standard | `sonnet` | non-empty Grok build model |
+| strong | `fable` | non-empty Grok reasoning model |
+| inherit | `inherit` | `inherit` |
+
+## Risks
+
+- Grok may not support the same spawn `model:` enum shape as Claude Code — resolver may need per-harness output types (alias vs concrete ID).
+- Tier table drift if xAI renames models — mitigated by audit checklist row.


### PR DESCRIPTION
## Summary

Planning PR for cross-harness model tier resolution (Claude Code + Grok Build).

Closes #6316 (planning slice — implementation follows in a separate PR).

## Artifacts

- **ADR-110** — semantic tiers (`cheap` / `standard` / `strong` / `inherit`), single resolver module, migration scope, out-of-scope surfaces (CI crons, billing)
- **spec** — `knowledge-base/project/specs/feat-harness-model-map/spec.md` with 3-PR stack and test matrix

## Changelog

- Proposed ADR-110 and implementation spec for harness-agnostic model tiering

## Test plan

- [x] Docs-only; `bash scripts/check-adr-ordinals.sh` passes locally