### PR TITLE
docs(learnings): 2 workflow learnings from the #6307 rls-fuzz deepening

### DIFF
--- a/knowledge-base/project/learnings/best-practices/2026-07-11-gitleaks-shared-non-test-helper-not-in-test-allowlist-and-scans-whole-diff-range.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-11-gitleaks-shared-non-test-helper-not-in-test-allowlist-and-scans-whole-diff-range.md
@@ -1,0 +1,85 @@
+---
+title: "A DSN/secret-shaped literal belongs in the gitleaks-allowlisted *.test.ts files, NOT a shared non-test helper — and CI gitleaks scans the whole diff RANGE, so a working-tree fix needs a history rewrite"
+date: 2026-07-11
+category: best-practices
+tags: [gitleaks, secret-scan, allowlist, test-fixtures, history-rewrite, diff-range, rls-fuzz]
+issue: 6307
+---
+
+# gitleaks: keep DSN literals in allowlisted test files, and remember it scans the whole diff range
+
+## Problem
+
+Extracting a shared test helper (`test/rls-fuzz/harness-fixture.ts`) out of three
+`*.integration.test.ts` files, I moved the local disposable-Postgres DSN default into
+the helper:
+
+```ts
+const DEFAULT_DSN = "postgres://<user>:<pass>@127.0.0.1:54322/postgres"; // real literal in source
+```
+
+(The real literal is the Supabase-CLI local default `postgres://<user>:<pass>@…` with
+`<user>`=`<pass>`=`postgres`; it is redacted here so THIS learning file — which lives under
+`knowledge-base/**/learnings/`, NOT in the gitleaks allowlist — does not itself trip the
+rule. That is the very trap this note is about.)
+
+CI's `gitleaks scan` failed: rule `database-url-with-password`, entropy 3.75. The exact
+same literal lives in the three original test files and passes — because `.gitleaks.toml`
+allowlists it via a **path pattern scoped to test files only**:
+
+```
+apps/web-platform/test/.*\.test\.(ts|tsx)$
+```
+
+`harness-fixture.ts` is a helper, **not** a `*.test.ts` file, so it fell outside the
+allowlist. Two compounding traps:
+
+1. **The literal is a non-secret** (the Supabase-CLI's well-known local default, user and
+   password both `postgres`, host `127.0.0.1`) but is secret-*shaped*, so it trips the
+   rule regardless.
+2. **CI gitleaks scans the whole PR diff RANGE** (`--log-opts="--no-merges BASE..HEAD"`),
+   not just the working tree. So after I removed the literal in a *new* commit, the scan
+   STILL failed — it saw the literal in the earlier commit that *added* the helper. A
+   working-tree fix is necessary but not sufficient.
+
+## Solution
+
+**Placement:** don't put a DSN/secret-shaped literal in a shared non-test helper. Keep it
+in the allowlisted `*.test.ts` files (each already defines
+`const DSN = process.env.RLS_FUZZ_DATABASE_URL ?? "<local default>"`) and have them pass
+it in — the helper's `connect(dsn: string)` takes a **required** arg (every caller already
+passed `connect(DSN)`, so the helper's own default was dead code). The helper then holds
+no literal and needs no allowlist widening — better than editing `.gitleaks.toml`, which
+the repo intentionally makes hard to widen (`lint-fixture-content` re-scans independently).
+
+**History:** because gitleaks scans the range, purge the literal from history. No `rebase -i`
+in this env — soft-reset to the branch base and recommit the (now-clean) tree:
+
+```
+BASE=$(git merge-base origin/main HEAD)
+git reset --soft "$BASE"    # keeps working tree + index, drops the offending commit
+git commit -F <clean message>
+git push --force-with-lease
+```
+
+(Fine for a squash-merge PR — the intermediate commits are collapsed anyway.) Verify
+locally against the repo config + the exact range before pushing:
+`gitleaks git -c .gitleaks.toml --log-opts="--no-merges origin/main..HEAD"`.
+
+## Key Insight
+
+Two independent facts, both easy to miss: (1) a gitleaks **path allowlist scoped to
+`*.test.ts` does not cover sibling helper modules** in the same directory — extracting
+shared code out of a test file can move a previously-allowlisted literal out of scope;
+(2) the PR scan is **range-based, not tree-based**, so removing a secret in a later commit
+does not clear a finding introduced by an earlier commit — the literal must leave *history*.
+Same class as the api-key-in-git-history cleanup, but for a non-secret that only needs to
+not *look* like one to the scanner: the cheapest fix is to never introduce the literal
+outside the allowlisted path in the first place.
+
+## Session Errors
+
+1. **DSN literal placed in the shared helper `harness-fixture.ts`** (outside the
+   `*.test.ts` allowlist) → CI gitleaks fail. Recovery: removed the literal (callers pass
+   DSN), soft-reset + recommit to purge it from history, force-push. Prevention: this
+   learning — keep secret-shaped literals in allowlisted test files, not extracted helpers.

