### PR TITLE
fix(worktree): reap orphaned Bash-sandbox temp at session-start to stop tmpfs exhaustion

### DIFF
--- a/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/soleur/skills/git-worktree/scripts/worktree-manager.sh
@@ -1868,6 +1868,11 @@ cleanup_merged_worktrees() {
   # Always clean up stale Claude tmp files (RAM-backed, can be huge)
   cleanup_claude_tmp
 
+  # Reap stale Bash-sandbox temp the harness orphans directly under /tmp. No
+  # settings.json/env lever exists to relocate or auto-clean it (verified against
+  # Claude Code docs 2026-07-11), so this session-start sweep is the only lever.
+  cleanup_stale_sandbox_tmp
+
   # Kill runaway processes that waste CPU (e.g., stuck gst-plugin-scanner)
   cleanup_runaway_processes
 
@@ -1960,6 +1965,66 @@ cleanup_claude_tmp() {
 
   if [[ $files_removed -gt 0 ]]; then
     echo -e "${GREEN}Cleaned $files_removed stale Claude task output(s), freed ~${total_freed} MB${NC}"
+  fi
+}
+
+# Reap stale Claude Code Bash-sandbox temp to reclaim tmpfs (RAM-backed /tmp).
+# Beyond cleanup_claude_tmp (which reaps /tmp/claude-<uid> task output), the Bash
+# sandbox leaves per-invocation artifacts DIRECTLY under /tmp that the harness does
+# not garbage-collect and that no settings.json/env option can relocate or auto-clean
+# (verified against Claude Code sandbox/application-data docs 2026-07-11: only
+# `cleanupPeriodDays` exists and it covers ~/.claude/projects/, not /tmp). On a small
+# tmpfs these starve the machine mid-run — the 2026-07-11 disk-full that interrupted a
+# planning subagent had ~10k dirs / ~23k dirents in /tmp. Two safely-reapable classes:
+#   - empty temp-dir shells left by mkdtemp callers      -> the dirent driver (~8.5k)
+#   - stale sandbox copies (child repo/apps/plugins/NOTICE or <id>/ssr) + creds copies
+#                                                        -> the space driver (~170M)
+# Reap is AGE-gated so a live in-flight sandbox (seconds-to-minutes old) is never
+# touched, SIGNATURE-gated so a random non-empty tmp dir another tool owns is spared,
+# and uses find -delete / rmdir (never rm -rf) to stay inside the repo rm-guardrail.
+# node-compile-cache is deliberately spared (a reusable Node V8 cache, not a leak).
+# Thresholds and the tmp root are env-overridable for unit testing.
+cleanup_stale_sandbox_tmp() {
+  local uid tmp_root empty_age stale_age
+  uid=$(id -u)
+  tmp_root="${SOLEUR_SANDBOX_TMP_ROOT:-/tmp}"
+  # Empty shells cannot hold live data; a short floor still spares a just-created
+  # dir about to be written. Non-empty copies get a full-day floor (a sandbox
+  # invocation lives seconds, so 24h is unambiguously orphaned).
+  empty_age="${SOLEUR_SANDBOX_EMPTY_MAX_AGE_MIN:-60}"
+  stale_age="${SOLEUR_SANDBOX_STALE_MAX_AGE_MIN:-1440}"
+  [[ -d "$tmp_root" ]] || return 0
+
+  local removed_empty=0 removed_stale=0 d
+
+  # 1) Empty temp-pattern dirs (the dirent driver). `-empty -type d` = empty dirs.
+  while IFS= read -r d; do
+    if rmdir "$d" 2>/dev/null; then
+      removed_empty=$((removed_empty + 1))
+    fi
+  done < <(find "$tmp_root" -mindepth 1 -maxdepth 1 -type d -empty -uid "$uid" \
+             -mmin +"$empty_age" -regextype posix-extended \
+             -regex "$tmp_root/[A-Za-z0-9_-]{15,}" 2>/dev/null)
+
+  # 2) Non-empty sandbox artifacts older than the stale floor, matched by signature.
+  while IFS= read -r d; do
+    case "$(basename "$d")" in
+      claude-creds-copy*) : ;;                       # harness credential copy
+      *)
+        # Only reap dirs bearing a known sandbox signature; never a random
+        # non-empty tmp dir some other tool owns.
+        [[ -d "$d/ssr" || -d "$d/repo" || -d "$d/apps" || -d "$d/plugins" || -e "$d/NOTICE" ]] || continue
+        ;;
+    esac
+    if find "$d" -delete 2>/dev/null; then
+      removed_stale=$((removed_stale + 1))
+    fi
+  done < <(find "$tmp_root" -mindepth 1 -maxdepth 1 -type d -uid "$uid" \
+             -mmin +"$stale_age" -regextype posix-extended \
+             -regex "$tmp_root/[A-Za-z0-9_-]{15,}" 2>/dev/null)
+
+  if [[ $removed_empty -gt 0 || $removed_stale -gt 0 ]]; then
+    echo -e "${GREEN}Reaped ${removed_empty} empty + ${removed_stale} stale sandbox temp dir(s) from ${tmp_root}${NC}"
   fi
 }
 

