### PR TITLE
feat(grok): Phase F — fidelity CI (grok inspect contract + golden eval) (#6325)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Phase F #6325 — Grok fidelity CI: grok inspect contract + /go golden-path eval.
+  # Job name `grok-fidelity` is load-bearing once pinned in ruleset-ci-required.tf.
+  grok-fidelity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2.1.2
+        with:
+          bun-version-file: ".bun-version"
+
+      - name: Install Grok CLI
+        run: |
+          set -euo pipefail
+          curl -fsSL https://x.ai/cli/install.sh | bash
+          echo "$HOME/.grok/bin" >> "$GITHUB_PATH"
+          grok --version
+
+      - name: Grok fidelity gate (inspect contract + golden-path eval)
+        run: bash plugins/soleur/scripts/grok-fidelity-gate.sh
+
   # Synthetic aggregator.
   #
   # LOAD-BEARING SUB-VALUE — this job is NOT redundant with

--- a/infra/github/ruleset-ci-required.tf
+++ b/infra/github/ruleset-ci-required.tf
@@ -189,6 +189,14 @@ resource "github_repository_ruleset" "ci_required" {
         context        = "rule-body-lint"
         integration_id = var.actions_integration_id
       }
+
+      # --- Tier 6: Grok fidelity gate (#6325 Phase F). Context is the JOB name
+      # `grok-fidelity` at .github/workflows/ci.yml — grok inspect contract +
+      # /go golden-path eval under Grok harness fixture.
+      required_check {
+        context        = "grok-fidelity"
+        integration_id = var.actions_integration_id
+      }
     }
 
     # Merge queue REVERTED (#5780 kill-switch, 2026-06-30). The queue was

--- a/infra/github/ruleset-ci-required.tf
+++ b/infra/github/ruleset-ci-required.tf
@@ -15,7 +15,7 @@
 #
 # Strict policy preserved (strict_required_status_checks_policy = true).
 #
-# Job-name contract: the 18 `context` strings below are public ABI for the
+# Job-name contract: the 19 `context` strings below are public ABI for the
 # branch-protection gate. A workflow job rename (`lint fixture content` ->
 # `lint-fixture-content`) silently un-requires the check until this resource
 # is updated in the same PR. See ADR-032 Sharp Edges.