--- a/knowledge-base/project/learnings/workflow-patterns/2026-07-11-plan-predating-sibling-migration-verify-live-catalog-at-work.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-07-11-plan-predating-sibling-migration-verify-live-catalog-at-work.md
@@ -1,0 +1,68 @@
+---
+title: "A plan authored against an unmerged PR's HEAD can go stale when a sibling migration lands — verify LIVE catalog facts at /work Phase 0, not the plan's quoted premises"
+date: 2026-07-11
+category: workflow-patterns
+tags: [plan-staleness, precondition-verification, rls-fuzz, catalog-facts, sibling-migration, dependency-rebase]
+issue: 6307
+---
+
+# A plan authored against an unmerged dependency can carry stale premises — re-verify the live catalog at /work
+
+## Problem
+
+The #6307 plan (deepen the RLS/authz-fuzz harness) was *deepened* on 2026-07-11
+against the **HEAD of the still-unmerged #6255 branch** (its hard dependency). It
+gated `/work` on "#6255 merged + rebase onto main," which is correct — but between
+plan time and merge, a **sibling migration** (`128_revoke_definer_rpc_residual_grants`,
+PR #6318) landed on that same branch and **closed #6306** (revoked the residual
+anon/authenticated EXECUTE on `find_stuck_active_conversations` +
+`acquire/release/touch_conversation_slot`).
+
+So the plan's **Item 4 — "drive the 4 #6306 fns under `anon`"** rested on a premise
+that was already false in the merged tree: those fns are revoked, dropped from the
+`securityDefinerAuthenticatedFns` catalog, and `KNOWN_EXPOSURES = {}`. The plan even
+*validated* the premise at plan time ("the four fns carry `has_function_privilege('anon',
+…)`") — but that was a plan-time reading of a moving target. A second premise was also
+stale: the plan assumed "Supabase default privileges grant anon EXECUTE broadly → the
+anon set ≈ authenticated set," but the LIVE anon-EXECUTE SECURITY DEFINER set was
+**empty** (0 fns).
+
+Both were caught at **/work Phase 0** by running the actual catalog query against the
+migrated local DB (`has_function_privilege('anon'/'authenticated', oid, 'EXECUTE')`)
+rather than trusting the plan — which is exactly what the plan's own G0.4 "confirm the
+premise against the live catalog" gate prescribed. Had the premises been trusted, Item 4
+would have produced test cases attacking fns that no longer exist in the catalog (a
+vacuous or un-compilable dimension).
+
+## Solution
+
+When a plan is authored against an **unmerged dependency's HEAD** and quotes catalog /
+grant / policy facts (`has_function_privilege`, `pg_policies` shapes, which fns are in
+`KNOWN_EXPOSURES`), treat every such fact as a **precondition to re-derive at /work
+Phase 0 against the freshly-migrated live DB**, not a fact. A sibling commit on the same
+dependency branch — especially a migration — can obsolete a whole plan item between plan
+and merge. Reconcile explicitly:
+
+- Item 4's concrete "attack the 4 #6306 fns under anon" was **dropped as obsolete**.
+- The **durable half** — a `securityDefinerAnonFns()` enumerator + an anon coverage gate
+  (a forward tripwire that reds if any *future* migration re-introduces an anon EXECUTE
+  grant, the exact #6306 root cause) — was shipped in its place. The reconciliation was
+  recorded in-code, in the ADR amendment, and surfaced to the operator before committing
+  the rest of the pipeline.
+
+## Key Insight
+
+"The plan validated the premise at plan time" is NOT "the premise holds at /work" when
+the plan predates the dependency's merge. This is `hr-when-a-plan-specifies-relative-paths-e-g`
+and the "plan-quoted numbers are preconditions to verify" rule applied to **catalog
+state**: the highest-risk staleness is not a line number but a *grant/policy fact a
+sibling migration silently flipped*. Re-run the authoritative query at Phase 0; if it
+falsifies a plan item, salvage the durable/general capability (an enumerator tripwire
+that would have auto-caught the very thing that changed) rather than either forcing the
+obsolete work or dropping the item entirely.
+
+## Session Errors
+
+None materialised — the /work Phase 0 catalog verification caught the stale premises
+before any obsolete code was written. Recorded here so the next plan-against-unmerged-
+dependency run re-derives catalog facts by default.


### PR DESCRIPTION
Captures two reusable learnings surfaced while shipping #6307 (the RLS/authz-fuzz harness deepening, merged in #6319):

1. **Plan predating an unmerged dependency** — a plan deepened against #6255's HEAD carried stale catalog premises after sibling migration 128 (#6318) closed #6306; the fix is to re-verify live catalog facts at /work Phase 0 and salvage the durable capability (an enumerator tripwire) rather than force the obsolete work.
2. **gitleaks placement + range scan** — a DSN literal in a shared non-test helper isn't covered by the `*.test.ts` allowlist, and CI scans the whole diff range so a working-tree fix needs a history rewrite.

Docs-only. No code paths touched.

## Changelog

Add two `knowledge-base/project/learnings/` files (workflow-patterns + best-practices) from the #6307 session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)