--- a/plugins/soleur/test/worktree-manager-sandbox-tmp-sweep.test.sh
+++ b/plugins/soleur/test/worktree-manager-sandbox-tmp-sweep.test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+# Tests for worktree-manager.sh cleanup_stale_sandbox_tmp() — the session-start
+# sweep that reaps stale Claude Code Bash-sandbox temp the harness orphans directly
+# under /tmp (no config lever exists to relocate/auto-clean it; verified 2026-07-11).
+#
+# Pins the two safety invariants that make an unconditional session-start sweep safe:
+#   - AGE gate: a fresh (in-flight) sandbox dir is NEVER reaped, only stale ones;
+#   - SIGNATURE gate: only known sandbox shapes (repo/apps/plugins/NOTICE/ssr child,
+#     or claude-creds-copy*) are reaped — a random non-empty tmp dir another tool
+#     owns is spared, and node-compile-cache (a reusable cache) is spared;
+#   - PATTERN gate: only /tmp/<15+-char> children match, and reaping uses
+#     find -delete / rmdir (never rm -rf), staying inside the repo rm-guardrail.
+#
+# The tmp root + age thresholds are env-overridable purely so this test can drive a
+# synthesized fixture instead of the real /tmp.
+#
+# Fixtures synthesized per cq-test-fixtures-synthesized-only.
+# Run: bash plugins/soleur/test/worktree-manager-sandbox-tmp-sweep.test.sh
+
+set -euo pipefail
+
+# Clear ALL git env vars that leak when this test runs inside a git hook/worktree.
+while IFS= read -r var; do
+  unset "$var" 2>/dev/null || true
+done < <(env | grep -oP '^GIT_\w+' || true)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+SCRIPT="$SCRIPT_DIR/../skills/git-worktree/scripts/worktree-manager.sh"
+
+echo "=== worktree-manager.sh cleanup_stale_sandbox_tmp() sweep ==="
+echo ""
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- Source the script inside a valid work-tree so the repo-readiness gate at the
+#     top passes. The BASH_SOURCE==$0 guard means main() does NOT run on source. ---
+WORKSPACE="$TMP/workspace"
+git init -q -b main "$WORKSPACE"
+git -C "$WORKSPACE" config user.email "test@test.local"
+git -C "$WORKSPACE" config user.name "Test"
+cd "$WORKSPACE"
+# shellcheck source=/dev/null
+source "$SCRIPT"
+
+OLD_MTIME='2020-01-01T00:00:00'   # unambiguously stale vs any sane threshold
+
+# Fixture tmp root the sweep operates on (NOT the real /tmp).
+FAKE_TMP="$TMP/faketmp"
+mkdir -p "$FAKE_TMP"
+
+exists() { [[ -e "$1" ]] && echo true || echo false; }
+
+# --- Build the fixture. A 15+-char basename is required to match the pattern gate.
+#     Parent dir mtime is stamped LAST (adding a child bumps it), so the age gate
+#     sees the intended value. ---
+
+# (a) empty stale shell -> REAPED
+mk_empty_stale="$FAKE_TMP/emptyStaleShell01"
+mkdir -p "$mk_empty_stale"; touch -d "$OLD_MTIME" "$mk_empty_stale"
+
+# (b) empty FRESH shell -> PRESERVED (in-flight safety; mtime = now)
+mk_empty_fresh="$FAKE_TMP/emptyFreshShell01"
+mkdir -p "$mk_empty_fresh"
+
+# (c) stale repo-copy sandbox (plugins/ child) -> REAPED
+mk_repo="$FAKE_TMP/repoCopySandbox01"
+mkdir -p "$mk_repo/plugins"; touch -d "$OLD_MTIME" "$mk_repo"
+
+# (d) stale ssr bundler dir -> REAPED
+mk_ssr="$FAKE_TMP/ssrBundlerDir00001"
+mkdir -p "$mk_ssr/ssr"; touch -d "$OLD_MTIME" "$mk_ssr"
+
+# (e) stale creds copy (name-matched) -> REAPED
+mk_creds="$FAKE_TMP/claude-creds-copy9"
+mkdir -p "$mk_creds/.claude"; touch -d "$OLD_MTIME" "$mk_creds"
+
+# (f) stale FRESH repo-copy -> PRESERVED (in-flight safety; mtime = now)
+mk_repo_fresh="$FAKE_TMP/repoCopyFresh0001"
+mkdir -p "$mk_repo_fresh/apps"
+
+# (g) stale node-compile-cache -> SPARED (reusable cache, not a leak)
+mk_ncc="$FAKE_TMP/node-compile-cache"
+mkdir -p "$mk_ncc/v22.22.2-x64-abc"; touch -d "$OLD_MTIME" "$mk_ncc"
+
+# (h) stale random NON-signature dir -> SPARED (unknown owner's data)
+mk_other="$FAKE_TMP/unknownToolDir0001"
+mkdir -p "$mk_other/somedata"; touch -d "$OLD_MTIME" "$mk_other"
+
+# (i) short-name empty stale dir (< 15 chars) -> SPARED (pattern gate)
+mk_short="$FAKE_TMP/shortEmpty"
+mkdir -p "$mk_short"; touch -d "$OLD_MTIME" "$mk_short"
+
+# --- Run the sweep against the fixture with default thresholds (60m empty / 24h stale).
+set +e
+SWEEP_OUT="$(SOLEUR_SANDBOX_TMP_ROOT="$FAKE_TMP" cleanup_stale_sandbox_tmp 2>"$TMP/sweep.err")"
+SWEEP_RC=$?
+set -e
+
+echo "Test 1: stale empty shell reaped"
+assert_eq "false" "$(exists "$mk_empty_stale")" "stale empty shell removed"
+
+echo "Test 2: FRESH empty shell preserved (in-flight safety)"
+assert_eq "true" "$(exists "$mk_empty_fresh")" "fresh empty shell preserved"
+
+echo "Test 3: stale repo-copy sandbox reaped (plugins/ signature)"
+assert_eq "false" "$(exists "$mk_repo")" "stale repo-copy removed"
+
+echo "Test 4: stale ssr bundler dir reaped"
+assert_eq "false" "$(exists "$mk_ssr")" "stale ssr dir removed"
+
+echo "Test 5: stale creds-copy reaped (name signature)"
+assert_eq "false" "$(exists "$mk_creds")" "stale creds-copy removed"
+
+echo "Test 6: FRESH repo-copy preserved (in-flight safety)"
+assert_eq "true" "$(exists "$mk_repo_fresh")" "fresh repo-copy preserved"
+
+echo "Test 7: node-compile-cache spared (reusable cache, not a leak)"
+assert_eq "true" "$(exists "$mk_ncc")" "node-compile-cache spared"
+
+echo "Test 8: unknown non-signature dir spared (safety)"
+assert_eq "true" "$(exists "$mk_other")" "unknown tool dir spared"
+
+echo "Test 9: short-name dir spared (pattern gate: <15 chars)"
+assert_eq "true" "$(exists "$mk_short")" "short-name dir spared"
+
+echo "Test 10: summary line reports the reap counts"
+assert_contains "$SWEEP_OUT" "Reaped" "summary line printed"
+# 1 empty (a) + 3 stale (c,d,e) reaped this run.
+assert_contains "$SWEEP_OUT" "1 empty + 3 stale" "counts: 1 empty + 3 stale"
+assert_eq "0" "$SWEEP_RC" "sweep returns 0"
+
+echo "Test 11: missing tmp root -> no-op, rc 0"
+set +e
+NOOP_OUT="$(SOLEUR_SANDBOX_TMP_ROOT="$TMP/does-not-exist" cleanup_stale_sandbox_tmp 2>&1)"
+NOOP_RC=$?
+set -e
+assert_eq "0" "$NOOP_RC" "missing tmp root returns 0"
+assert_eq "" "$NOOP_OUT" "missing tmp root prints nothing"
+
+echo "Test 12: second run is idempotent (nothing left to reap, no summary)"
+set +e
+SECOND_OUT="$(SOLEUR_SANDBOX_TMP_ROOT="$FAKE_TMP" cleanup_stale_sandbox_tmp 2>&1)"
+set -e
+if [[ "$SECOND_OUT" == *"Reaped"* ]]; then
+  echo "  FAIL: second run still reaped something"; FAIL=$((FAIL + 1))
+else
+  echo "  PASS: second run is a clean no-op"; PASS=$((PASS + 1))
+fi
+
+echo ""
+print_results


