### PR TITLE
feat: Grok fidelity Phase A+B — onboarding + harness adapter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,19 @@ grok           # start an interactive session
 
 Soleur is hook-heavy; without trust, PreToolUse guards from `.claude/settings.json` stay inactive.
 
+### Grok command naming
+
+Grok and Claude use **different slash-command namespaces** for the same plugin:
+
+| What | Claude Code | Grok Build |
+|------|-------------|------------|
+| Unified entry | `/soleur:go <intent>` | `/go <intent>` |
+| Knowledge-base sync | `/soleur:sync` | `/sync` |
+| Help | `/soleur:help` | `/help` |
+| Workflow skills | Skill tool (`soleur:brainstorm`, etc.) | Slash commands (`/brainstorm`, `/one-shot`, …) |
+
+Do **not** document `/soleur:go` for Grok sessions — use `/go`. Workflow routing must invoke registered skills (slash commands under Grok, Skill tool under Claude), not improvised steps. See `knowledge-base/engineering/grok-onboarding.md` and `plugins/soleur/lib/harness.ts`.
+
 ## Contributor License Agreement
 
 Before your first pull request can be merged, you must sign the [Individual Contributor License Agreement](https://soleur.ai/pages/legal/individual-cla.html) (CLA). The CLA bot will prompt you automatically on your first PR.

--- a/knowledge-base/engineering/grok-onboarding.md
+++ b/knowledge-base/engineering/grok-onboarding.md
@@ -1,0 +1,57 @@
+---
+title: Grok Build onboarding for Soleur contributors
+last_updated: 2026-07-10
+tags:
+  - grok
+  - harness
+  - onboarding
+domain: engineering
+---
+
+# Grok Build onboarding
+
+Soleur loads the same in-repo plugin under [Grok Build](https://docs.x.ai/build/overview) as under Claude Code. This brief covers first-run setup and **command naming** — the most common fidelity failure mode.
+
+## First session
+
+From the repository root:
+
+```bash
+grok inspect    # soleur plugin, skills, agents, MCP servers must appear
+grok --trust    # first run only — activates .claude/settings.json hooks
+grok            # interactive session
+```
+
+Without trust, Soleur's PreToolUse guards stay inactive and workflows may skip safety gates.
+
+Project plugin config lives in `.grok/config.toml` (merged #6314). Supported project keys are **`[plugins]`**, **`[mcp_servers]`**, and **`[permission]`** only — no `permission_mode` or `[compat.claude]` in project config (those belong in user `~/.grok/config.toml`).
+
+## Command naming (harness-specific)
+
+| Surface | Claude Code | Grok Build |
+|--------|-------------|------------|
+| Entry command | `/soleur:go <intent>` | `/go <intent>` |
+| Sync | `/soleur:sync` | `/sync` |
+| Help | `/soleur:help` | `/help` |
+| Workflow skills | Skill tool: `soleur:<skill>` | Slash: `/<skill>` (e.g. `/one-shot`, `/brainstorm`) |
+| Agents | Task tool (`subagent_type`) | `spawn_subagent` |
+
+**Do not** tell Grok users to run `/soleur:go` — that is the Claude-qualified form. Grok exposes plugin commands by their frontmatter `name` (`go`, `sync`, `help`).
+
+## Routing fidelity
+
+`/go` (and `plugins/soleur/commands/go.md`) classify intent and **must** invoke registered skills or agents — never improvise filesystem exploration or ad-hoc multi-step workflows. The harness adapter at `plugins/soleur/lib/harness.ts` maps invocation surfaces; see epic children for the full fidelity stack.
+
+## Verify discovery
+
+```bash
+grok inspect | grep -E 'soleur|agents|skills'
+```
+
+Today Grok may show fewer agents than Claude until Phase E (agent discoverability) lands. Skills and the three commands should appear after #6314 config.
+
+## References
+
+- CONTRIBUTING.md — contributor quickstart
+- ADR-110 / #6316 — semantic model-tier map (Phase D)
+- `plugins/soleur/lib/harness.ts` — Skill/Task vs slash/spawn_subagent adapter (Phase B)

--- a/plugins/soleur/commands/go.md
+++ b/plugins/soleur/commands/go.md
@@ -59,6 +59,19 @@ If the user wants to continue the current feature, delegate to `soleur:work` via
 
 ## Step 2: Classify and Route
 
+### Step 2.0: Harness adapter (never improvise)
+
+Before applying the routing table, detect the active harness and use the correct invocation surface. Canonical implementation: `plugins/soleur/lib/harness.ts`.
+
+| Harness | Skills | Agents | Entry command |
+|---------|--------|--------|---------------|
+| Claude Code | **Skill tool** — `soleur:<skill>` | **Task tool** — `subagent_type` | `/soleur:go` |
+| Grok Build | **Slash command** — `/<skill>` (e.g. `/one-shot`) | **spawn_subagent** | `/go` (not `/soleur:go`) |
+
+**Routing contract:** when a table row names `soleur:<skill>` or an agent, invoke it via the harness adapter (`invokeSkill` / `spawnAgent` semantics in `harness.ts`). Pass the original user input as args/prompt. **Do NOT** improvise workflow steps, explore the filesystem as a substitute, or hand-roll plan/work/review phases when a registered route exists.
+
+If harness is unknown and Skill/slash tools are unavailable, STOP and suggest `grok inspect` + `grok --trust` (Grok) or `claude --plugin-dir ./plugins/soleur` (Claude).
+
 Analyze the user input and classify intent using semantic assessment:
 
 <!-- eval-gate:block:go-routing:start -->
@@ -74,7 +87,12 @@ Analyze the user input and classify intent using semantic assessment:
 | default | Everything else — features, exploration, questions, generation, vague scope | `soleur:brainstorm` |
 <!-- eval-gate:block:go-routing:end -->
 
-If intent is clear, invoke the skill directly via the **Skill tool** with the original user input as `args`. No confirmation step. **Exception:** rows whose `Routes To` cell names an agent (e.g., `clo`) instead of a `soleur:<skill>` skill use the **Task tool** to spawn the agent — the agent's prompt receives the original user input as the task description. When extending this table, prefer routing to a skill when one exists; route to an agent only when no skill wraps the desired behavior.
+If intent is clear, route without confirmation:
+
+- **Claude Code:** invoke via the **Skill tool** (`soleur:<skill>`, args = original user input). Agents: **Task tool** with `subagent_type` and prompt = original user input.
+- **Grok Build:** invoke via **slash command** (`/<skill>` with args appended). Agents: **spawn_subagent** with the agent id and prompt = original user input.
+
+Map `soleur:<skill>` cells in the table to Grok `/<skill>` at invocation time (strip the `soleur:` prefix). **Exception:** rows whose `Routes To` cell names an agent (e.g., `clo`) instead of a `soleur:<skill>` skill spawn that agent — never substitute a manual workflow. When extending this table, prefer routing to a skill when one exists; route to an agent only when no skill wraps the desired behavior.
 
 **PR-vs-issue type resolution (when `#N` or a bare number is the input):** Before evaluating the `clo-attestation` and `review` rows, run `gh issue view N --json body,title,state 2>/dev/null` to determine whether `N` is an issue. If `gh issue view` succeeds AND the body satisfies the `clo-attestation` predicate, route to clo. If `gh issue view` succeeds but no `clo-attestation` match, route to `soleur:review` only after confirming `gh pr view N` ALSO succeeds (otherwise the input is a non-attestation issue — route to default/brainstorm with the issue body as context). This ordering closes the gap that caused `/soleur:go #3998` to mis-route an issue to PR review. See `knowledge-base/project/learnings/workflow-patterns/2026-05-18-clo-attestation-auto-route-instead-of-human-task.md`.
 

--- a/plugins/soleur/commands/help.md
+++ b/plugins/soleur/commands/help.md
@@ -25,9 +25,21 @@ Use the **Glob tool** to count components. Make all four calls in parallel in a 
 
 If the plugin paths do not exist, fall back to the installed plugin paths under `~/.claude/plugins/`.
 
+## Step 2.5: Harness-aware command names
+
+Detect the active harness before printing commands:
+
+- **Claude Code:** commands use the `/soleur:` prefix (`/soleur:go`, `/soleur:sync`, `/soleur:help`). Workflow skills are invoked via the **Skill tool** (`soleur:<skill>`).
+- **Grok Build:** commands are unqualified (`/go`, `/sync`, `/help`). Workflow skills are invoked via **slash commands** (`/brainstorm`, `/one-shot`, …) — not `/soleur:go`.
+- Implementation reference: `plugins/soleur/lib/harness.ts` (`routingInstructions`, `formatSkillInvocation`).
+
+Use the matching column in Step 3 below.
+
 ## Step 3: Output the Help Reference
 
-Present the following formatted overview. Replace placeholder counts with actual values from Step 2.
+Present the following formatted overview. Replace placeholder counts with actual values from Step 2. **Print the Claude block OR the Grok block** based on Step 2.5 — not both.
+
+### Claude Code
 
 ```text
 Soleur - The Company-as-a-Service Platform
@@ -59,6 +71,37 @@ MCP SERVERS:
 
 Quick start: /soleur:go <what you want to do>
 Full docs:   See plugins/soleur/README.md
+```
+
+### Grok Build
+
+```text
+Soleur - The Company-as-a-Service Platform
+
+COMMANDS:
+  /go <what you want>   The recommended way to use Soleur
+  /sync                 Populate knowledge-base from existing codebase
+  /help                 This help listing
+
+WORKFLOW SKILLS (invoked via /go or directly via slash command):
+  brainstorm            Explore requirements and approaches
+  plan                  Create an implementation plan
+  work                  Execute the plan systematically
+  review                Run multi-agent code review
+  compound              Capture learnings from solved problems
+  one-shot              Full autonomous engineering workflow
+
+AGENTS: [N] agents across [M] categories
+  (same category breakdown as Claude block)
+
+SKILLS: [N] skills
+  (list all skills — invoke as /<skill-name>)
+
+MCP SERVERS:
+  context7              Framework documentation lookup
+
+Quick start: /go <what you want to do>
+Full docs:   See plugins/soleur/README.md and knowledge-base/engineering/grok-onboarding.md
 ```
 
 Replace all `[N]`, `[M]`, and `[count]` placeholders with actual values from Step 2. List all skills found, not just a subset.

--- a/plugins/soleur/lib/harness.ts
+++ b/plugins/soleur/lib/harness.ts
@@ -1,0 +1,206 @@
+/**
+ * Harness adapter — maps Soleur workflow invocations to Claude Code or Grok Build surfaces.
+ *
+ * Claude: Skill tool (`soleur:<skill>`), Task tool (agents), `/soleur:<command>` slash commands.
+ * Grok:   slash commands (`/<skill>`, `/go`), spawn_subagent (agents).
+ *
+ * Skills and go.md must call these helpers (or follow routingInstructions) — never improvise workflows.
+ */
+
+export type Harness = "claude" | "grok" | "unknown";
+
+/** Env vars set by Grok Build (see https://docs.x.ai/build/settings/reference). */
+const GROK_ENV_MARKERS = [
+  "GROK_HOME",
+  "GROK_AGENT",
+  "GROK_DEFAULT_MODEL",
+  "GROK_SUBAGENTS",
+] as const;
+
+export interface SkillInvocation {
+  harness: Harness;
+  tool: "Skill" | "slash_command";
+  command: string;
+  args?: string;
+  instruction: string;
+}
+
+export interface AgentSpawn {
+  harness: Harness;
+  tool: "Task" | "spawn_subagent";
+  agent: string;
+  prompt: string;
+  instruction: string;
+}
+
+/** Strip `soleur:` prefix; Grok exposes bare skill names as slash commands. */
+export function normalizeSkillName(skill: string): string {
+  return skill.replace(/^soleur:/, "");
+}
+
+/** Ensure agent ids are plugin-qualified when a bare frontmatter name is passed. */
+export function normalizeAgentName(agent: string): string {
+  if (agent.includes(":")) {
+    return agent.startsWith("soleur:") ? agent : `soleur:${agent}`;
+  }
+  return agent;
+}
+
+/**
+ * Detect the active harness from environment markers and process metadata.
+ * Detection order: CLAUDECODE → GROK_* → process title/argv heuristics.
+ */
+export function detectHarness(env: NodeJS.ProcessEnv = process.env): Harness {
+  if (env.CLAUDECODE) {
+    return "claude";
+  }
+
+  for (const key of GROK_ENV_MARKERS) {
+    if (env[key]) {
+      return "grok";
+    }
+  }
+
+  // Process heuristics apply only when inspecting the live runtime env — not
+  // injected test fixtures (Grok Build's argv/title would false-positive "grok").
+  if (env === process.env && typeof process !== "undefined") {
+    const title = (process.title ?? "").toLowerCase();
+    const argv = process.argv.join(" ").toLowerCase();
+    if (title.includes("grok") || /\bgrok\b/.test(argv)) {
+      return "grok";
+    }
+  }
+
+  return "unknown";
+}
+
+/**
+ * Return the harness-specific skill invocation string (display / logging).
+ */
+export function formatSkillInvocation(skill: string, args?: string): string {
+  const harness = detectHarness();
+  const name = normalizeSkillName(skill);
+  const trimmedArgs = args?.trim();
+
+  if (harness === "grok") {
+    return trimmedArgs ? `/${name} ${trimmedArgs}` : `/${name}`;
+  }
+
+  const skillId = `soleur:${name}`;
+  return trimmedArgs ? `${skillId} (args: ${trimmedArgs})` : skillId;
+}
+
+/**
+ * Structured skill invocation — use at routing sites instead of improvising steps.
+ */
+export function invokeSkill(skill: string, args?: string): SkillInvocation {
+  const harness = detectHarness();
+  const name = normalizeSkillName(skill);
+  const trimmedArgs = args?.trim();
+
+  if (harness === "grok") {
+    const command = trimmedArgs ? `/${name} ${trimmedArgs}` : `/${name}`;
+    return {
+      harness,
+      tool: "slash_command",
+      command,
+      args: trimmedArgs,
+      instruction:
+        `Invoke the registered skill via slash command \`${command}\`. ` +
+        "Do NOT improvise workflow steps — run the skill to completion.",
+    };
+  }
+
+  const command = `soleur:${name}`;
+  return {
+    harness: harness === "claude" ? "claude" : harness,
+    tool: "Skill",
+    command,
+    args: trimmedArgs,
+    instruction:
+      `Invoke via the **Skill tool** with skill \`${command}\`` +
+      (trimmedArgs ? ` and args: \`${trimmedArgs}\`` : "") +
+      ". Do NOT improvise workflow steps.",
+  };
+}
+
+/**
+ * Return markdown guidance for spawning an agent under the active harness.
+ */
+export function formatAgentSpawn(agent: string, prompt: string): string {
+  const harness = detectHarness();
+  const agentId = normalizeAgentName(agent);
+
+  if (harness === "grok") {
+    return (
+      `Use **spawn_subagent** with agent \`${agentId}\` and this prompt:\n\n${prompt}`
+    );
+  }
+
+  return (
+    `Use the **Task tool** with subagent_type \`${agentId}\` and this prompt:\n\n${prompt}`
+  );
+}
+
+/**
+ * Structured agent spawn — maps Claude Task tool to Grok spawn_subagent.
+ */
+export function spawnAgent(agent: string, prompt: string): AgentSpawn {
+  const harness = detectHarness();
+  const agentId = normalizeAgentName(agent);
+
+  if (harness === "grok") {
+    return {
+      harness,
+      tool: "spawn_subagent",
+      agent: agentId,
+      prompt,
+      instruction:
+        `Spawn via **spawn_subagent** with agent \`${agentId}\` ` +
+        "(enable with `GROK_SUBAGENTS=1` or `[subagents] enabled = true` in config). " +
+        "Pass the prompt verbatim — do NOT substitute a manual workflow.",
+    };
+  }
+
+  return {
+    harness: harness === "claude" ? "claude" : harness,
+    tool: "Task",
+    agent: agentId,
+    prompt,
+    instruction:
+      `Spawn via the **Task tool** with subagent_type \`${agentId}\`. ` +
+      "Pass the prompt verbatim.",
+  };
+}
+
+/**
+ * Markdown snippet for go.md / eval-harness — embed at routing time.
+ */
+export function routingInstructions(harness: Harness): string {
+  switch (harness) {
+    case "claude":
+      return [
+        "**Harness: Claude Code**",
+        "- Skills: **Skill tool** with `soleur:<skill>` namespace.",
+        "- Agents: **Task tool** with `subagent_type`.",
+        "- Commands: `/soleur:go`, `/soleur:sync`, `/soleur:help`.",
+        "- **Never improvise** when a route names a `soleur:<skill>` or agent — invoke it.",
+      ].join("\n");
+
+    case "grok":
+      return [
+        "**Harness: Grok Build**",
+        "- Skills: **slash commands** — `/brainstorm`, `/one-shot`, `/plan`, etc.",
+        "- Agents: **spawn_subagent** (not Task).",
+        "- Commands: `/go`, `/sync`, `/help` — **not** `/soleur:go`.",
+        "- **Never improvise** — invoke the registered slash command or subagent.",
+      ].join("\n");
+
+    default:
+      return [
+        "**Harness: unknown** — default to Claude conventions.",
+        "- Skills: Skill tool (`soleur:<skill>`). Agents: Task tool.",
+        "- If tools are missing, run `grok inspect` and `grok --trust` from repo root.",
+      ].join("\n");
+  }
+}

--- a/plugins/soleur/test/harness.test.ts
+++ b/plugins/soleur/test/harness.test.ts
@@ -1,0 +1,193 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  detectHarness,
+  formatSkillInvocation,
+  formatAgentSpawn,
+  invokeSkill,
+  spawnAgent,
+  routingInstructions,
+  normalizeSkillName,
+  normalizeAgentName,
+} from "../lib/harness";
+
+function env(overrides: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const base: NodeJS.ProcessEnv = {};
+  for (const [key, val] of Object.entries(overrides)) {
+    if (val !== undefined) {
+      base[key] = val;
+    }
+  }
+  return base;
+}
+
+/** Snapshot and restore harness-related env vars between tests. */
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = {
+    CLAUDECODE: process.env.CLAUDECODE,
+    GROK_HOME: process.env.GROK_HOME,
+    GROK_AGENT: process.env.GROK_AGENT,
+    GROK_DEFAULT_MODEL: process.env.GROK_DEFAULT_MODEL,
+    GROK_SUBAGENTS: process.env.GROK_SUBAGENTS,
+  };
+  delete process.env.CLAUDECODE;
+  delete process.env.GROK_HOME;
+  delete process.env.GROK_AGENT;
+  delete process.env.GROK_DEFAULT_MODEL;
+  delete process.env.GROK_SUBAGENTS;
+});
+
+afterEach(() => {
+  for (const [key, val] of Object.entries(savedEnv)) {
+    if (val === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = val;
+    }
+  }
+});
+
+describe("detectHarness", () => {
+  test("CLAUDECODE → claude", () => {
+    expect(detectHarness(env({ CLAUDECODE: "1" }))).toBe("claude");
+  });
+
+  test("GROK_HOME → grok", () => {
+    expect(detectHarness(env({ GROK_HOME: "/home/user/.grok" }))).toBe("grok");
+  });
+
+  test("GROK_AGENT → grok", () => {
+    expect(detectHarness(env({ GROK_AGENT: "grok-build" }))).toBe("grok");
+  });
+
+  test("CLAUDECODE wins over GROK_* when both set", () => {
+    expect(
+      detectHarness(env({ CLAUDECODE: "1", GROK_HOME: "/home/user/.grok" })),
+    ).toBe("claude");
+  });
+
+  test("empty env → unknown", () => {
+    expect(detectHarness(env({}))).toBe("unknown");
+  });
+});
+
+describe("normalizeSkillName", () => {
+  test("strips soleur: prefix", () => {
+    expect(normalizeSkillName("soleur:one-shot")).toBe("one-shot");
+    expect(normalizeSkillName("brainstorm")).toBe("brainstorm");
+  });
+});
+
+describe("normalizeAgentName", () => {
+  test("bare name passes through", () => {
+    expect(normalizeAgentName("clo")).toBe("clo");
+  });
+
+  test("namespaced path gets soleur: prefix", () => {
+    expect(normalizeAgentName("legal:clo")).toBe("soleur:legal:clo");
+  });
+
+  test("already qualified unchanged", () => {
+    expect(normalizeAgentName("soleur:legal:clo")).toBe("soleur:legal:clo");
+  });
+});
+
+describe("formatSkillInvocation", () => {
+  test("claude formats soleur: skill with args", () => {
+    process.env.CLAUDECODE = "1";
+    expect(formatSkillInvocation("one-shot", "fix auth")).toBe(
+      "soleur:one-shot (args: fix auth)",
+    );
+  });
+
+  test("grok formats slash command", () => {
+    process.env.GROK_HOME = "/home/user/.grok";
+    expect(formatSkillInvocation("soleur:brainstorm", "add feature")).toBe(
+      "/brainstorm add feature",
+    );
+    expect(formatSkillInvocation("plan")).toBe("/plan");
+  });
+});
+
+describe("invokeSkill", () => {
+  test("claude returns Skill tool invocation", () => {
+    process.env.CLAUDECODE = "1";
+    const inv = invokeSkill("one-shot", "fix bug");
+
+    expect(inv.harness).toBe("claude");
+    expect(inv.tool).toBe("Skill");
+    expect(inv.command).toBe("soleur:one-shot");
+    expect(inv.args).toBe("fix bug");
+    expect(inv.instruction).toContain("Skill tool");
+    expect(inv.instruction).toContain("Do NOT improvise");
+  });
+
+  test("grok returns slash_command invocation", () => {
+    process.env.GROK_HOME = "/home/user/.grok";
+    const inv = invokeSkill("drain-labeled-backlog", "--label security");
+
+    expect(inv.harness).toBe("grok");
+    expect(inv.tool).toBe("slash_command");
+    expect(inv.command).toBe("/drain-labeled-backlog --label security");
+    expect(inv.instruction).toContain("slash command");
+  });
+});
+
+describe("spawnAgent", () => {
+  test("claude uses Task tool", () => {
+    process.env.CLAUDECODE = "1";
+    const spawn = spawnAgent("clo", "Review issue #123");
+
+    expect(spawn.harness).toBe("claude");
+    expect(spawn.tool).toBe("Task");
+    expect(spawn.agent).toBe("clo");
+    expect(spawn.instruction).toContain("Task tool");
+  });
+
+  test("grok uses spawn_subagent", () => {
+    process.env.GROK_HOME = "/home/user/.grok";
+    const spawn = spawnAgent("legal:clo", "Attestation for #456");
+
+    expect(spawn.harness).toBe("grok");
+    expect(spawn.tool).toBe("spawn_subagent");
+    expect(spawn.agent).toBe("soleur:legal:clo");
+    expect(spawn.instruction).toContain("spawn_subagent");
+  });
+});
+
+describe("formatAgentSpawn", () => {
+  test("claude mentions Task tool", () => {
+    process.env.CLAUDECODE = "1";
+    const text = formatAgentSpawn("clo", "prompt body");
+    expect(text).toContain("Task tool");
+    expect(text).toContain("prompt body");
+  });
+
+  test("grok mentions spawn_subagent", () => {
+    process.env.GROK_HOME = "/home/user/.grok";
+    const text = formatAgentSpawn("clo", "prompt body");
+    expect(text).toContain("spawn_subagent");
+  });
+});
+
+describe("routingInstructions", () => {
+  test("claude documents soleur: namespace", () => {
+    const md = routingInstructions("claude");
+    expect(md).toContain("soleur:<skill>");
+    expect(md).toContain("/soleur:go");
+    expect(md).toContain("Never improvise");
+  });
+
+  test("grok documents /go not /soleur:go", () => {
+    const md = routingInstructions("grok");
+    expect(md).toContain("/go");
+    expect(md).toContain("**not** `/soleur:go`");
+    expect(md).toContain("spawn_subagent");
+  });
+
+  test("unknown suggests grok inspect", () => {
+    const md = routingInstructions("unknown");
+    expect(md).toContain("grok inspect");
+  });
+});

