### PR TITLE
fix(security): revoke residual anon/authenticated EXECUTE on service-role-only SECURITY DEFINER RPCs

### DIFF
--- a/apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.down.sql
+++ b/apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.down.sql
@@ -1,0 +1,36 @@
+-- =====================================================================
+-- 128_revoke_definer_rpc_residual_grants.down.sql
+-- =====================================================================
+--
+-- Restores the pre-128 (residual, CREATE-time-default) EXECUTE grants to
+-- `anon` + `authenticated` on the five functions migration 128 revoked.
+-- Provided ONLY for migration-rollback machinery, mirroring
+-- 069_jti_deny_grant_restore.down.sql and the 093 down convention.
+--
+-- IMPORTANT CAVEAT (knowingly-broken): applying this down migration
+-- KNOWINGLY re-opens the exact #6306 vulnerability migration 128 closed —
+-- it re-grants EXECUTE on these SECURITY DEFINER functions to anon and
+-- authenticated, restoring:
+--   * cross-tenant enumeration of (conversation_id, user_id) pairs via
+--     find_stuck_active_conversations (GDPR Art. 5(1)(f) confidentiality
+--     break), and
+--   * the write-IDOR on the concurrency-slot RPCs (one user can free /
+--     steal / heartbeat another user's slot).
+-- Do NOT run this in production. It exists purely as rollback machinery /
+-- for a controlled regression test; the up-migration is the canonical
+-- path forward.
+-- =====================================================================
+
+grant execute on function public.find_stuck_active_conversations(integer) to anon, authenticated;
+grant execute on function public.acquire_conversation_slot(uuid, uuid, integer, uuid) to anon, authenticated;
+grant execute on function public.release_conversation_slot(uuid, uuid) to anon, authenticated;
+grant execute on function public.touch_conversation_slot(uuid, uuid) to anon, authenticated;
+grant execute on function public.release_slot_on_archive() to anon, authenticated;
+
+-- Note: we do NOT restore migration 037's original COMMENT ON FUNCTION text.
+-- The COMMENT set by the up-migration is the canonical post-128 state and is
+-- replaced by the next migration that re-comments the function (or stays in
+-- place if none lands). We also intentionally do NOT re-grant PUBLIC — the
+-- pre-128 live state had PUBLIC already revoked (by the original 037/029/036/093
+-- `revoke … from public`), so restoring it would over-widen beyond the state
+-- this migration is rolling back.

--- a/apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.sql
+++ b/apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.sql
@@ -1,0 +1,83 @@
+-- Migration 128: REVOKE residual anon/authenticated EXECUTE on five
+-- service-role-only SECURITY DEFINER functions — close the cross-tenant
+-- disclosure / write-IDOR surface reported in #6306.
+--
+-- Root cause: Supabase's default privileges grant EXECUTE on every new
+-- `public` function to `anon`, `authenticated`, `service_role` at CREATE
+-- time. Migrations 029/036/037/093 intended service-role-only access but
+-- ran only `revoke all on function … from public`, which removes the
+-- PUBLIC grant while leaving the *explicit* anon/authenticated grants
+-- intact. Live proacl on find_stuck_active_conversations:
+--   {postgres=X/postgres,anon=X/postgres,authenticated=X/postgres,service_role=X/postgres}
+--
+-- Because these functions are SECURITY DEFINER, their definer rights bypass
+-- base-table RLS. So any authenticated (or anonymous) PostgREST caller could:
+--   * find_stuck_active_conversations(integer) — enumerate EVERY tenant's
+--     stuck-active (conversation_id, user_id) pairs (cross-tenant read;
+--     GDPR Art. 5(1)(f) confidentiality break).
+--   * acquire/release/touch_conversation_slot(…) — mutate ANOTHER user's
+--     concurrency-slot ledger, locking a free-tier user (cap=1) out of
+--     starting any conversation (write IDOR / denial-of-service).
+--   * release_slot_on_archive() — a trigger function; PostgREST never
+--     exposes trigger-returning functions as RPC endpoints, so its practical
+--     disclosure risk is nil. Included for shape-uniformity only.
+--
+-- Fix: forward-only grant-change migration restoring the stated
+-- service-role-only intent. This is a mechanical application of the
+-- canonical repo pattern:
+--   * 027_mtd_cost_aggregate.sql:67-69  (REVOKE … FROM PUBLIC; authenticated; anon)
+--   * 116_worktree_write_lease.sql:203-205 (revoke all … from public, anon, authenticated)
+--   * 069_jti_deny_grant_restore.sql (the pure grant-change migration +
+--     verify-sentinel + down-migration triad this file copies verbatim).
+-- 125_list_conversations_enriched.sql:172-179 records the same DEFINER
+-- grant-hygiene rule; 037 is the one precedent that got it wrong.
+--
+-- No function BODY is edited (grants only), so the existing
+-- `set search_path = public, pg_temp` pins are untouched
+-- (cq-pg-security-definer-search-path-pin-pg-temp — no regression surface).
+--
+-- Durability: `CREATE OR REPLACE` preserves a function's ACL, but
+-- `DROP FUNCTION` + `CREATE` does NOT (it re-applies Supabase's default
+-- grants — which is exactly how the 4-arg acquire_conversation_slot got
+-- re-granted at 093:42,50). The load-bearing durability guard is therefore
+-- verify/128 running on EVERY deploy, not ACL-preservation — it must never
+-- be removed from web-platform-release.yml. The sentinel covers only these
+-- 5 signatures; a broad-class guard (ALTER DEFAULT PRIVILEGES / migration
+-- lint) is deferred to a tracked #6306 follow-up and #6256.
+--
+-- References:
+-- - Issue: #6306
+-- - Plan: knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
+-- - Precedent triad: migrations/069_jti_deny_grant_restore.sql (+ .down + verify/069)
+-- - Sibling audit: migrations 029 (release/touch), 036 (trigger), 037 (finder),
+--   093 (4-arg acquire); exemplars 027, 116, 125.
+
+-- (1) find_stuck_active_conversations(integer) — cross-tenant read (primary).
+revoke execute on function public.find_stuck_active_conversations(integer) from anon, authenticated;
+revoke execute on function public.find_stuck_active_conversations(integer) from public;
+
+-- (2) acquire_conversation_slot — 4-arg overload from 093:124 (the 3-arg form
+--     was dropped at 093:42; do NOT reference it). Write IDOR (slot theft).
+revoke execute on function public.acquire_conversation_slot(uuid, uuid, integer, uuid) from anon, authenticated;
+revoke execute on function public.acquire_conversation_slot(uuid, uuid, integer, uuid) from public;
+
+-- (3) release_conversation_slot(uuid, uuid) — write IDOR (slot free).
+revoke execute on function public.release_conversation_slot(uuid, uuid) from anon, authenticated;
+revoke execute on function public.release_conversation_slot(uuid, uuid) from public;
+
+-- (4) touch_conversation_slot(uuid, uuid) — write IDOR (heartbeat).
+revoke execute on function public.touch_conversation_slot(uuid, uuid) from anon, authenticated;
+revoke execute on function public.touch_conversation_slot(uuid, uuid) from public;
+
+-- (5) release_slot_on_archive() — trigger fn, defense-in-depth (not RPC-exposable).
+revoke execute on function public.release_slot_on_archive() from anon, authenticated;
+revoke execute on function public.release_slot_on_archive() from public;
+
+comment on function public.find_stuck_active_conversations(integer) is
+  'Service-role-only stuck-active conversation finder. SECURITY DEFINER '
+  'bypasses conversations RLS, so it must be callable ONLY by the '
+  'application-layer reaper via the service-role client '
+  '(server/agent-runner.ts). EXECUTE for anon/authenticated was a '
+  'residual CREATE-time default grant that migration 037 failed to revoke '
+  '(037 revoked from PUBLIC only); it enabled cross-tenant enumeration of '
+  '(conversation_id, user_id) pairs. Revoked in migration 128. Ref #6306.';

--- a/apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.sql
+++ b/apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.sql
@@ -30,7 +30,8 @@
 --   * 069_jti_deny_grant_restore.sql (the pure grant-change migration +
 --     verify-sentinel + down-migration triad this file copies verbatim).
 -- 125_list_conversations_enriched.sql:172-179 records the same DEFINER
--- grant-hygiene rule; 037 is the one precedent that got it wrong.
+-- grant-hygiene rule; 037 (the finder) plus 029/036/093 (the slot RPCs) are
+-- the precedents that got it wrong — each ran revoke-from-public-only.
 --
 -- No function BODY is edited (grants only), so the existing
 -- `set search_path = public, pg_temp` pins are untouched

--- a/apps/web-platform/supabase/verify/128_definer_rpc_residual_grants_revoked.sql
+++ b/apps/web-platform/supabase/verify/128_definer_rpc_residual_grants_revoked.sql
@@ -1,0 +1,87 @@
+-- Verify 128_revoke_definer_rpc_residual_grants.sql (#6306).
+--
+-- Contract: every row returns `check_name` + `bad`. Any `bad > 0` row fails
+-- CI verify-migrations (run-verify.sh parses tab-separated (check_name TEXT,
+-- bad INT) rows under ON_ERROR_STOP=1).
+--
+-- Sentinels confirm post-apply state from migration 128:
+--   * anon / authenticated / PUBLIC do NOT have EXECUTE on any of the five
+--     service-role-only SECURITY DEFINER functions (the deny state that
+--     closes the #6306 cross-tenant read + write-IDOR surface).
+--   * service_role STILL has EXECUTE on the four non-trigger functions
+--     (load-bearing: the reaper + slot flows call them via the service-role
+--     client — a lost grant breaks legitimate traffic). NOT asserted for the
+--     trigger function release_slot_on_archive(), which needs no grant.
+--
+-- Signature exactness is load-bearing (data-integrity P1): PUBLIC is the
+-- lowercase literal 'public'; acquire_conversation_slot is the 4-arg overload
+-- (uuid, uuid, integer, uuid) from 093:124 — a wrong signature raises
+-- `function … does not exist` and, under ON_ERROR_STOP=1, hard-fails the
+-- release pipeline (false red) rather than silently no-op'ing.
+
+-- (1) find_stuck_active_conversations(integer)
+SELECT 'find_stuck_active_conversations_anon_revoked' AS check_name,
+       CASE WHEN has_function_privilege('anon', 'public.find_stuck_active_conversations(integer)', 'EXECUTE') THEN 1 ELSE 0 END::int AS bad
+UNION ALL
+SELECT 'find_stuck_active_conversations_authenticated_revoked',
+       CASE WHEN has_function_privilege('authenticated', 'public.find_stuck_active_conversations(integer)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'find_stuck_active_conversations_public_revoked',
+       CASE WHEN has_function_privilege('public', 'public.find_stuck_active_conversations(integer)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'find_stuck_active_conversations_service_role_grant_present',
+       CASE WHEN has_function_privilege('service_role', 'public.find_stuck_active_conversations(integer)', 'EXECUTE') THEN 0 ELSE 1 END::int
+UNION ALL
+
+-- (2) acquire_conversation_slot(uuid, uuid, integer, uuid) — 4-arg overload
+SELECT 'acquire_conversation_slot_anon_revoked',
+       CASE WHEN has_function_privilege('anon', 'public.acquire_conversation_slot(uuid, uuid, integer, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'acquire_conversation_slot_authenticated_revoked',
+       CASE WHEN has_function_privilege('authenticated', 'public.acquire_conversation_slot(uuid, uuid, integer, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'acquire_conversation_slot_public_revoked',
+       CASE WHEN has_function_privilege('public', 'public.acquire_conversation_slot(uuid, uuid, integer, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'acquire_conversation_slot_service_role_grant_present',
+       CASE WHEN has_function_privilege('service_role', 'public.acquire_conversation_slot(uuid, uuid, integer, uuid)', 'EXECUTE') THEN 0 ELSE 1 END::int
+UNION ALL
+
+-- (3) release_conversation_slot(uuid, uuid)
+SELECT 'release_conversation_slot_anon_revoked',
+       CASE WHEN has_function_privilege('anon', 'public.release_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'release_conversation_slot_authenticated_revoked',
+       CASE WHEN has_function_privilege('authenticated', 'public.release_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'release_conversation_slot_public_revoked',
+       CASE WHEN has_function_privilege('public', 'public.release_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'release_conversation_slot_service_role_grant_present',
+       CASE WHEN has_function_privilege('service_role', 'public.release_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 0 ELSE 1 END::int
+UNION ALL
+
+-- (4) touch_conversation_slot(uuid, uuid)
+SELECT 'touch_conversation_slot_anon_revoked',
+       CASE WHEN has_function_privilege('anon', 'public.touch_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'touch_conversation_slot_authenticated_revoked',
+       CASE WHEN has_function_privilege('authenticated', 'public.touch_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'touch_conversation_slot_public_revoked',
+       CASE WHEN has_function_privilege('public', 'public.touch_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'touch_conversation_slot_service_role_grant_present',
+       CASE WHEN has_function_privilege('service_role', 'public.touch_conversation_slot(uuid, uuid)', 'EXECUTE') THEN 0 ELSE 1 END::int
+UNION ALL
+
+-- (5) release_slot_on_archive() — trigger fn. Deny checks only; NO service_role
+--     positive check (a trigger function needs no EXECUTE grant to fire).
+SELECT 'release_slot_on_archive_anon_revoked',
+       CASE WHEN has_function_privilege('anon', 'public.release_slot_on_archive()', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'release_slot_on_archive_authenticated_revoked',
+       CASE WHEN has_function_privilege('authenticated', 'public.release_slot_on_archive()', 'EXECUTE') THEN 1 ELSE 0 END::int
+UNION ALL
+SELECT 'release_slot_on_archive_public_revoked',
+       CASE WHEN has_function_privilege('public', 'public.release_slot_on_archive()', 'EXECUTE') THEN 1 ELSE 0 END::int;

--- a/apps/web-platform/test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts
+++ b/apps/web-platform/test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts
@@ -124,9 +124,15 @@ describe("verify 128_definer_rpc_residual_grants_revoked", () => {
 
   for (const { fn, args, serviceRolePositive } of TARGETS) {
     for (const role of ["anon", "authenticated", "public"] as const) {
-      it(`AC4: ${role} deny check for ${fn}(${args})`, () => {
+      it(`AC4: ${role} deny check (bound check_name + polarity) for ${fn}(${args})`, () => {
+        // Bind the check_name literal → probe → CASE polarity in ONE regex.
+        // Asserting only that the has_function_privilege probe EXISTS is
+        // vacuous: an inverted sentinel (`THEN 0 ELSE 1` — which would assert
+        // the role SHOULD have EXECUTE, a self-defeating deny check) or a row
+        // whose check_name is mislabeled would both stay green. A deny check
+        // MUST be `... THEN 1 ELSE 0` (bad=1 when the role still has EXECUTE).
         const re = new RegExp(
-          `has_function_privilege\\(\\s*'${role}'\\s*,\\s*'${sigPattern(fn, args)}'\\s*,\\s*'EXECUTE'\\s*\\)`,
+          `'${fn}_${role}_revoked'[^\\n]*,\\s*CASE\\s+WHEN\\s+has_function_privilege\\(\\s*'${role}'\\s*,\\s*'${sigPattern(fn, args)}'\\s*,\\s*'EXECUTE'\\s*\\)\\s+THEN\\s+1\\s+ELSE\\s+0`,
           "i",
         );
         expect(verifyExec).toMatch(re);
@@ -134,9 +140,13 @@ describe("verify 128_definer_rpc_residual_grants_revoked", () => {
     }
 
     if (serviceRolePositive) {
-      it(`AC4: service_role grant-present check for ${fn}(${args})`, () => {
+      it(`AC4: service_role grant-present check (bound check_name + polarity) for ${fn}(${args})`, () => {
+        // Present check MUST be `... THEN 0 ELSE 1` (bad=1 when service_role
+        // LACKS EXECUTE) — the load-bearing guard that an accidental
+        // service_role revoke breaks the reaper/slot flows. Inverting it to a
+        // deny-shaped `THEN 1 ELSE 0` would flag the correct grant as bad.
         const re = new RegExp(
-          `has_function_privilege\\(\\s*'service_role'\\s*,\\s*'${sigPattern(fn, args)}'\\s*,\\s*'EXECUTE'\\s*\\)`,
+          `'${fn}_service_role_grant_present'[^\\n]*,\\s*CASE\\s+WHEN\\s+has_function_privilege\\(\\s*'service_role'\\s*,\\s*'${sigPattern(fn, args)}'\\s*,\\s*'EXECUTE'\\s*\\)\\s+THEN\\s+0\\s+ELSE\\s+1`,
           "i",
         );
         expect(verifyExec).toMatch(re);

--- a/apps/web-platform/test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts
+++ b/apps/web-platform/test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Migration-shape test for 128_revoke_definer_rpc_residual_grants.sql (#6306).
+//
+// File-parse test, not a live-DB test. It pins the SQL contract that closes
+// the cross-tenant disclosure / write-IDOR surface: five service-role-only
+// SECURITY DEFINER functions still carried the CREATE-time default EXECUTE
+// grants to `anon` + `authenticated` (migrations 029/036/037/093 ran only
+// `revoke … from public`, which does NOT remove the explicit anon/authenticated
+// grants). The runtime deny state is proven by the deploy-time verify sentinel
+// (verify/128_*.sql, run by verify-migrations); this test guards the migration
+// *content* in CI without needing a live stack.
+//
+// Plan: 2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md.
+
+const MIGRATIONS_DIR = path.join(__dirname, "../../supabase/migrations");
+const VERIFY_DIR = path.join(__dirname, "../../supabase/verify");
+
+const UP_PATH = path.join(MIGRATIONS_DIR, "128_revoke_definer_rpc_residual_grants.sql");
+const DOWN_PATH = path.join(MIGRATIONS_DIR, "128_revoke_definer_rpc_residual_grants.down.sql");
+const VERIFY_PATH = path.join(VERIFY_DIR, "128_definer_rpc_residual_grants_revoked.sql");
+
+// The five audited functions. `serviceRolePositive` is false only for the
+// trigger function (release_slot_on_archive) — PostgREST never exposes it and
+// it needs no service_role grant, so verify/128 must NOT assert one for it
+// (plan Sharp Edge). `acquire_conversation_slot` MUST be the 4-arg overload
+// from 093:124 — the 3-arg form was dropped at 093:42 (data-integrity P1).
+const TARGETS = [
+  { fn: "find_stuck_active_conversations", args: "integer", serviceRolePositive: true },
+  { fn: "acquire_conversation_slot", args: "uuid, uuid, integer, uuid", serviceRolePositive: true },
+  { fn: "release_conversation_slot", args: "uuid, uuid", serviceRolePositive: true },
+  { fn: "touch_conversation_slot", args: "uuid, uuid", serviceRolePositive: true },
+  { fn: "release_slot_on_archive", args: "", serviceRolePositive: false },
+] as const;
+
+// Escape a raw SQL signature fragment (parens, commas, dots) for use inside a
+// RegExp source. Whitespace in the arg list is normalised to `\s*` so
+// `(uuid, uuid)` and `(uuid,uuid)` both match.
+function sigPattern(fn: string, args: string): string {
+  const escFn = fn.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escArgs = args
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\s*,\s*/g, "\\s*,\\s*")
+    .replace(/\s+/g, "\\s*");
+  return `public\\.${escFn}\\s*\\(\\s*${escArgs}\\s*\\)`;
+}
+
+describe("migration 128_revoke_definer_rpc_residual_grants", () => {
+  const up = readFileSync(UP_PATH, "utf8");
+  // Strip line-comments before pattern checks so header prose can mention the
+  // same tokens without tripping the regex (mirrors 036 pattern).
+  const upExec = up.replace(/--[^\n]*/g, "");
+
+  for (const { fn, args } of TARGETS) {
+    it(`AC1: revokes EXECUTE from anon, authenticated on ${fn}(${args})`, () => {
+      const re = new RegExp(
+        `revoke\\s+execute\\s+on\\s+function\\s+${sigPattern(fn, args)}\\s+from\\s+anon\\s*,\\s*authenticated`,
+        "i",
+      );
+      expect(upExec).toMatch(re);
+    });
+
+    it(`AC2: revokes EXECUTE from public (defense-in-depth) on ${fn}(${args})`, () => {
+      const re = new RegExp(
+        `revoke\\s+execute\\s+on\\s+function\\s+${sigPattern(fn, args)}\\s+from\\s+public`,
+        "i",
+      );
+      expect(upExec).toMatch(re);
+    });
+  }
+
+  it("AC9: documents service-role-only intent for find_stuck_active_conversations via COMMENT ON FUNCTION + Ref #6306", () => {
+    const re = new RegExp(
+      `comment\\s+on\\s+function\\s+${sigPattern("find_stuck_active_conversations", "integer")}\\s+is`,
+      "i",
+    );
+    expect(upExec).toMatch(re);
+    // The #6306 reference lives in the (unstripped) source so the intent is
+    // traceable from the migration itself.
+    expect(up).toMatch(/#6306/);
+  });
+
+  it("pins the 4-arg acquire_conversation_slot overload, never the dropped 3-arg form", () => {
+    // The 3-arg (uuid, uuid, integer) signature was dropped at 093:42; revoking
+    // against it would raise `function does not exist` under ON_ERROR_STOP=1.
+    expect(upExec).not.toMatch(
+      /revoke\s+execute\s+on\s+function\s+public\.acquire_conversation_slot\s*\(\s*uuid\s*,\s*uuid\s*,\s*integer\s*\)/i,
+    );
+  });
+});
+
+describe("migration 128 down", () => {
+  const down = readFileSync(DOWN_PATH, "utf8");
+  const downExec = down.replace(/--[^\n]*/g, "");
+
+  it("AC3: restores the pre-fix anon/authenticated grants (rollback machinery)", () => {
+    for (const { fn, args } of TARGETS) {
+      const re = new RegExp(
+        `grant\\s+execute\\s+on\\s+function\\s+${sigPattern(fn, args)}\\s+to\\s+anon\\s*,\\s*authenticated`,
+        "i",
+      );
+      expect(downExec, `down must re-grant ${fn}(${args})`).toMatch(re);
+    }
+  });
+
+  it("AC3: carries a 093.down-style prod caveat that it knowingly re-opens the #6306 IDOR", () => {
+    expect(down).toMatch(/#6306/);
+    expect(down).toMatch(/do NOT run (this )?in production|rollback[- ]machinery only/i);
+  });
+});
+
+describe("verify 128_definer_rpc_residual_grants_revoked", () => {
+  const verify = readFileSync(VERIFY_PATH, "utf8");
+  const verifyExec = verify.replace(/--[^\n]*/g, "");
+
+  it("AC5: conforms to the (check_name, bad) two-column contract", () => {
+    // run-verify.sh parses tab-separated (check_name TEXT, bad INT) rows.
+    expect(verifyExec).toMatch(/as\s+check_name/i);
+    // Every check coerces `bad` to ::int (069 convention).
+    expect(verifyExec).toMatch(/::int/i);
+  });
+
+  for (const { fn, args, serviceRolePositive } of TARGETS) {
+    for (const role of ["anon", "authenticated", "public"] as const) {
+      it(`AC4: ${role} deny check for ${fn}(${args})`, () => {
+        const re = new RegExp(
+          `has_function_privilege\\(\\s*'${role}'\\s*,\\s*'${sigPattern(fn, args)}'\\s*,\\s*'EXECUTE'\\s*\\)`,
+          "i",
+        );
+        expect(verifyExec).toMatch(re);
+      });
+    }
+
+    if (serviceRolePositive) {
+      it(`AC4: service_role grant-present check for ${fn}(${args})`, () => {
+        const re = new RegExp(
+          `has_function_privilege\\(\\s*'service_role'\\s*,\\s*'${sigPattern(fn, args)}'\\s*,\\s*'EXECUTE'\\s*\\)`,
+          "i",
+        );
+        expect(verifyExec).toMatch(re);
+      });
+    } else {
+      it(`does NOT assert a service_role grant on the trigger fn ${fn}()`, () => {
+        const re = new RegExp(
+          `has_function_privilege\\(\\s*'service_role'\\s*,\\s*'${sigPattern(fn, args)}'`,
+          "i",
+        );
+        expect(verifyExec).not.toMatch(re);
+      });
+    }
+  }
+});

--- a/knowledge-base/project/learnings/test-failures/2026-07-11-verify-sentinel-content-test-must-pin-case-polarity.md
+++ b/knowledge-base/project/learnings/test-failures/2026-07-11-verify-sentinel-content-test-must-pin-case-polarity.md
@@ -1,0 +1,62 @@
+---
+title: "verify/*.sql content tests must pin CASE polarity + bind check_name, not just probe existence"
+date: 2026-07-11
+category: test-failures
+module: apps/web-platform/test/supabase-migrations
+tags: [supabase, verify-sentinel, migration-content-test, vacuous-green, has_function_privilege, grant-hygiene]
+issue: 6306
+pr: 6318
+---
+
+# verify/*.sql content tests must pin CASE polarity, not just probe existence
+
+## Problem
+
+A migration-content test (`readFileSync` the `verify/NNN_*.sql` sentinel + regex-assert,
+036-style) for a grant-revoke migration (#6306, migration 128) asserted only that each
+`has_function_privilege('<role>', '<sig>', 'EXECUTE')` **probe exists** in the verify file.
+It did NOT assert the surrounding `CASE WHEN … THEN 1 ELSE 0` (deny) vs `THEN 0 ELSE 1`
+(present) polarity that carries the actual semantics.
+
+`test-design-reviewer` flagged the vacuous-green mutation: inverting a deny check to
+`THEN 0 ELSE 1` (which makes the sentinel assert that `anon` *should* have EXECUTE — a
+self-defeating guard) leaves the probe substring unchanged, so every content-test assertion
+still passes. The suite claimed to guard "the deny state" but guarded only probe presence.
+The verify sentinel is the load-bearing runtime guard (`run-verify.sh` at deploy time); a
+silently-inverted sentinel would ship green and never catch a real grant re-opening.
+
+## Solution
+
+Bind three things in ONE regex per check — the `check_name` literal → the probe → the CASE
+polarity:
+
+```js
+// deny check MUST be THEN 1 ELSE 0 (bad=1 when the role still has EXECUTE)
+const re = new RegExp(
+  `'${fn}_${role}_revoked'[^\\n]*,\\s*CASE\\s+WHEN\\s+has_function_privilege\\(` +
+  `\\s*'${role}'\\s*,\\s*'${sig}'\\s*,\\s*'EXECUTE'\\s*\\)\\s+THEN\\s+1\\s+ELSE\\s+0`,
+  "i",
+);
+// service_role-present check MUST be THEN 0 ELSE 1 (bad=1 when service_role LACKS EXECUTE)
+```
+
+Binding the `check_name` literal also catches a mislabeled row (a check_name typo that would
+otherwise pass because the probe alone matched).
+
+**Prove non-vacuity by mutation:** flip one deny check's polarity in the verify file
+(`THEN 1 ELSE 0` → `THEN 0 ELSE 1`), run the suite (must go RED on exactly that check), then
+restore and confirm GREEN + a clean `git diff --stat` on the verify file. Do the restore with
+a targeted inverse edit, not `git checkout --` (the file may carry sibling uncommitted edits).
+
+## Key Insight
+
+This is the SQL-sentinel instance of a known defect class: **a source-grep test that asserts
+the dangerous half of an expression EXISTS but not the branch/polarity/direction that makes
+it correct is vacuous.** For any `verify/*.sql` (check_name, bad) sentinel, the load-bearing
+part is the `CASE … THEN <bad-value>` direction, not the `has_function_privilege(...)` call —
+pin the direction. Same reflex as the `red-verification-must-distinguish-gated-from-ungated`
+family: mentally mutate the artifact and confirm the test flips RED for each mutation.
+
+## Tags
+category: test-failures
+module: apps/web-platform/test/supabase-migrations

--- a/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
@@ -11,6 +11,21 @@ date: 2026-07-11
 
 # 🐛 fix(security): revoke residual anon/authenticated EXECUTE on service-role-only SECURITY DEFINER RPCs (#6306)
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-11
+**Sections enhanced:** Risks & Mitigations (precedent diff), Observability command (ssh-token fix), sibling audit grounding
+**Review agents used:** data-integrity-guardian, security-sentinel (grant/RLS-focused; a full 40-agent fan-out is not warranted for a mechanical REVOKE migration)
+
+### Key Improvements
+1. Precedent-diff (Phase 4.4) grounded: the fix is a verbatim application of the `069_jti_deny_grant_restore` migration+verify+down shape and the `027`/`116` REVOKE-from-all-three exemplars — no novel pattern.
+2. Verify sentinel design pinned to the `verify/069` two-axis form: assert the deny state AND the load-bearing `service_role` positive (omitted for the trigger function).
+3. Stale-premise re-scope (rls-fuzz un-baseline) carried into Research Reconciliation + Phase 4 cross-ref, so the P1 fix does not block on the unmerged #6256 harness.
+
+### New Considerations Discovered
+- `release_slot_on_archive()` returns `trigger` → not PostgREST-RPC-exposable; included for shape-uniformity only, and its verify checks must NOT assert a `service_role` grant.
+- `CREATE OR REPLACE` does not reset privileges, so the fix is durable against future function-body edits — but only these 5 signatures are sentinel-covered (broad-class enforcement belongs to #6256).
+
 ## Overview
 
 `public.find_stuck_active_conversations(integer)` is a `SECURITY DEFINER` function whose EXECUTE
@@ -87,6 +102,21 @@ whose only grant statement is `revoke … on function … from public`:
 | `acquire/touch/release_worktree_lease(…)` ×3 | 116 | revoke public+anon+authenticated | SAFE (exemplar) |
 | `list_conversations_enriched(…)` | 125 | revoke public+anon, **GRANT authenticated** | SAFE (intentionally authenticated-callable — different case) |
 
+**Audit completeness (independently confirmed by both deepen reviewers):** enumerating every non-`.down`
+migration that revokes EXECUTE from `public` but never from `anon`/`authenticated` yields exactly these 5
+functions (migrations 029/036/037/093). The hygienic near-siblings on the same service-role path —
+`033_migrate_api_key_to_v2_rpc.sql:53-55`, `042_increment_conversation_cost_v2.sql:56`,
+`053_organizations_and_workspace_members.sql` (`is_workspace_member`, `handle_new_user`) — already
+`revoke … from public, anon, authenticated` and are correctly excluded. **Blind spot (out of scope, owned by
+the follow-up below / #6256):** this criterion cannot detect a service-role-only DEFINER function that manages
+**no grants at all** (retaining all four CREATE-time defaults incl. `public`) — a worse defect this net does
+not cover. This fix does not close the *class*, only these 5 instances.
+
+**RLS-in-caller-role trap does NOT apply (positive confirmation):** unlike the jti-deny 069 case, none of the
+5 functions is referenced inside any RLS `USING`/`WITH CHECK` clause (the only `user_concurrency_slots` policy
+is `auth.uid() = user_id`, `029:92-93`, no function call), so revoking `authenticated` cannot break policy
+evaluation. This is the exact failure mode that would make the revoke unsafe — and it is absent.
+
 **Safety of revoking `anon`/`authenticated`:** every FIX target is invoked only by server-side code
 through the **service-role** client — `server/concurrency.ts:1` (`createServiceClient`) for the slot RPCs
 and `server/agent-runner.ts:117-118` (`createServiceClient`) for the finder reaper. `release_slot_on_archive`
@@ -119,7 +149,10 @@ revoke execute on function public.<fn>(<args>) from public;
 ```
 Add a `COMMENT ON FUNCTION` on `find_stuck_active_conversations` documenting service-role-only intent + #6306.
 `128_*.down.sql` restores the pre-fix grants (`grant execute … to anon, authenticated`) purely for
-rollback machinery, mirroring `069_*.down.sql`.
+rollback machinery, mirroring `069_*.down.sql`. **It MUST carry a `093_acquire_slot_workspace_id.down.sql`-style
+prod caveat** ("KNOWINGLY re-opens the #6306 cross-tenant IDOR — do NOT run in production; rollback-machinery
+only"), because applying this down migration re-introduces the exact vulnerability being closed
+(security-sentinel P2-1).
 
 ### Phase 2 — Verify sentinel (`verify/128_definer_rpc_residual_grants_revoked.sql`)
 Follow the `(check_name TEXT, bad INT)` contract enforced by `scripts/run-verify.sh`. `UNION ALL`:
@@ -155,7 +188,7 @@ comment on #6256.
 ### Pre-merge (PR)
 - [ ] `AC1` Migration `128_*.sql` revokes EXECUTE from `anon` and `authenticated` for all 5 audited functions (grep: 5 × `from anon, authenticated`).
 - [ ] `AC2` Migration also revokes from `public` (defense-in-depth) for each target.
-- [ ] `AC3` `128_*.down.sql` exists and restores the pre-fix `anon`/`authenticated` grants (rollback-only).
+- [ ] `AC3` `128_*.down.sql` exists, restores the pre-fix `anon`/`authenticated` grants (rollback-only), AND carries a `093.down`-style prod caveat that it knowingly re-opens the #6306 IDOR (grep: down file contains a "do NOT run in production" / "rollback-machinery only" marker).
 - [ ] `AC4` `verify/128_*.sql` emits, for each of the 5 targets, an `anon` deny check + an `authenticated` deny check + a `public` deny check (`bad=1` when the role still has EXECUTE), and for the 4 non-trigger targets a `service_role` grant-present check (`bad=1` when service_role LACKS EXECUTE).
 - [ ] `AC5` `verify/128_*.sql` conforms to the `(check_name, bad)` two-column contract (`run-verify.sh` parses it; every row is `(TEXT, INT)`).
 - [ ] `AC6` `128-revoke-definer-rpc-residual-grants.test.ts` passes: `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`.
@@ -168,6 +201,7 @@ comment on #6256.
 - [ ] `PM1` `web-platform-release.yml#migrate` applies migration 128 on merge to main (path-filtered auto-apply — no operator SSH/CLI).
 - [ ] `PM2` `verify-migrations` job runs `verify/128_*.sql` post-apply; all `bad=0` (deny state confirmed against prod).
 - [ ] `PM3` `/ship` posts a cross-ref comment on #6256 recording the rls-fuzz un-baseline follow-up (Phase 4).
+- [ ] `PM4` `/ship` files a `type/security` follow-up issue for the repo-wide `ALTER DEFAULT PRIVILEGES` / migration-lint baseline (root-cause hardening deferred from this hotfix; see Alternatives).
 
 ## Observability
 
@@ -191,7 +225,7 @@ logs:
   where: GitHub Actions run logs for the verify-migrations job (::group:: per verify file)
   retention: GitHub Actions default (90 days)
 discoverability_test:
-  command: "doppler run -c prd -- bash apps/web-platform/scripts/run-verify.sh   # runs verify/128 against prod, exit 1 on any bad>0 — NO ssh"
+  command: "doppler run -c prd -- bash apps/web-platform/scripts/run-verify.sh   # runs verify/128 against prod; exit 1 on any bad>0 (no remote shell needed)"
   expected_output: "ok 128_definer_rpc_residual_grants_revoked/<check_name> (bad=0) for every check; Verify summary: N passed, 0 failed"
 ```
 
@@ -218,6 +252,18 @@ processing activity, data flow, or external transfer**. No Article 30 register e
 posture improves. No Critical gdpr-gate finding is expected; full-skill invocation is low-value for a
 defense-strengthening grant revoke.
 
+## Risks & Mitigations (precedent diff — Phase 4.4)
+
+This is a **pattern-bound** SQL-permissioning change; the repo has an established canonical form, so the pattern is NOT novel.
+
+| Concern | Precedent (grounded) | Mitigation in this plan |
+|---|---|---|
+| Correct REVOKE shape | `027_mtd_cost_aggregate.sql:67-69` (`FROM PUBLIC; FROM authenticated; FROM anon`); `116_worktree_write_lease.sql:203-205` (`from public, anon, authenticated`) | Migration 128 revokes `anon, authenticated` + defense-in-depth `public` for each target — matches both exemplars. |
+| Pure grant-change migration + verify + down | `069_jti_deny_grant_restore.sql` + `.down.sql` + `verify/069_*.sql` | 128 copies this exact triad shape (header prose → REVOKE block → COMMENT; down restores grants; verify asserts deny + service_role positive). |
+| Service-role grant must survive | `verify/069` check (3): `has_function_privilege('service_role', …) → bad=1 if false` | verify/128 replicates the positive check for the 4 non-trigger RPCs. |
+| Intentionally-authenticated DEFINER fn misclassified as vulnerable | `125_list_conversations_enriched.sql:172-179` header documents the inverse (GRANT authenticated on purpose) | 125 explicitly excluded from the FIX set (§sibling audit) — the audit distinguishes service-role-only intent from authenticated-callable. |
+| search_path pinning on any touched DEFINER fn | `cq-pg-security-definer-search-path-pin-pg-temp`; 037 body already pins `public, pg_temp` | No function BODY is edited (grants only), so existing `set search_path` pins are untouched — no regression surface. |
+
 ## Test Scenarios
 1. **Deny state (deploy-time):** after apply, `has_function_privilege('authenticated', 'public.find_stuck_active_conversations(integer)', 'EXECUTE')` → `false` (verify/128, bad=0).
 2. **Service-role preserved:** `has_function_privilege('service_role', …)` → `true` for the 4 non-trigger RPCs — the reaper + slot flows keep working.
@@ -227,9 +273,9 @@ defense-strengthening grant revoke.
 
 ## Sharp Edges
 - **Migration ordinal is provisional.** `128` may be claimed by a sibling PR in the one-shot pipeline; the migration runner rejects duplicate numbers. /work Phase 0 re-checks next-free against `origin/main` and renumbers migration + verify + down + test together if needed.
-- **`CREATE OR REPLACE` does not reset privileges** — a later migration that re-`CREATE OR REPLACE`s any of these 5 functions will NOT re-grant anon/authenticated (grants persist across replace), so the fix is durable; but a *new* function with the same defect would slip past — the verify sentinel only covers these 5. (Broader class enforcement is the province of #6256's fuzz harness.)
+- **`CREATE OR REPLACE` preserves the ACL, but `DROP FUNCTION` + `CREATE` does NOT** — the load-bearing durability guard is **verify/128 running on every deploy**, not ACL-preservation (security-sentinel P2-2). The codebase's established habit of DROP+CREATE for signature changes is exactly why the 4-arg `acquire_conversation_slot` is on the FIX list: `093:42,50` dropped the 3-arg and re-created the 4-arg, which re-applied Supabase's default `anon`/`authenticated` grants. Any future re-issue of these 5 functions via DROP+CREATE re-opens the grant — verify/128 catches it at the release gate, which is **why verify/128 must never be removed from `web-platform-release.yml`**. The sentinel covers only these 5 signatures; a *new* defective DEFINER function is invisible until the follow-up below (or #6256) lands.
 - **`release_slot_on_archive()` returns `trigger`** — PostgREST does not expose trigger-returning functions as RPC endpoints and a direct call errors on absent `TG_*` context, so its practical disclosure risk is nil; it is included purely for shape-uniformity. Do NOT assert a `service_role` grant on it in verify/128.
-- **`has_function_privilege` role-name literals:** PUBLIC is the lowercase literal `'public'` (per `verify/069` check (5)); use exact signatures incl. arg types (`(integer)`, `(uuid, uuid, integer, uuid)`) or the check silently no-ops on a signature mismatch.
+- **`has_function_privilege` signature exactness is load-bearing (data-integrity P1):** PUBLIC is the lowercase literal `'public'` (per `verify/069` check (5)). Use the **exact current** signature incl. arg types. A wrong signature does NOT silently no-op — Postgres raises `ERROR: function "public.fn(...)" does not exist`, and `run-verify.sh` runs under `ON_ERROR_STOP=1` (`run-verify.sh:55-57`), so a stale signature **hard-fails the release pipeline on every run** (false red). Highest-risk copy error: `acquire_conversation_slot` MUST be the **4-arg** `(uuid, uuid, integer, uuid)` from `093:50` — the 3-arg `(uuid, uuid, integer)` at `029:205` was dropped at `093:42`. Do NOT copy the 3-arg form.
 - **Do not `Closes #6256`** — the rls-fuzz harness is a separate open issue; only cross-reference it.
 - A plan whose `## User-Brand Impact` section is empty or placeholder fails `deepen-plan` Phase 4.6 — this one is filled with the concrete artifact/vector/threshold.
 
@@ -237,6 +283,6 @@ defense-strengthening grant revoke.
 | Approach | Verdict |
 |---|---|
 | Fix only `find_stuck_active_conversations` (issue's literal primary) | Rejected — the sibling slot RPCs share the identical defect and carry a *worse* (write IDOR) impact; a security fix that leaves known-identical siblings exposed is half a fix at `single-user incident` threshold. Issue AC explicitly mandates the sibling audit. |
-| `ALTER DEFAULT PRIVILEGES` to stop future default grants | Rejected — does not remediate the 5 *existing* grants (the live exposure); orthogonal hardening better owned by #6256 / a dedicated migration-lint. Out of scope. |
+| `ALTER DEFAULT PRIVILEGES` to stop future default grants | Deferred, NOT silently — does not remediate the 5 *existing* grants (the live exposure), so it cannot substitute for this fix. But both deepen reviewers (security-sentinel P2-3, data-integrity blind-spot) flag that the root cause — Supabase's default `ALTER DEFAULT PRIVILEGES` granting EXECUTE to anon/authenticated on every new `public` function — remains unguarded past these 5 names. **`/ship` files a tracked follow-up issue** (label `type/security`, milestone Phase 4) for a repo-wide baseline: either an `ALTER DEFAULT PRIVILEGES … REVOKE EXECUTE … FROM anon, authenticated` migration OR a migration-lint gate that fails CI on a `revoke-from-public`-only DEFINER function. This is a concrete tracked deferral, not a soft "province of #6256" handoff. |
 | Block on #6256 to un-baseline rpc-cases.ts | Rejected — #6256 is unmerged; a P1 cross-tenant disclosure must not wait on an unrelated harness. The verify/128 sentinel is the durable guard; #6256 gets a cross-ref note. |
 | TS integration test as the primary guard | Rejected — the `verify/*.sql` sentinel (deploy-time, runs against prod) is the canonical always-on guard for grant state, per the jti-deny precedent. The TS test guards migration *content* only. |

--- a/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
@@ -186,15 +186,15 @@ comment on #6256.
 ## Acceptance Criteria
 
 ### Pre-merge (PR)
-- [ ] `AC1` Migration `128_*.sql` revokes EXECUTE from `anon` and `authenticated` for all 5 audited functions (grep: 5 × `from anon, authenticated`).
-- [ ] `AC2` Migration also revokes from `public` (defense-in-depth) for each target.
-- [ ] `AC3` `128_*.down.sql` exists, restores the pre-fix `anon`/`authenticated` grants (rollback-only), AND carries a `093.down`-style prod caveat that it knowingly re-opens the #6306 IDOR (grep: down file contains a "do NOT run in production" / "rollback-machinery only" marker).
-- [ ] `AC4` `verify/128_*.sql` emits, for each of the 5 targets, an `anon` deny check + an `authenticated` deny check + a `public` deny check (`bad=1` when the role still has EXECUTE), and for the 4 non-trigger targets a `service_role` grant-present check (`bad=1` when service_role LACKS EXECUTE).
-- [ ] `AC5` `verify/128_*.sql` conforms to the `(check_name, bad)` two-column contract (`run-verify.sh` parses it; every row is `(TEXT, INT)`).
-- [ ] `AC6` `128-revoke-definer-rpc-residual-grants.test.ts` passes: `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`.
-- [ ] `AC7` Typecheck clean: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`.
-- [ ] `AC8` No FIX target is reachable from any authenticated/anon caller path in `server/` (grep confirms `concurrency.ts` + `agent-runner.ts` use `createServiceClient`; documented in §sibling audit).
-- [ ] `AC9` `find_stuck_active_conversations` carries a `COMMENT ON FUNCTION` documenting service-role-only intent + Ref #6306.
+- [x] `AC1` Migration `128_*.sql` revokes EXECUTE from `anon` and `authenticated` for all 5 audited functions (grep: 5 × `from anon, authenticated`).
+- [x] `AC2` Migration also revokes from `public` (defense-in-depth) for each target.
+- [x] `AC3` `128_*.down.sql` exists, restores the pre-fix `anon`/`authenticated` grants (rollback-only), AND carries a `093.down`-style prod caveat that it knowingly re-opens the #6306 IDOR (grep: down file contains a "do NOT run in production" / "rollback-machinery only" marker).
+- [x] `AC4` `verify/128_*.sql` emits, for each of the 5 targets, an `anon` deny check + an `authenticated` deny check + a `public` deny check (`bad=1` when the role still has EXECUTE), and for the 4 non-trigger targets a `service_role` grant-present check (`bad=1` when service_role LACKS EXECUTE).
+- [x] `AC5` `verify/128_*.sql` conforms to the `(check_name, bad)` two-column contract (`run-verify.sh` parses it; every row is `(TEXT, INT)`).
+- [x] `AC6` `128-revoke-definer-rpc-residual-grants.test.ts` passes: `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts` (35/35).
+- [x] `AC7` Typecheck clean: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` (rc=0).
+- [x] `AC8` No FIX target is reachable from any authenticated/anon caller path in `server/` (grep confirms `concurrency.ts` + `agent-runner.ts` use `createServiceClient`; documented in §sibling audit).
+- [x] `AC9` `find_stuck_active_conversations` carries a `COMMENT ON FUNCTION` documenting service-role-only intent + Ref #6306.
 - [ ] `AC10` PR body uses `Closes #6306` (this fix is complete at merge — the migration auto-applies via `web-platform-release.yml#migrate`, and verify runs in the same pipeline; unlike ops-remediation, there is no post-merge operator write, so `Closes` is correct).
 
 ### Post-merge (pipeline-automated, no operator action)

--- a/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
@@ -1,0 +1,242 @@
+---
+title: "fix(security): revoke residual anon/authenticated EXECUTE on service-role-only SECURITY DEFINER RPCs"
+issue: 6306
+type: fix
+classification: security
+lane: single-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+date: 2026-07-11
+---
+
+# 🐛 fix(security): revoke residual anon/authenticated EXECUTE on service-role-only SECURITY DEFINER RPCs (#6306)
+
+## Overview
+
+`public.find_stuck_active_conversations(integer)` is a `SECURITY DEFINER` function whose EXECUTE
+privilege is still held by `anon` **and** `authenticated`. Because its definer rights bypass base-table
+RLS on `conversations`, any authenticated (or anonymous) caller can enumerate **every tenant's**
+stuck-active `(conversation_id, user_id)` pairs — a cross-tenant information disclosure / IDOR primitive.
+
+**Root cause (confirmed against `037_stuck_active_finder_rpc.sql:63-64`):** Supabase's default privileges
+grant EXECUTE on every new `public` function to `anon`, `authenticated`, `service_role` at `CREATE` time.
+Migration 037 ran only `revoke all on function … from public` — which removes the PUBLIC grant but leaves
+the **explicit** `anon`/`authenticated` grants intact. Live `proacl`:
+`{postgres=X/postgres,anon=X/postgres,authenticated=X/postgres,service_role=X/postgres}`.
+
+**Fix:** a forward-only grant-change migration (`128_*`) that revokes EXECUTE from `anon`, `authenticated`
+(and defensively `PUBLIC`) on the affected functions, restoring 037's stated service-role-only intent —
+plus a `verify/128_*.sql` sentinel asserting the deny state, mirroring the jti-deny sentinel class
+(`verify/069_jti_deny_grant_restore.sql`). The migration also folds in the **sibling sweep** the issue
+mandates: the identical `revoke-from-public`-only defect exists on the concurrency-slot RPCs.
+
+**Precedent is well-established in the repo** — this migration is a mechanical application of the pattern
+already used correctly by:
+- `027_mtd_cost_aggregate.sql:67-69` (`REVOKE … FROM PUBLIC; FROM authenticated; FROM anon`),
+- `116_worktree_write_lease.sql:203-205` (`revoke all … from public, anon, authenticated`),
+- `069_jti_deny_grant_restore.sql` (the pure grant-change migration + verify-sentinel + down-migration shape this plan copies verbatim).
+
+Migration `125_list_conversations_enriched.sql:172-179` documents the same DEFINER grant-hygiene rule in
+its header ("GRANT hygiene inverts the DEFINER precedents (027/037 …)") — 037 is the one precedent that
+got it wrong; this fix closes that gap.
+
+## Research Reconciliation — Spec vs. Codebase
+
+Two premises in the issue body are **stale** and reshape the plan (Phase 0.6 premise validation):
+
+| Issue claim | Codebase reality | Plan response |
+|---|---|---|
+| "Un-baseline the `test.fails` entry in `test/rls-fuzz/rpc-cases.ts`" (AC4) | `test/rls-fuzz/` and `rpc-cases.ts` **do not exist**. The RLS/authz-fuzz harness (#6256) is **OPEN / not merged**. `find … -iname '*rpc-cases*'` returns nothing. | The un-baseline AC cannot be satisfied — there is no file to edit. **Re-scoped** to a cross-reference note: this fix's durable regression guard is the `verify/128` sentinel (always-on, deploy-time). When #6256's harness lands, its `rpc-cases.ts` entry for these RPCs MUST be a **normal denial assertion**, never a baselined `test.fails`. Recorded in `decision-challenges.md`; `/ship` posts a cross-ref comment to #6256. **Do NOT block this P1 fix on the unmerged harness.** |
+| "Discovered by the harness (#6256, **ADR-103**)" | **ADR-103** is `ADR-103-dedicated-host-boot-heartbeats-require-guarded-reprovision-path.md` — unrelated to the fuzz harness. | Citation mis-numbered; harmless to the fix. Noted so the plan does not inherit a false ADR reference. No new ADR is authored (see §Architecture Decision). |
+
+Everything else in the issue held: migration `037_stuck_active_finder_rpc.sql` exists with exactly the
+described `revoke-from-public`-only shape; the `verify/` sentinel directory exists with the jti-deny
+sentinels the issue cites as the pattern class; `#6256` and the harness are real (just not yet merged).
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** an authenticated attacker enumerates other tenants'
+`(conversation_id, user_id)` pairs, and — via the sibling slot RPCs — can `release`/`acquire`/`touch`
+**another user's** concurrency slot, locking a free-tier user (cap=1) out of starting any conversation.
+
+**If this leaks, the user's data/workflow is exposed via:** direct PostgREST RPC
+(`POST /rest/v1/rpc/find_stuck_active_conversations`) callable by any `anon`/`authenticated` JWT, bypassing
+`conversations` RLS through SECURITY DEFINER rights — a cross-tenant confidentiality break (GDPR Art. 5(1)(f))
+and a denial-of-service IDOR on the slot RPCs.
+
+**Brand-survival threshold:** single-user incident.
+
+> CPO sign-off required at plan time before `/work` begins. `user-impact-reviewer` will be invoked at
+> review-time (handled by the review skill's conditional-agent block). In this headless one-shot run the
+> CPO framing is carried in this section; review-time enforcement remains the diff-shaped gate.
+
+## Affected functions — sibling audit
+
+Enumerated by scanning every `security definer` function in `apps/web-platform/supabase/migrations/*.sql`
+whose only grant statement is `revoke … on function … from public`:
+
+| Function (signature) | Migration | Current grant shape | Verdict |
+|---|---|---|---|
+| `find_stuck_active_conversations(integer)` | 037 | revoke public only → +service_role | **FIX (primary)** — cross-tenant read |
+| `acquire_conversation_slot(uuid, uuid, integer, uuid)` | 093 (current 4-arg) | revoke public only → +service_role | **FIX** — write IDOR (slot theft) |
+| `release_conversation_slot(uuid, uuid)` | 029 | revoke public only → +service_role | **FIX** — write IDOR (slot free) |
+| `touch_conversation_slot(uuid, uuid)` | 029 | revoke public only → +service_role | **FIX** — write IDOR (heartbeat) |
+| `release_slot_on_archive()` | 036 | revoke public only, `returns trigger` | **FIX (defense-in-depth)** — trigger fn, not RPC-exposable by PostgREST; low practical risk but same shape, revoke for uniformity |
+| `acquire_conversation_slot(uuid, uuid, integer)` (3-arg) | 029 | — | **N/A** — dropped by `093:42` (`DROP FUNCTION IF EXISTS`) |
+| `sum_user_mtd_cost(uuid, timestamptz)` | 027 | revoke public+authenticated+anon | SAFE (exemplar — the correct pattern) |
+| `acquire/touch/release_worktree_lease(…)` ×3 | 116 | revoke public+anon+authenticated | SAFE (exemplar) |
+| `list_conversations_enriched(…)` | 125 | revoke public+anon, **GRANT authenticated** | SAFE (intentionally authenticated-callable — different case) |
+
+**Safety of revoking `anon`/`authenticated`:** every FIX target is invoked only by server-side code
+through the **service-role** client — `server/concurrency.ts:1` (`createServiceClient`) for the slot RPCs
+and `server/agent-runner.ts:117-118` (`createServiceClient`) for the finder reaper. `release_slot_on_archive`
+runs as a trigger. No authenticated/anon caller path exists, so the revoke is behavior-preserving for
+legitimate callers and closes the attacker path.
+
+## Architecture Decision (ADR/C4)
+
+**No ADR / C4 change.** This restores the *already-decided* service-role-only intent of migration 037; it
+introduces no ownership/tenancy boundary move, no new substrate, no resolver/trust-boundary change. The
+grant-hygiene rule is already recorded in `027`/`069`/`125` migration headers and
+`cq-pg-security-definer-search-path-pin-pg-temp`. C4 completeness check: grant/privilege changes alter no
+C4 element — no new external actor, external system, container, or access relationship (the affected RPCs
+and their sole service-role caller are already modeled as internal server↔DB edges). "No C4 impact" is
+therefore supported, not asserted blindly.
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (re-verify at /work time)
+1. Confirm the next free migration ordinal against `origin/main` (`ls …/migrations/ | grep -oE '^[0-9]+' | sort -n | tail -1`). `128` is **provisional** — a sibling PR may claim it; the migration runner rejects duplicate numbers, so re-check and renumber the migration + verify + down + test in the same edit if `128` is taken.
+2. Re-confirm live `proacl` shape on the 5 targets is still `revoke-from-public`-only (guards against a sibling PR fixing one first).
+
+### Phase 1 — Migration + down (`128_revoke_definer_rpc_residual_grants.sql`)
+Model on `069_jti_deny_grant_restore.sql` verbatim (header prose → REVOKE block → `COMMENT ON FUNCTION`).
+For each of the 5 FIX targets emit:
+```sql
+revoke execute on function public.<fn>(<args>) from anon, authenticated;
+-- defense-in-depth (revoke-on-empty is a no-op):
+revoke execute on function public.<fn>(<args>) from public;
+```
+Add a `COMMENT ON FUNCTION` on `find_stuck_active_conversations` documenting service-role-only intent + #6306.
+`128_*.down.sql` restores the pre-fix grants (`grant execute … to anon, authenticated`) purely for
+rollback machinery, mirroring `069_*.down.sql`.
+
+### Phase 2 — Verify sentinel (`verify/128_definer_rpc_residual_grants_revoked.sql`)
+Follow the `(check_name TEXT, bad INT)` contract enforced by `scripts/run-verify.sh`. `UNION ALL`:
+- For each of the 5 targets: `has_function_privilege('anon', 'public.<fn>(<args>)', 'EXECUTE')` → `bad=1 if true`; same for `'authenticated'`; same for `'public'`.
+- For the 4 non-trigger targets: `has_function_privilege('service_role', …)` → `bad=1 if false` (load-bearing regression guard — the service-role grant MUST survive, mirroring `verify/069` check (3)).
+- Do NOT assert a service_role grant on `release_slot_on_archive()` (trigger fn needs none).
+
+### Phase 3 — Migration content test (`test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`)
+Mirror the existing `036-release-slot-on-archive.test.ts` convention: source-grep assertions that migration 128
+contains a `revoke execute … from anon, authenticated` line for each of the 5 functions, and that
+`verify/128_*.sql` asserts `has_function_privilege(...'anon'...)` and `...'authenticated'...` for each.
+(The runtime deny state is proven by the deploy-time verify sentinel; this test guards the migration
+*content* in CI without needing a live stack.)
+
+### Phase 4 — Cross-reference #6256 (no code)
+Record in `specs/feat-one-shot-6306-rpc-grant-revoke/decision-challenges.md` that when the #6256 fuzz
+harness lands, its `test/rls-fuzz/rpc-cases.ts` entry for `find_stuck_active_conversations` must be a plain
+denial assertion (not a baselined `test.fails`). `/ship` renders this into the PR body and posts a cross-ref
+comment on #6256.
+
+## Files to Create
+- `apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.sql`
+- `apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.down.sql`
+- `apps/web-platform/supabase/verify/128_definer_rpc_residual_grants_revoked.sql`
+- `apps/web-platform/test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`
+- `knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/decision-challenges.md` (Phase 4 note)
+
+## Files to Edit
+- None. (Issue AC4's `test/rls-fuzz/rpc-cases.ts` edit is re-scoped — the file does not exist; see Research Reconciliation.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `AC1` Migration `128_*.sql` revokes EXECUTE from `anon` and `authenticated` for all 5 audited functions (grep: 5 × `from anon, authenticated`).
+- [ ] `AC2` Migration also revokes from `public` (defense-in-depth) for each target.
+- [ ] `AC3` `128_*.down.sql` exists and restores the pre-fix `anon`/`authenticated` grants (rollback-only).
+- [ ] `AC4` `verify/128_*.sql` emits, for each of the 5 targets, an `anon` deny check + an `authenticated` deny check + a `public` deny check (`bad=1` when the role still has EXECUTE), and for the 4 non-trigger targets a `service_role` grant-present check (`bad=1` when service_role LACKS EXECUTE).
+- [ ] `AC5` `verify/128_*.sql` conforms to the `(check_name, bad)` two-column contract (`run-verify.sh` parses it; every row is `(TEXT, INT)`).
+- [ ] `AC6` `128-revoke-definer-rpc-residual-grants.test.ts` passes: `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`.
+- [ ] `AC7` Typecheck clean: `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit`.
+- [ ] `AC8` No FIX target is reachable from any authenticated/anon caller path in `server/` (grep confirms `concurrency.ts` + `agent-runner.ts` use `createServiceClient`; documented in §sibling audit).
+- [ ] `AC9` `find_stuck_active_conversations` carries a `COMMENT ON FUNCTION` documenting service-role-only intent + Ref #6306.
+- [ ] `AC10` PR body uses `Closes #6306` (this fix is complete at merge — the migration auto-applies via `web-platform-release.yml#migrate`, and verify runs in the same pipeline; unlike ops-remediation, there is no post-merge operator write, so `Closes` is correct).
+
+### Post-merge (pipeline-automated, no operator action)
+- [ ] `PM1` `web-platform-release.yml#migrate` applies migration 128 on merge to main (path-filtered auto-apply — no operator SSH/CLI).
+- [ ] `PM2` `verify-migrations` job runs `verify/128_*.sql` post-apply; all `bad=0` (deny state confirmed against prod).
+- [ ] `PM3` `/ship` posts a cross-ref comment on #6256 recording the rls-fuzz un-baseline follow-up (Phase 4).
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: verify/128 sentinel (has_function_privilege deny checks on 5 RPCs)
+  cadence: every merge to main touching apps/web-platform/supabase/** (post-apply)
+  alert_target: verify-migrations CI job (fails the release pipeline on bad>0)
+  configured_in: .github/workflows/web-platform-release.yml (verify-migrations job) + apps/web-platform/scripts/run-verify.sh
+error_reporting:
+  destination: GitHub Actions annotations (::error::<file>/<check_name>: FAIL) — release job hard-fails, blocking deploy
+  fail_loud: true
+failure_modes:
+  - mode: a future CREATE OR REPLACE / GRANT re-opens anon or authenticated EXECUTE
+    detection: verify/128 anon+authenticated+public deny checks return bad=1
+    alert_route: verify-migrations job failure → release pipeline red
+  - mode: the fix accidentally revokes service_role EXECUTE (breaks the reaper / slot RPCs)
+    detection: verify/128 service_role grant-present checks return bad=1
+    alert_route: verify-migrations job failure → release pipeline red
+logs:
+  where: GitHub Actions run logs for the verify-migrations job (::group:: per verify file)
+  retention: GitHub Actions default (90 days)
+discoverability_test:
+  command: "doppler run -c prd -- bash apps/web-platform/scripts/run-verify.sh   # runs verify/128 against prod, exit 1 on any bad>0 — NO ssh"
+  expected_output: "ok 128_definer_rpc_residual_grants_revoked/<check_name> (bad=0) for every check; Verify summary: N passed, 0 failed"
+```
+
+## Domain Review
+
+**Domains relevant:** none (backend security/DB tooling change; no Product/UI surface).
+
+No files under `components/**`, `app/**/page.tsx`, or any UI-surface glob — the mechanical UI-surface
+override does not fire. Product/UX Gate: NONE. Engineering-security is the implementing domain (default);
+`user-impact-reviewer` is enrolled at review-time via the `single-user incident` threshold, not a domain
+leader spawn.
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` cross-referenced against `037_stuck_active_finder_rpc`,
+`concurrency`, `find_stuck_active_conversations`, `acquire_conversation_slot`, and `rls-fuzz` returned zero
+matches.
+
+## GDPR / Compliance
+
+Touches a `.sql` migration surface (regex trigger), but the change is **remediation** — it *closes* a
+cross-tenant confidentiality gap (GDPR Art. 5(1)(f) integrity/confidentiality) and introduces **no new
+processing activity, data flow, or external transfer**. No Article 30 register entry is added. Net compliance
+posture improves. No Critical gdpr-gate finding is expected; full-skill invocation is low-value for a
+defense-strengthening grant revoke.
+
+## Test Scenarios
+1. **Deny state (deploy-time):** after apply, `has_function_privilege('authenticated', 'public.find_stuck_active_conversations(integer)', 'EXECUTE')` → `false` (verify/128, bad=0).
+2. **Service-role preserved:** `has_function_privilege('service_role', …)` → `true` for the 4 non-trigger RPCs — the reaper + slot flows keep working.
+3. **Reaper regression:** `agent-runner-stuck-active-reaper.test.ts` + `agent-runner-reaper-cadence.test.ts` remain green (service-role path unchanged).
+4. **Slot flows regression:** concurrency acquire/release/touch tests remain green (service-role client path unchanged).
+5. **Migration content:** `128-revoke-definer-rpc-residual-grants.test.ts` fails if any FIX target is missing its `from anon, authenticated` revoke.
+
+## Sharp Edges
+- **Migration ordinal is provisional.** `128` may be claimed by a sibling PR in the one-shot pipeline; the migration runner rejects duplicate numbers. /work Phase 0 re-checks next-free against `origin/main` and renumbers migration + verify + down + test together if needed.
+- **`CREATE OR REPLACE` does not reset privileges** — a later migration that re-`CREATE OR REPLACE`s any of these 5 functions will NOT re-grant anon/authenticated (grants persist across replace), so the fix is durable; but a *new* function with the same defect would slip past — the verify sentinel only covers these 5. (Broader class enforcement is the province of #6256's fuzz harness.)
+- **`release_slot_on_archive()` returns `trigger`** — PostgREST does not expose trigger-returning functions as RPC endpoints and a direct call errors on absent `TG_*` context, so its practical disclosure risk is nil; it is included purely for shape-uniformity. Do NOT assert a `service_role` grant on it in verify/128.
+- **`has_function_privilege` role-name literals:** PUBLIC is the lowercase literal `'public'` (per `verify/069` check (5)); use exact signatures incl. arg types (`(integer)`, `(uuid, uuid, integer, uuid)`) or the check silently no-ops on a signature mismatch.
+- **Do not `Closes #6256`** — the rls-fuzz harness is a separate open issue; only cross-reference it.
+- A plan whose `## User-Brand Impact` section is empty or placeholder fails `deepen-plan` Phase 4.6 — this one is filled with the concrete artifact/vector/threshold.
+
+## Alternative Approaches Considered
+| Approach | Verdict |
+|---|---|
+| Fix only `find_stuck_active_conversations` (issue's literal primary) | Rejected — the sibling slot RPCs share the identical defect and carry a *worse* (write IDOR) impact; a security fix that leaves known-identical siblings exposed is half a fix at `single-user incident` threshold. Issue AC explicitly mandates the sibling audit. |
+| `ALTER DEFAULT PRIVILEGES` to stop future default grants | Rejected — does not remediate the 5 *existing* grants (the live exposure); orthogonal hardening better owned by #6256 / a dedicated migration-lint. Out of scope. |
+| Block on #6256 to un-baseline rpc-cases.ts | Rejected — #6256 is unmerged; a P1 cross-tenant disclosure must not wait on an unrelated harness. The verify/128 sentinel is the durable guard; #6256 gets a cross-ref note. |
+| TS integration test as the primary guard | Rejected — the `verify/*.sql` sentinel (deploy-time, runs against prod) is the canonical always-on guard for grant state, per the jti-deny precedent. The TS test guards migration *content* only. |

--- a/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
@@ -100,7 +100,7 @@ whose only grant statement is `revoke … on function … from public`:
 | `acquire_conversation_slot(uuid, uuid, integer)` (3-arg) | 029 | — | **N/A** — dropped by `093:42` (`DROP FUNCTION IF EXISTS`) |
 | `sum_user_mtd_cost(uuid, timestamptz)` | 027 | revoke public+authenticated+anon | SAFE (exemplar — the correct pattern) |
 | `acquire/touch/release_worktree_lease(…)` ×3 | 116 | revoke public+anon+authenticated | SAFE (exemplar) |
-| `list_conversations_enriched(…)` | 125 | revoke public+anon, **GRANT authenticated** | SAFE (intentionally authenticated-callable — different case) |
+| `list_conversations_enriched(…)` | 125 | revoke public+anon, **GRANT authenticated** | SAFE (`SECURITY INVOKER`, not DEFINER; intentionally authenticated-callable — different case) |
 
 **Audit completeness (independently confirmed by both deepen reviewers):** enumerating every non-`.down`
 migration that revokes EXECUTE from `public` but never from `anon`/`authenticated` yields exactly these 5

--- a/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/decision-challenges.md
+++ b/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/decision-challenges.md
@@ -1,0 +1,48 @@
+# Decision Challenges — feat-one-shot-6306-rpc-grant-revoke
+
+Issue: #6306 — revoke residual anon/authenticated EXECUTE on service-role-only
+SECURITY DEFINER RPCs.
+
+## Re-scoped issue premises (Phase 0.6 premise validation)
+
+Two premises in the issue body were stale and did not survive verification against
+the codebase. Both are recorded here so a downstream reader (or the #6256 harness
+author) does not re-inherit them.
+
+### 1. AC4 "un-baseline the `test.fails` entry in `test/rls-fuzz/rpc-cases.ts`" — NOT satisfiable
+
+`test/rls-fuzz/` and `rpc-cases.ts` **do not exist** in this repo yet. The runtime
+RLS/authz-fuzz harness that owns them (#6256, the "ADR-103" the issue cites — see
+premise 2) is **OPEN / not merged**. `find … -iname '*rpc-cases*'` returns nothing.
+
+**Resolution:** the un-baseline AC cannot be actioned — there is no file to edit. This
+fix's durable regression guard is the always-on deploy-time sentinel
+`verify/128_definer_rpc_residual_grants_revoked.sql` (fails the release pipeline on
+any `bad>0`), NOT a test-harness baseline flip.
+
+**Cross-reference follow-up (owned by #6256, not this PR):** when the #6256 fuzz
+harness lands, its `test/rls-fuzz/rpc-cases.ts` entry for
+`find_stuck_active_conversations` (and the four sibling slot RPCs) MUST be a plain
+denial assertion — never a baselined `test.fails` known-exposure, since migration 128
+has now closed the exposure. `/ship` posts a cross-ref comment on #6256 recording this.
+**This P1 fix does NOT block on the unmerged harness.**
+
+### 2. "Discovered by the harness (#6256, **ADR-103**)" — ADR mis-numbered
+
+`ADR-103` is `ADR-103-dedicated-host-boot-heartbeats-require-guarded-reprovision-path.md`,
+unrelated to the fuzz harness. The citation is harmless to the fix (the harness itself,
+#6256, is real). Noted so the plan/PR does not inherit a false ADR reference. No new ADR
+is authored — migration 128 restores an already-decided service-role-only intent
+(migration 037) and moves no ownership/tenancy/trust boundary.
+
+## Deferred root-cause hardening (tracked, not silent)
+
+Migration 128 remediates the **five existing** residual grants (the live exposure). It
+does NOT close the *class*: Supabase's default `ALTER DEFAULT PRIVILEGES` still grants
+EXECUTE to anon/authenticated on every *future* `public` SECURITY DEFINER function, and
+the audit criterion (revoke-from-public-only) cannot detect a definer function that
+manages **no grants at all**. `/ship` files a tracked `type/security` follow-up issue
+(PM4) for a repo-wide baseline: either an `ALTER DEFAULT PRIVILEGES … REVOKE EXECUTE …
+FROM anon, authenticated` migration OR a migration-lint gate that fails CI on a
+revoke-from-public-only DEFINER function. This is a concrete tracked deferral, not a soft
+"province of #6256" handoff.

--- a/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/session-state.md
@@ -1,0 +1,21 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md
+- Status: complete
+
+### Errors
+None. Two stale issue premises re-scoped (test/rls-fuzz/rpc-cases.ts does not exist; harness #6256 still OPEN; ADR-103 citation is wrong). The link-check "BROKEN" flag was decision-challenges.md, a Phase-4 file-to-create, not a broken reference.
+
+### Decisions
+- Scope expanded from 1 to 5 functions: sibling audit found the identical revoke-from-public-only defect on 4 concurrency-slot RPCs (acquire/release/touch_conversation_slot + release_slot_on_archive trigger fn). Folded all 5 into one migration.
+- Two stale issue premises re-scoped (Phase 0.6): un-baseline test.fails AC converted to cross-ref note (durable guard is verify/128 sentinel); ADR-103 citation flagged wrong.
+- Fix shape pinned to canonical repo precedent (migration+verify+down triad of 069_jti_deny_grant_restore). All target RPCs called only via createServiceClient — revoking anon/authenticated is behavior-preserving.
+- Threshold = single-user incident (requires_cpo_signoff: true): write-IDOR slot RPCs let one attacker lock out/grief another user.
+- Deepen review applied 4 corrections: guarded down migration against re-opening IDOR (P2-1); corrected durability reasoning naming DROP+CREATE re-grant vector with verify/128 guard (P2-2); made ALTER DEFAULT PRIVILEGES root-cause a /ship follow-up (P2-3); fixed inverted Sharp Edge — wrong has_function_privilege signature hard-fails release pipeline under ON_ERROR_STOP=1 (pinned 4-arg acquire signature).
+
+### Components Invoked
+- Skill: soleur:plan (#6306)
+- Skill: soleur:deepen-plan
+- Agent: soleur:engineering:review:data-integrity-guardian
+- Agent: soleur:engineering:review:security-sentinel

--- a/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/tasks.md
@@ -1,0 +1,37 @@
+# Tasks — fix(security): revoke residual anon/authenticated EXECUTE on service-role-only DEFINER RPCs (#6306)
+
+Plan: `knowledge-base/project/plans/2026-07-11-fix-revoke-definer-rpc-residual-grants-plan.md`
+Lane: single-domain · Threshold: single-user incident · requires_cpo_signoff: true
+
+## Phase 0 — Preconditions
+- [ ] 0.1 Re-check next-free migration ordinal against `origin/main`; `128` is provisional — renumber migration+verify+down+test together if taken.
+- [ ] 0.2 Re-confirm live `proacl` on the 5 targets is still `revoke-from-public`-only.
+
+## Phase 1 — Migration + down
+- [ ] 1.1 Create `apps/web-platform/supabase/migrations/128_revoke_definer_rpc_residual_grants.sql` (model on `069_jti_deny_grant_restore.sql`).
+- [ ] 1.2 For each of the 5 FIX targets: `revoke execute … from anon, authenticated;` + defense-in-depth `from public;`.
+    - `find_stuck_active_conversations(integer)`
+    - `acquire_conversation_slot(uuid, uuid, integer, uuid)`
+    - `release_conversation_slot(uuid, uuid)`
+    - `touch_conversation_slot(uuid, uuid)`
+    - `release_slot_on_archive()`
+- [ ] 1.3 Add `COMMENT ON FUNCTION find_stuck_active_conversations` — service-role-only intent + Ref #6306.
+- [ ] 1.4 Create `128_revoke_definer_rpc_residual_grants.down.sql` restoring the pre-fix grants (rollback-only, mirror `069_*.down.sql`).
+
+## Phase 2 — Verify sentinel
+- [ ] 2.1 Create `apps/web-platform/supabase/verify/128_definer_rpc_residual_grants_revoked.sql` with the `(check_name, bad)` contract.
+- [ ] 2.2 Per target: `anon` deny + `authenticated` deny + `public` deny checks (bad=1 when EXECUTE still held).
+- [ ] 2.3 For the 4 non-trigger targets: `service_role` grant-present check (bad=1 when service_role LACKS EXECUTE). Omit for `release_slot_on_archive()`.
+
+## Phase 3 — Migration content test
+- [ ] 3.1 Create `apps/web-platform/test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts` (mirror `036-release-slot-on-archive.test.ts`).
+- [ ] 3.2 Assert migration 128 contains the anon/authenticated revoke for each of the 5 functions and verify/128 asserts the deny state.
+- [ ] 3.3 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`.
+
+## Phase 4 — #6256 cross-reference (no code)
+- [ ] 4.1 Record in `decision-challenges.md`: when #6256 harness lands, `rpc-cases.ts` entry for these RPCs must be a plain denial (not baselined `test.fails`).
+
+## Verification
+- [ ] V1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
+- [ ] V2 Reaper + concurrency-slot regression suites green (service-role path unchanged).
+- [ ] V3 PR body uses `Closes #6306`; `/ship` posts cross-ref comment on #6256.

--- a/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6306-rpc-grant-revoke/tasks.md
@@ -16,7 +16,8 @@ Lane: single-domain · Threshold: single-user incident · requires_cpo_signoff: 
     - `touch_conversation_slot(uuid, uuid)`
     - `release_slot_on_archive()`
 - [ ] 1.3 Add `COMMENT ON FUNCTION find_stuck_active_conversations` — service-role-only intent + Ref #6306.
-- [ ] 1.4 Create `128_revoke_definer_rpc_residual_grants.down.sql` restoring the pre-fix grants (rollback-only, mirror `069_*.down.sql`).
+- [ ] 1.4 Create `128_revoke_definer_rpc_residual_grants.down.sql` restoring the pre-fix grants (rollback-only, mirror `069_*.down.sql`). MUST carry a `093.down`-style caveat: "KNOWINGLY re-opens #6306 IDOR — do NOT run in production; rollback-machinery only".
+- [ ] 1.5 Use EXACT current signatures — `acquire_conversation_slot` is the 4-arg `(uuid, uuid, integer, uuid)` (093), NOT the dropped 3-arg (029). A wrong sig hard-fails run-verify under ON_ERROR_STOP=1.
 
 ## Phase 2 — Verify sentinel
 - [ ] 2.1 Create `apps/web-platform/supabase/verify/128_definer_rpc_residual_grants_revoked.sql` with the `(check_name, bad)` contract.
@@ -28,8 +29,9 @@ Lane: single-domain · Threshold: single-user incident · requires_cpo_signoff: 
 - [ ] 3.2 Assert migration 128 contains the anon/authenticated revoke for each of the 5 functions and verify/128 asserts the deny state.
 - [ ] 3.3 Run `cd apps/web-platform && ./node_modules/.bin/vitest run test/supabase-migrations/128-revoke-definer-rpc-residual-grants.test.ts`.
 
-## Phase 4 — #6256 cross-reference (no code)
+## Phase 4 — Cross-reference + follow-up (no code)
 - [ ] 4.1 Record in `decision-challenges.md`: when #6256 harness lands, `rpc-cases.ts` entry for these RPCs must be a plain denial (not baselined `test.fails`).
+- [ ] 4.2 `/ship` files a `type/security` follow-up issue for the repo-wide `ALTER DEFAULT PRIVILEGES` / migration-lint baseline (root-cause hardening, deferred from this hotfix).
 
 ## Verification
 - [ ] V1 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.


### PR DESCRIPTION
## Summary

Five service-role-only `SECURITY DEFINER` functions still carried the CREATE-time-default `EXECUTE` grant to `anon` + `authenticated`. Migrations 029/036/037/093 revoked only from `PUBLIC`, which leaves the explicit `anon`/`authenticated` grants intact. Because these functions bypass RLS (definer rights), any authenticated (or anonymous) PostgREST caller could:

- `find_stuck_active_conversations(integer)` — enumerate **every tenant's** stuck-active `(conversation_id, user_id)` pairs (cross-tenant read; GDPR Art. 5(1)(f)).
- `acquire` / `release` / `touch_conversation_slot(…)` — mutate **another user's** concurrency-slot ledger, locking a free-tier user (cap=1) out of starting any conversation (write IDOR / denial-of-service).
- `release_slot_on_archive()` — a trigger function (never RPC-exposable); revoked for shape-uniformity only.

Migration `128` revokes `EXECUTE` from `anon`, `authenticated`, and (defense-in-depth) `PUBLIC` on all five, restoring migration 037's stated service-role-only intent. Modeled verbatim on the `069_jti_deny_grant_restore` migration + down + verify sentinel triad.

Closes #6306

## Changelog

### Web Platform
- Add migration `128_revoke_definer_rpc_residual_grants.sql` revoking residual `anon`/`authenticated`/`PUBLIC` EXECUTE on 5 `SECURITY DEFINER` RPCs.
- Add `128_*.down.sql` (rollback-machinery only; carries an explicit "do NOT run in production — knowingly re-opens the #6306 IDOR" caveat).
- Add `verify/128_definer_rpc_residual_grants_revoked.sql` — 15 anon/authenticated/public deny checks + 4 `service_role`-present checks, run by the `verify-migrations` CI job on every deploy (the load-bearing durability guard).
- Add `128-revoke-definer-rpc-residual-grants.test.ts` — migration-content test (35 assertions; verify CASE-polarity + `check_name` binding, mutation-verified).

## User-Brand Impact

**If this lands broken, the user experiences:** an authenticated attacker enumerates other tenants' `(conversation_id, user_id)` pairs, and — via the slot RPCs — frees/steals/heartbeats another user's concurrency slot, locking a free-tier user out of starting any conversation.

**If this leaks, the user's data/workflow is exposed via:** direct `POST /rest/v1/rpc/<fn>` callable by any `anon`/`authenticated` JWT, bypassing `conversations` RLS through SECURITY DEFINER rights.

**Safety of the revoke:** every target is invoked only by the server-side service-role client (`server/concurrency.ts`, `server/agent-runner.ts`); no authenticated/anon caller path exists, so the revoke is behavior-preserving for legitimate callers. Verified: none of the 5 functions is referenced in any RLS `USING`/`WITH CHECK` clause, so revoking `authenticated` cannot break policy evaluation.

- **Brand-survival threshold:** single-user incident

## Test plan

- [x] `128-revoke-definer-rpc-residual-grants.test.ts` — 35/35 (content + polarity + check_name binding).
- [x] Mutation-verified: inverting a verify deny-check polarity goes RED; restore → GREEN.
- [x] `tsc --noEmit` clean.
- [x] Full `apps/web-platform` vitest suite — 12482 passed, 0 failed (incl. `migration-rpc-grants` + all 52 `supabase-migrations` suites).
- [x] Reaper + concurrency regression suites green (service-role path unchanged).

Automated post-merge (no operator action): `web-platform-release.yml#migrate` applies migration 128 on merge; the `verify-migrations` job runs `verify/128` post-apply and hard-fails the release on any `bad>0` (deny state confirmed against prod). Rollback is forward-only; the down migration never auto-runs.

## Model Dissents (informational)

Two premises in issue #6306 were re-scoped during planning (recorded in `specs/feat-one-shot-6306-rpc-grant-revoke/decision-challenges.md`):

- Issue AC4 ("un-baseline the `test.fails` entry in `test/rls-fuzz/rpc-cases.ts`") is not satisfiable — that file and its harness (#6256) do not exist yet / are unmerged. The durable regression guard is the always-on `verify/128` sentinel; when #6256 lands, its entry for these RPCs must be a plain denial assertion, not a baselined `test.fails`. This P1 fix does not block on the unmerged harness.
- The issue's "ADR-103" citation is mis-numbered (ADR-103 is dedicated-host boot heartbeats, unrelated). Harmless to the fix.

The sibling audit expanded scope from the 1 named function to all 5 sharing the identical `revoke-from-public`-only defect. Root-cause hardening beyond these 5 instances (a repo-wide `ALTER DEFAULT PRIVILEGES` baseline or migration-lint gate) is tracked as a separate follow-up.

Generated with [Claude Code](https://claude.com/claude-code)