### PR DESCRIPTION
## Summary

The Claude Code Bash sandbox leaves per-invocation artifacts **directly under `/tmp`** that the harness never garbage-collects. On a small tmpfs this fills the disk mid-run — during a `/soleur:go 6307` session on 2026-07-11 a planning subagent hit a `/tmp` disk-full with **~10k dirs / ~23k dirents**. This adds a session-start sweep to reclaim them.

### What actually accumulates (measured, not assumed)

| Class | Count | Size | Origin |
|---|---|---|---|
| Empty `mkdtemp` shells (99% empty) | ~8,585 | ~87M | dirent driver |
| Repo-copy sandboxes (`repo`/`apps`/`plugins`/`NOTICE` child) | ~1,816 | **~170M** | space driver |
| `<id>/ssr` bundler dirs | 2 | ~12M | Next.js bundler |
| `node-compile-cache`, `claude-creds-copy*` | 2 | ~2.5M | Node runtime / harness creds |

All are Claude Code harness / Node runtime / bundler artifacts — **none created by Soleur skill code**, so creation can't be prevented from this repo.

### Why a sweep and not a config change

Verified against Claude Code sandbox + application-data docs (2026-07-11): **no `settings.json` key or env var** relocates `$TMPDIR`, disables per-command repo copying, or auto-cleans `/tmp`. `cleanupPeriodDays` covers `~/.claude/projects/` only. The periodic sweep is the only lever this repo owns. (The underlying orphaning looks like a harness lifecycle gap worth reporting upstream — out of scope here.)