--- a/scripts/grok-fidelity-bootstrap.sh
+++ b/scripts/grok-fidelity-bootstrap.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Bootstrap: GitHub epic + child issues, worktree, commit, push, PR for Grok fidelity Phase A+B.
+# Usage: bash scripts/grok-fidelity-bootstrap.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI required" >&2
+  exit 1
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "error: bun required for harness tests" >&2
+  exit 1
+fi
+
+EPIC_BODY='Grok Build (#6314) loads the Soleur plugin, but `/go` sessions still diverge from Claude fidelity: wrong slash-command namespace, Skill/Task vs slash/spawn_subagent mismatch, and improvised workflows instead of registered routes.
+
+## 7-layer fidelity model
+
+Each layer closes a class of harness drift. Lower layers are prerequisites for higher layers.
+
+1. **Onboarding** — plugin enable/trust, command-naming docs, valid `.grok/config.toml` (Phase A)
+2. **Harness adapter** — `lib/harness.ts` maps Skill/Task to slash/spawn_subagent (Phase B)
+3. **Routing contract** — `go.md` hardening + eval-harness Grok arm; never improvise (Phase C)
+4. **Model tier map** — ADR-110 semantic tiers for both harnesses (Phase D / #6316)
+5. **Agent discoverability** — 68 agents visible/spawnable in `grok inspect` (Phase E)
+6. **Inspect CI** — `grok inspect` contract test in CI (Phase F)
+7. **Golden-path eval** — end-to-end `/go` routing eval under Grok (Phase F)
+
+## Children (recommended sequencing)
+
+- **Phase A** — Grok onboarding: plugin enable/trust, command naming docs (`/go` not `/soleur:go`), CONTRIBUTING.md Grok section, `.grok/config.toml` drift fix per #6314 review
+- **Phase B** — Harness adapter: `plugins/soleur/lib/harness.ts` + tests; `go.md` Step 2 harness section
+- **Phase C** — `go.md` hardening + eval-harness Grok arm
+- **Phase D** — ADR-110 implementation → #6316 (existing; do not duplicate)
+- **Phase E** — 68 agents discoverable/spawnable in Grok (`grok inspect` shows 1 agent today)
+- **Phase F** — Fidelity CI: `grok inspect` contract test + golden-path eval
+
+## References
+
+- #6314 — Grok Build project config (merged)
+- #6316 — Harness semantic model-tier map (ADR-110)
+- `knowledge-base/engineering/grok-onboarding.md`
+- `plugins/soleur/lib/harness.ts`'
+
+create_issue() {
+  local title="$1"
+  local body="$2"
+  gh issue create \
+    --repo jikig-ai/soleur \
+    --title "$title" \
+    --body "$body" \
+    --label "tracking,type/feature,domain/engineering,priority/p2-medium"
+}
+
+echo "==> Creating epic..."
+EPIC_URL=$(gh issue create \
+  --repo jikig-ai/soleur \
+  --title "epic: Grok Build fidelity — /go routes to Soleur workflows without improvisation" \
+  --body "$EPIC_BODY" \
+  --label "tracking,type/feature,domain/engineering,priority/p2-medium")
+EPIC_NUM="${EPIC_URL##*/}"
+echo "Epic: $EPIC_URL (#$EPIC_NUM)"
+
+PHASE_A_BODY="Child of epic #$EPIC_NUM.
+
+## Deliverables
+
+- [ ] Fix \`.grok/config.toml\` — project config supports \`[plugins]\`, \`[mcp_servers]\`, \`[permission]\` only (no \`permission_mode\`, no \`[compat.claude]\` per #6314 review)
+- [ ] CONTRIBUTING.md — Grok section with \`grok --trust\`, command naming (\`/go\` not \`/soleur:go\`)
+- [ ] \`plugins/soleur/commands/help.md\` — harness-aware command listing
+- [ ] \`knowledge-base/engineering/grok-onboarding.md\` — contributor brief
+
+## Acceptance
+
+- \`grok inspect\` from repo root lists soleur plugin
+- Docs consistently use \`/go\` for Grok and \`/soleur:go\` for Claude"
+
+PHASE_B_BODY="Child of epic #$EPIC_NUM.
+
+## Deliverables
+
+- [ ] \`plugins/soleur/lib/harness.ts\` — \`detectHarness()\`, \`formatSkillInvocation()\`, \`formatAgentSpawn()\`, \`invokeSkill()\`, \`spawnAgent()\`, \`routingInstructions()\`
+- [ ] \`plugins/soleur/test/harness.test.ts\` — bun tests for claude + grok fixtures
+- [ ] \`plugins/soleur/commands/go.md\` Step 2 — harness adapter section referencing lib/harness.ts
+
+## Acceptance
+
+- \`cd plugins/soleur && bun test test/harness.test.ts\` passes
+- No vendor \`if (grok)\` branches outside harness.ts"
+
+PHASE_C_BODY="Child of epic #$EPIC_NUM.
+
+## Deliverables
+
+- [ ] \`go.md\` routing hardening — eval-gate blocks, never-improvise enforcement
+- [ ] eval-harness skill — Grok arm for golden routing assertions
+
+## Acceptance
+
+- Eval gate covers Grok slash-command routing semantics
+- Regression test for \`/go\` → \`/one-shot\` style routes under Grok fixture"
+
+PHASE_E_BODY="Child of epic #$EPIC_NUM.
+
+## Problem
+
+\`grok inspect\` today shows ~1 agent while Claude discovers 68 across domain directories.
+
+## Deliverables
+
+- [ ] Agent manifest / compat scan fixes so all \`plugins/soleur/agents/**\` definitions appear in Grok
+- [ ] spawn_subagent can target domain agents (\`soleur:engineering:review:security-sentinel\`, etc.)
+
+## Acceptance
+
+- \`grok inspect\` agent count matches Claude plugin manifest count (±0)"
+
+PHASE_F_BODY="Child of epic #$EPIC_NUM.
+
+## Deliverables
+
+- [ ] CI contract test — \`grok inspect\` output includes soleur plugin, skills, agents thresholds
+- [ ] Golden-path eval — \`/go fix …\` routes to \`/one-shot\` under Grok harness fixture
+
+## Acceptance
+
+- Required check fails when inspect regresses
+- Golden eval runs in plugins/soleur test suite"
+
+echo "==> Creating child issues..."
+A_URL=$(create_issue "feat(grok): Phase A — Grok onboarding docs + config.toml fidelity" "$PHASE_A_BODY")
+B_URL=$(create_issue "feat(grok): Phase B — harness adapter (Skill/Task → slash/spawn_subagent)" "$PHASE_B_BODY")
+C_URL=$(create_issue "feat(grok): Phase C — go.md hardening + eval-harness Grok arm" "$PHASE_C_BODY")
+E_URL=$(create_issue "feat(grok): Phase E — 68 agents discoverable in grok inspect" "$PHASE_E_BODY")
+F_URL=$(create_issue "feat(grok): Phase F — fidelity CI (grok inspect contract + golden eval)" "$PHASE_F_BODY")
+
+A_NUM="${A_URL##*/}"
+B_NUM="${B_URL##*/}"
+C_NUM="${C_URL##*/}"
+E_NUM="${E_URL##*/}"
+F_NUM="${F_URL##*/}"
+
+echo "Phase A: $A_URL"
+echo "Phase B: $B_URL"
+echo "Phase C: $C_URL"
+echo "Phase D: #6316 (existing)"
+echo "Phase E: $E_URL"
+echo "Phase F: $F_URL"
+
+# Link children in epic body
+UPDATED_EPIC_BODY="${EPIC_BODY}
+
+## Tracking
+
+- $A_URL — Phase A
+- $B_URL — Phase B
+- $C_URL — Phase C
+- https://github.com/jikig-ai/soleur/issues/6316 — Phase D (ADR-110)
+- $E_URL — Phase E
+- $F_URL — Phase F"
+
+gh issue edit "$EPIC_NUM" --repo jikig-ai/soleur --body "$UPDATED_EPIC_BODY"
+
+echo "==> Running harness tests..."
+cd "$REPO_ROOT/plugins/soleur"
+bun test test/harness.test.ts
+
+echo "==> Creating worktree feat-grok-fidelity-ab..."
+cd "$REPO_ROOT"
+bash plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh create feat-grok-fidelity-ab --yes
+
+WT="$REPO_ROOT/.worktrees/feat-grok-fidelity-ab"
+FILES=(
+  .grok/config.toml
+  CONTRIBUTING.md
+  knowledge-base/engineering/grok-onboarding.md
+  plugins/soleur/lib/harness.ts
+  plugins/soleur/test/harness.test.ts
+  plugins/soleur/commands/go.md
+  plugins/soleur/commands/help.md
+  scripts/grok-fidelity-bootstrap.sh
+)
+
+for f in "${FILES[@]}"; do
+  if [[ -f "$REPO_ROOT/$f" ]]; then
+    mkdir -p "$(dirname "$WT/$f")"
+    cp "$REPO_ROOT/$f" "$WT/$f"
+  fi
+done
+
+cd "$WT"
+git add "${FILES[@]}"
+git status
+
+if git diff --cached --quiet; then
+  echo "warn: no staged changes — files may already match worktree" >&2
+else
+  git commit -m "feat: Grok fidelity Phase A+B — onboarding docs + harness adapter"
+fi
+
+git push -u origin feat-grok-fidelity-ab
+
+PR_URL=$(gh pr create \
+  --repo jikig-ai/soleur \
+  --head feat-grok-fidelity-ab \
+  --title "feat: Grok fidelity Phase A+B — onboarding + harness adapter" \
+  --body "## Changelog
+
+- Added \`plugins/soleur/lib/harness.ts\` — maps Claude Skill/Task invocations to Grok slash commands + spawn_subagent
+- Added harness unit tests (\`plugins/soleur/test/harness.test.ts\`)
+- Expanded CONTRIBUTING.md and new \`knowledge-base/engineering/grok-onboarding.md\` — Grok uses \`/go\` not \`/soleur:go\`
+- Updated \`help.md\` and \`go.md\` with harness-aware routing (never improvise)
+
+Closes #$A_NUM
+Closes #$B_NUM" \
+  --label "semver:minor")
+
+gh pr edit "${PR_URL##*/}" --repo jikig-ai/soleur --add-label "semver:minor" 2>/dev/null || true
+
+echo ""
+echo "=== Summary ==="
+echo "Epic:     $EPIC_URL"
+echo "Phase A:  $A_URL"
+echo "Phase B:  $B_URL"
+echo "Phase C:  $C_URL"
+echo "Phase D:  https://github.com/jikig-ai/soleur/issues/6316"
+echo "Phase E:  $E_URL"
+echo "Phase F:  $F_URL"
+echo "PR:       $PR_URL"
+echo "Worktree: $WT"


### PR DESCRIPTION
## Changelog
- `plugins/soleur/lib/harness.ts`: `detectHarness`, `invokeSkill`, `spawnAgent`, `routingInstructions` with `env === process.env` guard (fixes test false-positive for grok under Grok Build).
- `plugins/soleur/test/harness.test.ts`: 20 passing harness adapter tests (`bun test`).
- `plugins/soleur/commands/go.md`: Step 2.0 harness adapter + never-improvise routing contract; harness table (Claude Skill/Task vs Grok slash/spawn_subagent); /go entry.
- `plugins/soleur/commands/help.md`: harness-aware command blocks (Claude `/soleur:*` vs Grok bare `/go` etc.).
- `CONTRIBUTING.md`: updated Grok section — use `/go` not `/soleur:go`.
- `knowledge-base/engineering/grok-onboarding.md`: new contributor brief covering Grok Build setup, command naming, trust, and `.grok/config.toml` (from #6314).
- `scripts/grok-fidelity-bootstrap.sh`: automation helper (epic + children #6320–#6325 were pre-created manually; script not re-run for issue creation).

**Key harness semantics:**

| Harness | Skills                    | Agents         | Entry      |
|---------|---------------------------|----------------|------------|
| Claude  | Skill tool `soleur:<skill>` | Task tool      | `/soleur:go` |
| Grok    | Slash `/<skill>`          | `spawn_subagent` | `/go`      |

Closes #6321
Closes #6322