### PR TITLE
test(rls-fuzz): un-baseline #6306 RPCs closed by migration 128 (green main)

### DIFF
--- a/apps/web-platform/test/rls-fuzz/rls-rpc.integration.test.ts
+++ b/apps/web-platform/test/rls-fuzz/rls-rpc.integration.test.ts
@@ -153,50 +153,13 @@ describe.skipIf(!ENABLED)("RLS/authz-fuzz — SECURITY DEFINER RPC bypass (local
     }
   });
 
-  // KNOWN_EXPOSURES — these LEAK today (harness found them, tracked by the issue).
-  // Each denial assertion runs under test.fails: green while the exposure stands,
-  // and RED the moment the grant is fixed (assertion starts passing) → un-baseline.
-  test.fails(`KNOWN-EXPOSURE ${KNOWN_EXPOSURES.find_stuck_active_conversations.issue}: find_stuck_active_conversations leaks cross-tenant rows`, async () => {
-    const rows = await rolledBack(async (t) => {
-      await t`set local role authenticated`;
-      await t.unsafe("select set_config('request.jwt.claims', $1, true)", [bClaims()]);
-      const [r] = await t.unsafe("select count(*)::int as n from find_stuck_active_conversations(0)");
-      return (r as unknown as { n: number }).n;
-    });
-    expect(rows, "denial would be 0 cross-tenant rows").toBe(0);
-  });
-
-  test.fails(`KNOWN-EXPOSURE ${KNOWN_EXPOSURES.acquire_conversation_slot.issue}: acquire_conversation_slot writes A's slot`, async () => {
-    const status = await rolledBack(async (t) => {
-      await t`set local role authenticated`;
-      await t.unsafe("select set_config('request.jwt.claims', $1, true)", [bClaims()]);
-      const [r] = await t.unsafe(`select status from acquire_conversation_slot('${ctx.userA}','${ctx.convA2}',5,'${ctx.wsA}')`);
-      return (r as unknown as { status: string }).status;
-    });
-    expect(status, "denial would refuse the cross-tenant acquire").not.toBe("ok");
-  });
-
-  test.fails(`KNOWN-EXPOSURE ${KNOWN_EXPOSURES.release_conversation_slot.issue}: release_conversation_slot deletes A's slot`, async () => {
-    const stillPresent = await rolledBack(async (t) => {
-      await t.unsafe(`insert into user_concurrency_slots (user_id,workspace_id,conversation_id) values ('${ctx.userA}','${ctx.wsA}','${ctx.convA}') on conflict do nothing`);
-      await t`set local role authenticated`;
-      await t.unsafe("select set_config('request.jwt.claims', $1, true)", [bClaims()]);
-      await t.unsafe(`select release_conversation_slot('${ctx.userA}','${ctx.convA}')`);
-      await t`reset role`; // observe within-txn as superuser
-      const [r] = await t.unsafe(`select count(*)::int as n from user_concurrency_slots where user_id='${ctx.userA}' and conversation_id='${ctx.convA}'`);
-      return (r as unknown as { n: number }).n;
-    });
-    expect(stillPresent, "denial would leave A's slot intact").toBeGreaterThan(0);
-  });
-
-  test.fails(`KNOWN-EXPOSURE ${KNOWN_EXPOSURES.touch_conversation_slot.issue}: touch_conversation_slot updates A's slot`, async () => {
-    const touched = await rolledBack(async (t) => {
-      await t.unsafe(`insert into user_concurrency_slots (user_id,workspace_id,conversation_id) values ('${ctx.userA}','${ctx.wsA}','${ctx.convA}') on conflict do nothing`);
-      await t`set local role authenticated`;
-      await t.unsafe("select set_config('request.jwt.claims', $1, true)", [bClaims()]);
-      const [r] = await t.unsafe(`select touch_conversation_slot('${ctx.userA}','${ctx.convA}') as n`);
-      return (r as unknown as { n: number }).n;
-    });
-    expect(touched, "denial would touch 0 of A's slots").toBe(0);
-  });
+  // KNOWN_EXPOSURES is empty: the #6306 exposures (find_stuck_active_conversations
+  // + acquire/release/touch_conversation_slot) were closed by migration 128
+  // (PR #6318), which revokes the residual anon/authenticated EXECUTE. Those fns
+  // no longer appear in the securityDefinerAuthenticatedFns catalog, so the AC8
+  // coverage gate above (stale = classified − catalog) enforces their removal from
+  // all three maps. The per-fn `test.fails` denial baselines were removed here as
+  // part of that un-baselining; the deploy-time verify/128_*.sql sentinel is the
+  // durable regression guard for the closed grant. Future KNOWN_EXPOSURES entries
+  // re-introduce a parametrized `test.fails` loop over the map.
 });