### The fix

`worktree-manager.sh` already reaps `/tmp/claude-<uid>` task output via `cleanup_claude_tmp()` but nothing else. This adds a sibling `cleanup_stale_sandbox_tmp()` wired into the same session-start path (`cleanup_merged_worktrees`), with three safety gates:

- **AGE** — empty shells >60m, non-empty copies >24h; a live in-flight sandbox (seconds-to-minutes old) is never touched.
- **SIGNATURE** — only known sandbox shapes reaped; a random non-empty tmp dir another tool owns is spared, and `node-compile-cache` (a reusable Node V8 cache) is spared.
- **PATTERN** — only `/tmp/<15+-char>` children; `find -delete` / `rmdir`, never `rm -rf` (stays inside the repo rm-guardrail).

Thresholds and the tmp root are env-overridable purely for unit testing.

## Test

`plugins/soleur/test/worktree-manager-sandbox-tmp-sweep.test.sh` — 15 assertions: both reaped classes, all three safety gates (fresh / non-signature / short-name preserved), `node-compile-cache` spared, idempotency, and the missing-root no-op. Auto-discovered by the existing `plugins/soleur/test/*.test.sh` CI glob (`test-scripts` shard). Regression: `worktree-manager-stale-lock-diag` + `lease-protects-active` still green; `bash -n` + shellcheck add no new warnings.

## Changelog

Add `cleanup_stale_sandbox_tmp()` to the session-start worktree maintenance path: reaps orphaned Claude Code Bash-sandbox temp dirs from `/tmp` (age/signature/pattern-gated, `find -delete` only) to prevent tmpfs exhaustion during long autonomous runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)