--- a/knowledge-base/engineering/grok-onboarding.md
+++ b/knowledge-base/engineering/grok-onboarding.md
@@ -77,7 +77,12 @@ Canonical sources live under `plugins/soleur/agents/**`. After editing, regenera
 cd plugins/soleur && bun run scripts/sync-grok-agent-compat.ts
 ```
 
-CI drift check: `bun run scripts/sync-grok-agent-compat.ts --check` (required in Phase F #6325).
+CI drift checks (Phase F #6325):
+
+```bash
+bash plugins/soleur/scripts/grok-fidelity-gate.sh   # full gate (CI job grok-fidelity)
+cd plugins/soleur && bun run scripts/sync-grok-agent-compat.ts --check
+```
 
 ## References
 

--- a/plugins/soleur/lib/go-routing.ts
+++ b/plugins/soleur/lib/go-routing.ts
@@ -1,0 +1,88 @@
+/**
+ * /go routing dispatch — maps classified intent labels to registered skills/agents.
+ *
+ * Mirrors the eval-gate routing table in plugins/soleur/commands/go.md.
+ * Golden-path eval (Phase F #6325) asserts Grok slash_command dispatch fidelity.
+ */
+
+import { invokeSkill, spawnAgent, type Harness, type SkillInvocation, type AgentSpawn } from "./harness";
+
+/** Skill routes from go.md routing table (soleur: prefix stripped at dispatch). */
+export const GO_SKILL_ROUTES: Record<string, string> = {
+  fix: "one-shot",
+  drain: "drain-labeled-backlog",
+  "drain-prs": "drain-prs",
+  review: "review",
+  incident: "incident",
+  default: "brainstorm",
+};
+
+/** Agent routes (spawn_subagent / Task — never improvised workflows). */
+export const GO_AGENT_ROUTES: Record<string, string> = {
+  "clo-attestation": "clo",
+  "legal-threshold": "clo",
+};
+
+export type GoRouteTarget =
+  | { kind: "skill"; skill: string }
+  | { kind: "agent"; agent: string };
+
+/** Resolve a classified routing label to its registered target. */
+export function resolveGoRoute(label: string): GoRouteTarget {
+  if (label in GO_AGENT_ROUTES) {
+    return { kind: "agent", agent: GO_AGENT_ROUTES[label] };
+  }
+  const skill = GO_SKILL_ROUTES[label] ?? GO_SKILL_ROUTES.default;
+  return { kind: "skill", skill };
+}
+
+export type GoDispatch =
+  | { kind: "skill"; invocation: SkillInvocation }
+  | { kind: "agent"; spawn: AgentSpawn };
+
+/**
+ * Dispatch a classified /go route under the active harness.
+ * Pass `env` in tests to pin Grok vs Claude without mutating process.env.
+ */
+export function dispatchGoRoute(
+  label: string,
+  userInput: string,
+  env?: NodeJS.ProcessEnv,
+): GoDispatch {
+  const target = resolveGoRoute(label);
+  const prev = { ...process.env };
+
+  if (env) {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in env)) delete process.env[key];
+    }
+    Object.assign(process.env, env);
+  }
+
+  try {
+    if (target.kind === "agent") {
+      return { kind: "agent", spawn: spawnAgent(target.agent, userInput) };
+    }
+    return { kind: "skill", invocation: invokeSkill(target.skill, userInput) };
+  } finally {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in prev)) delete process.env[key];
+    }
+    Object.assign(process.env, prev);
+  }
+}
+
+/** Pin harness for deterministic golden-path tests. */
+export function grokTestEnv(): NodeJS.ProcessEnv {
+  return { GROK_HOME: "/home/user/.grok" };
+}
+
+export function claudeTestEnv(): NodeJS.ProcessEnv {
+  return { CLAUDECODE: "1" };
+}
+
+/** Expected Grok slash command for a skill route (golden-path assertion). */
+export function expectedGrokSlashCommand(skill: string, args?: string): string {
+  const trimmed = args?.trim();
+  return trimmed ? `/${skill} ${trimmed}` : `/${skill}`;
+}

--- a/plugins/soleur/lib/grok-inspect-contract.ts
+++ b/plugins/soleur/lib/grok-inspect-contract.ts
@@ -1,0 +1,167 @@
+/**
+ * Grok inspect contract — parse `grok inspect` output and validate Soleur fidelity thresholds.
+ *
+ * Phase F (#6325): CI contract test for plugin/skills/agents discoverability.
+ * Static artifact checks complement live `grok inspect` when the CLI is on PATH.
+ */
+
+import { Glob } from "bun";
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { resolve } from "path";
+import {
+  EXPECTED_SOLEUR_AGENT_COUNT,
+  AGENTS_MANIFEST_PATH,
+  PLUGIN_ROOT,
+} from "./agent-registry";
+
+export const REPO_ROOT = resolve(PLUGIN_ROOT, "../..");
+export const GROK_CONFIG_PATH = resolve(REPO_ROOT, ".grok/config.toml");
+
+/** Floor for soleur plugin skills in `grok inspect` Plugins section. */
+export const MIN_SOLEUR_PLUGIN_SKILL_COUNT = 90;
+
+export interface GrokInspectParsed {
+  soleurPluginListed: boolean;
+  soleurPluginSkillCount: number;
+  soleurProjectAgentCount: number;
+  totalSkillsListed: number;
+}
+
+/** Count soleur SKILL.md files on disk (canonical source). */
+export function countSoleurSkillsOnDisk(): number {
+  return Array.from(new Glob("skills/**/SKILL.md").scanSync(PLUGIN_ROOT)).length;
+}
+
+/** Count committed Grok compat stubs under `.grok/agents/`. */
+export function countGrokAgentStubs(): number {
+  const dir = resolve(REPO_ROOT, ".grok/agents");
+  try {
+    return readdirSync(dir).filter((f) => f.endsWith(".md")).length;
+  } catch {
+    return 0;
+  }
+}
+
+/** Parse `grok inspect` stdout for Soleur plugin + project agent rows. */
+export function parseGrokInspectOutput(output: string): GrokInspectParsed {
+  const lines = output.split("\n");
+  let soleurPluginListed = false;
+  let soleurPluginSkillCount = 0;
+  let soleurProjectAgentCount = 0;
+  let totalSkillsListed = 0;
+  let inAgents = false;
+
+  for (const line of lines) {
+    const skillsHeader = line.match(/^\s+Skills \((\d+)\)/);
+    if (skillsHeader) {
+      totalSkillsListed = Number(skillsHeader[1]);
+      inAgents = false;
+      continue;
+    }
+
+    if (/^\s+Agents \(\d+\)/.test(line)) {
+      inAgents = true;
+      continue;
+    }
+
+    if (inAgents && /^\s+Plugins \(\d+\)/.test(line)) {
+      inAgents = false;
+      continue;
+    }
+
+    if (inAgents && /soleur:[^\s]+\s+project/.test(line)) {
+      soleurProjectAgentCount++;
+      continue;
+    }
+
+    const pluginLine = line.match(/^\s+└ soleur \(project[^)]*\)\s+(\d+) skills/);
+    if (pluginLine) {
+      soleurPluginListed = true;
+      soleurPluginSkillCount = Number(pluginLine[1]);
+    }
+  }
+
+  return {
+    soleurPluginListed,
+    soleurPluginSkillCount,
+    soleurProjectAgentCount,
+    totalSkillsListed,
+  };
+}
+
+export interface StaticArtifactContract {
+  manifestCount: number;
+  stubCount: number;
+  skillCount: number;
+  grokConfigHasSoleur: boolean;
+}
+
+export function readStaticArtifactContract(): StaticArtifactContract {
+  const manifestPath = resolve(REPO_ROOT, AGENTS_MANIFEST_PATH);
+  let manifestCount = 0;
+  if (existsSync(manifestPath)) {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as { count?: number };
+    manifestCount = manifest.count ?? 0;
+  }
+
+  let grokConfigHasSoleur = false;
+  if (existsSync(GROK_CONFIG_PATH)) {
+    const cfg = readFileSync(GROK_CONFIG_PATH, "utf-8");
+    grokConfigHasSoleur =
+      /enabled\s*=\s*\[[^\]]*["']soleur["']/.test(cfg) ||
+      /paths\s*=\s*\[[^\]]*plugins\/soleur/.test(cfg);
+  }
+
+  return {
+    manifestCount,
+    stubCount: countGrokAgentStubs(),
+    skillCount: countSoleurSkillsOnDisk(),
+    grokConfigHasSoleur,
+  };
+}
+
+/** Return human-readable violation messages (empty = pass). */
+export function validateGrokInspectParsed(parsed: GrokInspectParsed): string[] {
+  const violations: string[] = [];
+  if (!parsed.soleurPluginListed) {
+    violations.push("soleur plugin missing from Plugins section");
+  }
+  if (parsed.soleurPluginSkillCount < MIN_SOLEUR_PLUGIN_SKILL_COUNT) {
+    violations.push(
+      `soleur plugin skill count ${parsed.soleurPluginSkillCount} < floor ${MIN_SOLEUR_PLUGIN_SKILL_COUNT}`,
+    );
+  }
+  if (parsed.soleurProjectAgentCount < EXPECTED_SOLEUR_AGENT_COUNT) {
+    violations.push(
+      `soleur project agents ${parsed.soleurProjectAgentCount} < expected ${EXPECTED_SOLEUR_AGENT_COUNT}`,
+    );
+  }
+  return violations;
+}
+
+/** Validate committed artifacts without invoking grok CLI. */
+export function validateStaticArtifacts(): string[] {
+  const violations: string[] = [];
+  const artifacts = readStaticArtifactContract();
+
+  if (!artifacts.grokConfigHasSoleur) {
+    violations.push(".grok/config.toml does not enable soleur plugin");
+  }
+  if (artifacts.manifestCount !== EXPECTED_SOLEUR_AGENT_COUNT) {
+    violations.push(
+      `agents.manifest.json count ${artifacts.manifestCount} !== ${EXPECTED_SOLEUR_AGENT_COUNT}`,
+    );
+  }
+  if (artifacts.stubCount !== EXPECTED_SOLEUR_AGENT_COUNT) {
+    violations.push(
+      `.grok/agents stub count ${artifacts.stubCount} !== ${EXPECTED_SOLEUR_AGENT_COUNT}`,
+    );
+  }
+  if (artifacts.skillCount < MIN_SOLEUR_PLUGIN_SKILL_COUNT) {
+    violations.push(
+      `on-disk soleur skills ${artifacts.skillCount} < floor ${MIN_SOLEUR_PLUGIN_SKILL_COUNT}`,
+    );
+  }
+
+  return violations;
+}

--- a/plugins/soleur/scripts/grok-fidelity-gate.sh
+++ b/plugins/soleur/scripts/grok-fidelity-gate.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Grok fidelity CI gate (Phase F #6325).
+#
+# Validates:
+#   1. Agent compat artifacts (sync-grok-agent-compat --check)
+#   2. Static + live grok inspect contract (bun tests)
+#   3. Golden-path /go routing under Grok harness fixture
+#
+# Usage: bash plugins/soleur/scripts/grok-fidelity-gate.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PLUGIN_ROOT="$REPO_ROOT/plugins/soleur"
+
+cd "$PLUGIN_ROOT"
+
+echo "==> sync-grok-agent-compat --check"
+bun run scripts/sync-grok-agent-compat.ts --check
+
+echo "==> grok inspect contract + golden-path eval"
+bun test test/grok-inspect-contract.test.ts test/go-routing-golden-path.test.ts
+
+if command -v grok >/dev/null 2>&1; then
+  echo "==> live grok inspect contract (CLI on PATH)"
+  INSPECT_OUT="$(mktemp)"
+  trap 'rm -f "$INSPECT_OUT"' EXIT
+  (cd "$REPO_ROOT" && grok inspect >"$INSPECT_OUT")
+  bun -e "
+    import { readFileSync } from 'fs';
+    import { parseGrokInspectOutput, validateGrokInspectParsed } from './lib/grok-inspect-contract.ts';
+    const out = readFileSync(process.argv[1], 'utf-8');
+    const parsed = parseGrokInspectOutput(out);
+    const violations = validateGrokInspectParsed(parsed);
+    if (violations.length) {
+      console.error('grok inspect contract violations:');
+      for (const v of violations) console.error('  -', v);
+      process.exit(1);
+    }
+    console.log('grok inspect contract OK:', parsed.soleurProjectAgentCount, 'project agents,', parsed.soleurPluginSkillCount, 'plugin skills');
+  " "$INSPECT_OUT"
+else
+  echo "WARNING: grok CLI not on PATH — static artifact tests ran; live inspect skipped"
+  exit 1
+fi
+
+echo "grok-fidelity-gate: PASS"

--- a/plugins/soleur/scripts/grok-fidelity-gate.sh
+++ b/plugins/soleur/scripts/grok-fidelity-gate.sh
@@ -12,6 +12,10 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 PLUGIN_ROOT="$REPO_ROOT/plugins/soleur"
 
+# Root package.json provides shared deps (e.g. yaml for agent-registry imports).
+cd "$REPO_ROOT"
+bun install --frozen-lockfile
+
 cd "$PLUGIN_ROOT"
 
 echo "==> sync-grok-agent-compat --check"

--- a/plugins/soleur/test/fixtures/grok-inspect/minimal-contract.txt
+++ b/plugins/soleur/test/fixtures/grok-inspect/minimal-contract.txt
@@ -1,0 +1,10 @@
+  Skills (10)
+  └ brainstorm                        plugin: soleur
+
+  Agents (67)
+  └ soleur:engineering:review:security-sentinel     project
+  └ soleur:support:ticket-triage                    project
+
+  Plugins (2)
+  └ soleur (project, enabled)         94 skills, 67 agents, hooks
+  └ other (user, enabled)             -

--- a/plugins/soleur/test/go-routing-golden-path.test.ts
+++ b/plugins/soleur/test/go-routing-golden-path.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import {
+  dispatchGoRoute,
+  resolveGoRoute,
+  expectedGrokSlashCommand,
+  grokTestEnv,
+  claudeTestEnv,
+  GO_SKILL_ROUTES,
+} from "../lib/go-routing";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { extractLabel } = require("../skills/eval-harness/scripts/parse-label.cjs");
+
+const GO_ROUTING_TASKS = resolve(
+  import.meta.dir,
+  "../skills/eval-harness/tasks/go-routing.jsonl",
+);
+const GO_ENUM_PATH = resolve(
+  import.meta.dir,
+  "../skills/eval-harness/enums/go-routes.json",
+);
+
+type GoldenRow = { vars: { input: string; golden_label: string } };
+
+function loadGoRoutingGoldenRows(): GoldenRow[] {
+  return readFileSync(GO_ROUTING_TASKS, "utf-8")
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as GoldenRow);
+}
+
+const GO_ENUM: string[] = JSON.parse(readFileSync(GO_ENUM_PATH, "utf-8"));
+
+describe("go-routing golden-path (Grok harness)", () => {
+  test('fix intent routes to /one-shot slash_command', () => {
+    const input =
+      "The dashboard throws a 500 when I click Export. It worked yesterday — can you fix it?";
+    const dispatch = dispatchGoRoute("fix", input, grokTestEnv());
+
+    expect(dispatch.kind).toBe("skill");
+    if (dispatch.kind !== "skill") return;
+
+    expect(dispatch.invocation.harness).toBe("grok");
+    expect(dispatch.invocation.tool).toBe("slash_command");
+    expect(dispatch.invocation.command).toBe(expectedGrokSlashCommand("one-shot", input));
+    expect(dispatch.invocation.instruction).toContain("Do NOT improvise");
+  });
+
+  test("all skill routes produce Grok slash commands (not soleur: prefix)", () => {
+    for (const [label, skill] of Object.entries(GO_SKILL_ROUTES)) {
+      const dispatch = dispatchGoRoute(label, "test args", grokTestEnv());
+      expect(dispatch.kind).toBe("skill");
+      if (dispatch.kind !== "skill") continue;
+
+      expect(dispatch.invocation.command).toBe(expectedGrokSlashCommand(skill, "test args"));
+      expect(dispatch.invocation.command).not.toMatch(/^\/soleur:/);
+    }
+  });
+
+  test("agent routes use spawn_subagent under Grok", () => {
+    const dispatch = dispatchGoRoute(
+      "legal-threshold",
+      "Customer DSAR deletion request",
+      grokTestEnv(),
+    );
+    expect(dispatch.kind).toBe("agent");
+    if (dispatch.kind !== "agent") return;
+
+    expect(dispatch.spawn.harness).toBe("grok");
+    expect(dispatch.spawn.tool).toBe("spawn_subagent");
+    expect(dispatch.spawn.agent).toBe("clo");
+  });
+
+  test("Claude harness preserves soleur: Skill tool for fix route", () => {
+    const dispatch = dispatchGoRoute("fix", "fix auth", claudeTestEnv());
+    expect(dispatch.kind).toBe("skill");
+    if (dispatch.kind !== "skill") return;
+
+    expect(dispatch.invocation.harness).toBe("claude");
+    expect(dispatch.invocation.tool).toBe("Skill");
+    expect(dispatch.invocation.command).toBe("soleur:one-shot");
+  });
+});
+
+describe("go-routing golden-path (eval-harness corpus)", () => {
+  test("fix golden row label resolves to one-shot skill", () => {
+    const rows = loadGoRoutingGoldenRows();
+    const fixRow = rows.find((r) => r.vars.golden_label === "fix");
+    expect(fixRow).toBeDefined();
+
+    const target = resolveGoRoute(fixRow!.vars.golden_label);
+    expect(target).toEqual({ kind: "skill", skill: "one-shot" });
+
+    const dispatch = dispatchGoRoute(fixRow!.vars.golden_label, fixRow!.vars.input, grokTestEnv());
+    expect(dispatch.kind).toBe("skill");
+    if (dispatch.kind === "skill") {
+      expect(dispatch.invocation.command).toMatch(/^\/one-shot /);
+    }
+  });
+
+  test("golden labels are members of go-routes enum", () => {
+    for (const row of loadGoRoutingGoldenRows()) {
+      expect(GO_ENUM).toContain(row.vars.golden_label);
+      // Simulated classifier output for harness dispatch smoke (no LLM).
+      const label = extractLabel(row.vars.golden_label, GO_ENUM);
+      expect(label).toBe(row.vars.golden_label);
+    }
+  });
+});

--- a/plugins/soleur/test/grok-inspect-contract.test.ts
+++ b/plugins/soleur/test/grok-inspect-contract.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { $ } from "bun";
+import {
+  parseGrokInspectOutput,
+  validateGrokInspectParsed,
+  validateStaticArtifacts,
+  countSoleurSkillsOnDisk,
+  MIN_SOLEUR_PLUGIN_SKILL_COUNT,
+  REPO_ROOT,
+} from "../lib/grok-inspect-contract";
+import { EXPECTED_SOLEUR_AGENT_COUNT } from "../lib/agent-registry";
+
+const FIXTURE = readFileSync(
+  resolve(import.meta.dir, "fixtures/grok-inspect/minimal-contract.txt"),
+  "utf-8",
+);
+
+function grokOnPath(): boolean {
+  try {
+    return Bun.spawnSync(["which", "grok"]).exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+describe("grok-inspect-contract parser", () => {
+  test("parses minimal fixture for soleur plugin + sample agent rows", () => {
+    const parsed = parseGrokInspectOutput(FIXTURE);
+    expect(parsed.soleurPluginListed).toBe(true);
+    expect(parsed.soleurPluginSkillCount).toBe(94);
+    expect(parsed.soleurProjectAgentCount).toBe(2);
+    // Threshold validation runs against live inspect + static artifacts, not this snippet.
+    expect(validateGrokInspectParsed({
+      ...parsed,
+      soleurProjectAgentCount: EXPECTED_SOLEUR_AGENT_COUNT,
+    })).toEqual([]);
+  });
+
+  test("flags missing soleur plugin", () => {
+    const parsed = parseGrokInspectOutput("  Plugins (1)\n  └ other (user) 1 skills\n");
+    expect(parsed.soleurPluginListed).toBe(false);
+    expect(validateGrokInspectParsed(parsed).length).toBeGreaterThan(0);
+  });
+});
+
+describe("grok-inspect-contract static artifacts", () => {
+  test("manifest, stubs, skills, and config meet thresholds", () => {
+    expect(validateStaticArtifacts()).toEqual([]);
+    expect(countSoleurSkillsOnDisk()).toBeGreaterThanOrEqual(MIN_SOLEUR_PLUGIN_SKILL_COUNT);
+  });
+
+  test("sync-grok-agent-compat --check passes", async () => {
+    const result = await $`bun run scripts/sync-grok-agent-compat.ts --check`
+      .cwd(resolve(REPO_ROOT, "plugins/soleur"))
+      .quiet()
+      .nothrow();
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grok-inspect-contract live inspect", () => {
+  test("grok inspect satisfies contract when grok is on PATH", async () => {
+    if (!grokOnPath()) {
+      console.log("SKIP: grok not on PATH — live inspect gate deferred to grok-fidelity CI job");
+      return;
+    }
+
+    const result = await $`grok inspect`.cwd(REPO_ROOT).quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+
+    const parsed = parseGrokInspectOutput(result.stdout.toString());
+    const violations = validateGrokInspectParsed(parsed);
+    expect(violations).toEqual([]);
+    expect(parsed.soleurProjectAgentCount).toBeGreaterThanOrEqual(EXPECTED_SOLEUR_AGENT_COUNT);
+    expect(parsed.soleurPluginSkillCount).toBeGreaterThanOrEqual(MIN_SOLEUR_PLUGIN_SKILL_COUNT);
+  }, 60_000);
+});

--- a/scripts/ci-required-ruleset-canonical-required-status-checks.json
+++ b/scripts/ci-required-ruleset-canonical-required-status-checks.json
@@ -70,5 +70,9 @@
   {
     "context": "rule-body-lint",
     "integration_id": 15368
+  },
+  {
+    "context": "grok-fidelity",
+    "integration_id": 15368
   }
 ]

--- a/scripts/required-checks.txt
+++ b/scripts/required-checks.txt
@@ -93,6 +93,10 @@ adr-ordinals
 # .github/actions/bot-pr-with-synthetic-checks/action.yml + ADR-092.
 rule-body-lint
 
+# #6325 Phase F — Grok fidelity gate. ci.yml `grok-fidelity` job: grok inspect
+# contract + /go golden-path eval. Always-runs; installs Grok CLI on ubuntu-latest.
+grok-fidelity
+
 # #4384 — legal-doc-cross-document-gate.yml jobs.enforce. Always-runs (no
 # path filter post-#4384) — synthetic needed for bot PRs only.
 enforce

--- a/tests/scripts/test-audit-ruleset-bypass.sh
+++ b/tests/scripts/test-audit-ruleset-bypass.sh
@@ -615,11 +615,12 @@ t_rsc_order_insensitive() {
   rm -rf "$tmp"
 }
 
-# T-rsc-7: real canonical RSC has 18 entries with CodeQL pinned to 57789.
+# T-rsc-7: real canonical RSC has 19 entries with CodeQL pinned to 57789.
 # Reconciled from the stale 5-check baseline to the Terraform-managed live set
 # (#4397); bumped 16->17 by #6049 (adr-ordinals reconciled from live); bumped
-# 17->18 by #6103 (rule-body-lint, ADR-091). The exact count is kept in lockstep
-# with infra/github/ruleset-ci-required.tf by T-rsc-9 below.
+# 17->18 by #6103 (rule-body-lint, ADR-091); bumped 18->19 by #6325
+# (grok-fidelity, Phase F). The exact count is kept in lockstep with
+# infra/github/ruleset-ci-required.tf by T-rsc-9 below.
 t_rsc_real_canonical_shape() {
   local real="$REPO_ROOT/scripts/ci-required-ruleset-canonical-required-status-checks.json"
   if [[ ! -f "$real" ]]; then
@@ -632,10 +633,10 @@ t_rsc_real_canonical_shape() {
   # Every non-CodeQL check is a GitHub Actions context (15368). A flattened
   # CodeQL integration_id would let github-actions[bot] spoof the GHAS gate.
   non_codeql_apps=$(jq -r '[.[] | select(.context!="CodeQL") | .integration_id] | unique | join(",")' < "$real")
-  if [[ "$n" == "18" && "$codeql_app" == "57789" && "$non_codeql_apps" == "15368" ]]; then
-    _report "T-rsc-7 real canonical RSC: 18 entries, CodeQL=57789, rest=15368" ok
+  if [[ "$n" == "19" && "$codeql_app" == "57789" && "$non_codeql_apps" == "15368" ]]; then
+    _report "T-rsc-7 real canonical RSC: 19 entries, CodeQL=57789, rest=15368" ok
   else
-    _report "T-rsc-7 real canonical RSC: 18 entries, CodeQL=57789, rest=15368" fail "n=$n codeql_app=$codeql_app non_codeql=$non_codeql_apps"
+    _report "T-rsc-7 real canonical RSC: 19 entries, CodeQL=57789, rest=15368" fail "n=$n codeql_app=$codeql_app non_codeql=$non_codeql_apps"
   fi
 }
 


### PR DESCRIPTION
## Summary

Phase F of epic #6320: CI gate ensuring Grok Build discovers Soleur correctly and `/go` routing golden-path eval passes under the Grok harness.

## Changes

- `plugins/soleur/lib/grok-inspect-contract.ts` — parse/validate `grok inspect` output
- `plugins/soleur/lib/go-routing.ts` — dispatch helpers for golden-path eval
- `plugins/soleur/scripts/grok-fidelity-gate.sh` — CI entry point
- `plugins/soleur/test/grok-inspect-contract.test.ts` + `go-routing-golden-path.test.ts`
- `.github/workflows/ci.yml` — new `grok-fidelity` job (installs Grok CLI)
- `infra/github/ruleset-ci-required.tf` + canonical JSON + `required-checks.txt` — pin `grok-fidelity` as required (apply-github-infra on merge)
- `knowledge-base/engineering/grok-onboarding.md` — gate commands

## Verification

```bash
bash plugins/soleur/scripts/grok-fidelity-gate.sh
bun test plugins/soleur/test/grok-inspect-contract.test.ts plugins/soleur/test/go-routing-golden-path.test.ts
```

Closes #6325