--- a/apps/web-platform/test/rls-fuzz/rpc-cases.ts
+++ b/apps/web-platform/test/rls-fuzz/rpc-cases.ts
@@ -95,8 +95,6 @@ export const EXCLUDED: Record<string, string> = {
   outbound_send_exists: "global recipient-hash / body-sha dedup namespace; not workspace-tenant scoped",
   record_outbound_send: "global recipient-hash send ledger; not workspace-tenant scoped",
   suppress_recipient: "global recipient-hash suppression ledger; not workspace-tenant scoped",
-  // trigger function — not meaningfully callable with cross-tenant params
-  release_slot_on_archive: "AFTER-trigger function on conversations; not a directly-callable RPC surface",
 };
 
 /**
@@ -105,22 +103,16 @@ export const EXCLUDED: Record<string, string> = {
  * default privileges left `authenticated` (and `anon`) an EXECUTE grant, and the
  * fn trusts caller-supplied params without an `auth.uid()` check. Tracked by the
  * issue; asserted under `test.fails` (green while exposed, RED once fixed).
+ *
+ * The #6306 exposures (find_stuck_active_conversations + acquire/release/touch_
+ * conversation_slot, plus the release_slot_on_archive trigger fn) were CLOSED by
+ * migration 128_revoke_definer_rpc_residual_grants (PR #6318): it revokes the
+ * residual anon/authenticated EXECUTE, so those fns drop out of the
+ * `securityDefinerAuthenticatedFns` catalog entirely and no longer belong in any
+ * of the three maps. Un-baselined here per the harness's own forced-un-baselining
+ * contract (this docstring, line 15-18) — the AC8 coverage gate's `stale` check
+ * (classified − catalog) fails until they are removed. Empty now (no tracked
+ * live exposure); the deploy-time `verify/128_*.sql` sentinel is the durable
+ * regression guard for the closed grant.
  */
-export const KNOWN_EXPOSURES: Record<string, { issue: string; note: string }> = {
-  find_stuck_active_conversations: {
-    issue: "#6306",
-    note: "returns (id,user_id) for ALL tenants' stuck conversations to any authenticated/anon caller",
-  },
-  acquire_conversation_slot: {
-    issue: "#6306",
-    note: "trusts p_user_id → an authenticated caller can occupy/exhaust ANOTHER tenant's concurrency slots",
-  },
-  release_conversation_slot: {
-    issue: "#6306",
-    note: "trusts p_user_id → an authenticated caller can delete ANOTHER tenant's concurrency slot",
-  },
-  touch_conversation_slot: {
-    issue: "#6306",
-    note: "trusts p_user_id → an authenticated caller can keep-alive ANOTHER tenant's concurrency slot",
-  },
-};
+export const KNOWN_EXPOSURES: Record<string, { issue: string; note: string }> = {};


### PR DESCRIPTION
## Summary

The #6256 RLS/authz-fuzz harness merged (PR #6255) with a `test.fails` baseline for the 5 #6306 RPCs. PR #6318's migration 128 then **closed** that exposure — so on `main`, the harness's AC8 coverage gate (`rls-rpc.integration.test.ts:116`, `stale = classified − catalog`) fails: the 5 fns are gone from the `securityDefinerAuthenticatedFns` catalog but still classified in `rpc-cases.ts`. `rls-fuzz` is not a required check, so #6318 auto-merged green on the required set; this restores `rls-fuzz` to green.

This is the un-baselining the harness's own docstring (`rpc-cases.ts:15-18`) mandates once the grant is fixed — the actionable form of #6306's AC4, which was un-actionable at plan time because the harness hadn't merged yet.

## Changelog

### Web Platform (test-only)
- Empty `KNOWN_EXPOSURES` (drop the 4 finder/slot entries).
- Remove `release_slot_on_archive` from `EXCLUDED` (revoked → out of catalog).
- Remove the 4 dangling `KNOWN-EXPOSURE` `test.fails` blocks (titles dereference `KNOWN_EXPOSURES.<fn>.issue` → collection-time crash once the map is empty; tsc is blind to `Record` index access).

## Test plan

- [x] `tsc --noEmit` clean.
- [x] `vitest run test/rls-fuzz/` collects without crashing (2 unit files pass, 3 integration skip without a local DSN); the coverage gate runs in CI's `rls-fuzz` job against the local stack with migration 128 applied.

Ref #6306. Follow-up to PR #6318.

Generated with [Claude Code](https://claude.com/claude-code)