### PR TITLE
feat(infra): gate co-located inngest bootstrap behind web_colocate_inngest (default false)

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -150,12 +150,18 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # #6178: the cloud-init-inngest-bootstrap drift-guard (below) now includes an
-      # AC7 terraform-render leg that is the SINGLE behavioral authority for the
-      # web_colocate_inngest gate (only a real `terraform templatefile` render exercises
-      # the load-bearing `~}` whitespace-strip). Without terraform on PATH the leg SKIPs
-      # (a "maybe-run" test is not a gate) — this step makes it run for real in CI.
+      # #6178: the cloud-init-inngest-bootstrap drift-guard (below) includes an AC7
+      # terraform-render leg — the behavioral authority for the web_colocate_inngest gate
+      # (only a real `terraform templatefile` render exercises the load-bearing `~}`
+      # whitespace-strip). Without terraform on PATH the leg SKIPs; this step makes it
+      # execute (a broken gate then reds this job's log). NOTE: deploy-script-tests is an
+      # advisory job (not in ruleset-ci-required.tf) — this is a visible-red signal, not a
+      # merge-blocking gate. terraform_wrapper: false keeps `terraform console` stdout
+      # byte-clean so the render leg's heredoc-strip (render_yaml_ok, which depends on the
+      # last output line being exactly `EOT`) is not corrupted by the default log wrapper.
       - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_wrapper: false
 
       - name: Run ci-deploy.sh tests
         run: bash apps/web-platform/infra/ci-deploy.test.sh

--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -150,6 +150,13 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # #6178: the cloud-init-inngest-bootstrap drift-guard (below) now includes an
+      # AC7 terraform-render leg that is the SINGLE behavioral authority for the
+      # web_colocate_inngest gate (only a real `terraform templatefile` render exercises
+      # the load-bearing `~}` whitespace-strip). Without terraform on PATH the leg SKIPs
+      # (a "maybe-run" test is not a gate) — this step makes it run for real in CI.
+      - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+
       - name: Run ci-deploy.sh tests
         run: bash apps/web-platform/infra/ci-deploy.test.sh
 

--- a/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
+++ b/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
@@ -250,9 +250,11 @@ ENDIF_LINE=$(grep -nE '^%\{ endif ~\}$' "$CLOUD_INIT" | head -1 | cut -d: -f1)
 TRAP_DISARM_LINE=$(grep -nE 'disarm, else the composite trap' "$CLOUD_INIT" | head -1 | cut -d: -f1)
 assert "if-directive precedes the bootstrap comment"        "(( IF_LINE < COMMENT_LINE ))"
 assert "endif-directive follows the block's trap disarm"    "(( ENDIF_LINE > TRAP_DISARM_LINE ))"
-# `type = bool` is LOAD-BEARING: `%{ if web_colocate_inngest }` is truthy for ANY
-# non-empty string, so the rollback route TF_VAR_web_colocate_inngest="false" (a string)
-# gates correctly ONLY because the variable coerces the string to boolean false.
+# `type = bool` is LOAD-BEARING: Terraform's `%{ if }` directive HCL-bool-converts its
+# operand — the canonical string "false" coerces to boolean false (the rollback route
+# TF_VAR_web_colocate_inngest="false"), and a non-bool string fails CLOSED at plan time
+# ("condition must be of type bool"). `type = bool` pins the variable-boundary contract;
+# the render leg's "false" (string) case exercises the coercion end-to-end.
 assert "web_colocate_inngest declared type = bool (load-bearing string→bool coercion)" \
   "awk '/variable \"web_colocate_inngest\"/,/^}/' '$VARS_TF' | grep -qE 'type[[:space:]]*=[[:space:]]*bool'"
 
@@ -293,8 +295,12 @@ PY
       "grep -qF 'name soleur-web-platform' '$OUT'"
     assert "render web_colocate_inngest=$CASE RETAINS INNGEST_BASE_URL" \
       "grep -qF 'INNGEST_BASE_URL' '$OUT'"
-    assert "render web_colocate_inngest=$CASE RETAINS fail-closed /run/soleur-hostscripts.ok gate" \
-      "grep -qF 'soleur-hostscripts.ok' '$OUT'"
+    # Retention token = the poweroff item's UNIQUE fail-closed action string (cloud-init.yml
+    # ~:710), NOT the bare 'soleur-hostscripts.ok' (which also appears in pre-gate comments
+    # :440/:527 and would match regardless of endif placement — user-impact-review hardening
+    # against a vacuous retention assertion).
+    assert "render web_colocate_inngest=$CASE RETAINS fail-closed 'refusing to start app' poweroff gate" \
+      "grep -qF 'refusing to start app' '$OUT'"
     assert "render web_colocate_inngest=$CASE is valid YAML" "render_yaml_ok '$OUT'"
   done
   # true (bool) keeps the co-located bootstrap.

--- a/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
+++ b/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
@@ -130,11 +130,15 @@ else
   echo "  SKIP: dash not installed (POSIX portability check skipped — CI will exercise it)"
 fi
 
-# --- AC3: YAML round-trip ---
+# --- AC3: YAML round-trip (raw source, templatefile directives stripped) ---
+# #6178: cloud-init.yml now carries col-0 `%{ if web_colocate_inngest ~}` / `%{ endif ~}`
+# templatefile directives. YAML rejects `%` at column 0 (directive indicator → ScannerError),
+# so strip those directive lines before parsing the NON-rendered source. Rendered-state YAML
+# validity is asserted once, in the AC7 terraform-render leg — the single home for that property.
 echo ""
-echo "--- AC3: cloud-init.yml YAML round-trip ---"
-assert "cloud-init.yml parses as valid YAML" \
-  "python3 -c \"import yaml; yaml.safe_load(open('$CLOUD_INIT'))\""
+echo "--- AC3: cloud-init.yml YAML round-trip (directives stripped) ---"
+assert "cloud-init.yml (templatefile directives stripped) parses as valid YAML" \
+  "grep -v '^%{' '$CLOUD_INIT' | python3 -c \"import sys,yaml; yaml.safe_load(sys.stdin)\""
 
 # --- AC5: sudoers byte-parity between source file and cloud-init inline (#4144) ---
 # The same Cmnd_Alias/Defaults/deploy lines live in three places:
@@ -228,6 +232,83 @@ PIN_REF_COUNT=$(grep -coE 'soleur-inngest-bootstrap:v[0-9]+\.[0-9]+\.[0-9]+' "$C
 DISTINCT_PINS=$(grep -oE 'soleur-inngest-bootstrap:v[0-9]+\.[0-9]+\.[0-9]+' "$CLOUD_INIT" | sort -u | wc -l)
 assert "both soleur-inngest-bootstrap pin refs (IREF + ZIREF) present and share one tag (found $PIN_REF_COUNT refs, $DISTINCT_PINS distinct)" \
   "(( PIN_REF_COUNT == 2 && DISTINCT_PINS == 1 ))"
+
+# --- AC7: web_colocate_inngest gate (#6178) — structural smoke ---
+# The "Bootstrap Inngest server on first boot" runcmd item is wrapped in a col-0
+# templatefile `%{ if web_colocate_inngest ~}` / `%{ endif ~}` directive pair so a
+# freshly-created web host with the toggle false does NOT co-locate inngest.
+echo ""
+echo "--- AC7: web_colocate_inngest gate — structural ---"
+VARS_TF="$SCRIPT_DIR/variables.tf"
+assert "exactly one col-0 '%{ if web_colocate_inngest ~}' directive" \
+  "(( \$(grep -cE '^%\{ if web_colocate_inngest ~\}$' '$CLOUD_INIT') == 1 ))"
+assert "exactly one col-0 '%{ endif ~}' directive" \
+  "(( \$(grep -cE '^%\{ endif ~\}$' '$CLOUD_INIT') == 1 ))"
+IF_LINE=$(grep -nE '^%\{ if web_colocate_inngest ~\}$' "$CLOUD_INIT" | head -1 | cut -d: -f1)
+COMMENT_LINE=$(grep -nE 'Bootstrap Inngest server on first boot' "$CLOUD_INIT" | head -1 | cut -d: -f1)
+ENDIF_LINE=$(grep -nE '^%\{ endif ~\}$' "$CLOUD_INIT" | head -1 | cut -d: -f1)
+TRAP_DISARM_LINE=$(grep -nE 'disarm, else the composite trap' "$CLOUD_INIT" | head -1 | cut -d: -f1)
+assert "if-directive precedes the bootstrap comment"        "(( IF_LINE < COMMENT_LINE ))"
+assert "endif-directive follows the block's trap disarm"    "(( ENDIF_LINE > TRAP_DISARM_LINE ))"
+# `type = bool` is LOAD-BEARING: `%{ if web_colocate_inngest }` is truthy for ANY
+# non-empty string, so the rollback route TF_VAR_web_colocate_inngest="false" (a string)
+# gates correctly ONLY because the variable coerces the string to boolean false.
+assert "web_colocate_inngest declared type = bool (load-bearing string→bool coercion)" \
+  "awk '/variable \"web_colocate_inngest\"/,/^}/' '$VARS_TF' | grep -qE 'type[[:space:]]*=[[:space:]]*bool'"
+
+# --- AC7: web_colocate_inngest gate — terraform render authority ---
+# The single behavioral authority for the gate's effect. A real `terraform templatefile`
+# render is the ONLY thing that exercises the load-bearing `~}` whitespace-strip; the
+# rendered-YAML validity property also lives here (not duplicated in AC3). SKIP locally
+# when terraform is absent — CI's deploy-script-tests job supplies it via setup-terraform.
+echo ""
+echo "--- AC7: web_colocate_inngest gate — terraform render authority ---"
+if command -v terraform >/dev/null 2>&1; then
+  RENDER_SCRATCH=$(mktemp -d)
+  # Render the web cloud-init with a given web_colocate_inngest value into $2.
+  # All map vars are placeholders EXCEPT the toggle; keep in sync with server.tf's
+  # templatefile map — a new map var breaks this render (the intended tripwire).
+  render_ci() {
+    printf 'templatefile("%s", { image_name="i", fail2ban_sshd_local_b64="x", host_scripts_content_hash="h", tunnel_token="t", webhook_deploy_secret="w", doppler_token="d", sentry_dsn="s", resend_api_key="r", ghcr_read_user="u", ghcr_read_token="g", ci_ssh_public_key_openssh="k", web_colocate_inngest=%s })\n' \
+      "$CLOUD_INIT" "$1" | terraform -chdir="$RENDER_SCRATCH" console 2>/dev/null > "$2"
+  }
+  # yaml.safe_load a rendered doc, stripping terraform console's `<<EOT … EOT` heredoc wrapper.
+  render_yaml_ok() {
+    python3 - "$1" <<'PY'
+import sys, yaml
+L = open(sys.argv[1]).read().splitlines()
+body = "\n".join(L[1:-1]) if (L and L[0].lstrip().startswith("<<")) else "\n".join(L)
+yaml.safe_load(body)
+PY
+  }
+  # false (bool) and "false" (string, the rollback route) must BOTH gate off.
+  for CASE in 'false' '"false"'; do
+    OUT="$RENDER_SCRATCH/render.txt"
+    render_ci "$CASE" "$OUT"
+    assert "render web_colocate_inngest=$CASE OMITS soleur-inngest-bootstrap image pull" \
+      "! grep -qF 'soleur-inngest-bootstrap' '$OUT'"
+    assert "render web_colocate_inngest=$CASE OMITS the inngest-bootstrap.sh invocation" \
+      "! grep -qF 'EXTRACT_DIR/inngest-bootstrap.sh' '$OUT'"
+    assert "render web_colocate_inngest=$CASE RETAINS --name soleur-web-platform (app bring-up)" \
+      "grep -qF 'name soleur-web-platform' '$OUT'"
+    assert "render web_colocate_inngest=$CASE RETAINS INNGEST_BASE_URL" \
+      "grep -qF 'INNGEST_BASE_URL' '$OUT'"
+    assert "render web_colocate_inngest=$CASE RETAINS fail-closed /run/soleur-hostscripts.ok gate" \
+      "grep -qF 'soleur-hostscripts.ok' '$OUT'"
+    assert "render web_colocate_inngest=$CASE is valid YAML" "render_yaml_ok '$OUT'"
+  done
+  # true (bool) keeps the co-located bootstrap.
+  TRUE_OUT="$RENDER_SCRATCH/render-true.txt"
+  render_ci true "$TRUE_OUT"
+  assert "render web_colocate_inngest=true INCLUDES soleur-inngest-bootstrap image pull" \
+    "grep -qF 'soleur-inngest-bootstrap' '$TRUE_OUT'"
+  assert "render web_colocate_inngest=true INCLUDES the inngest-bootstrap.sh invocation" \
+    "grep -qF 'EXTRACT_DIR/inngest-bootstrap.sh' '$TRUE_OUT'"
+  assert "render web_colocate_inngest=true is valid YAML" "render_yaml_ok '$TRUE_OUT'"
+  rm -rf "$RENDER_SCRATCH"
+else
+  echo "  SKIP: terraform not installed (render authority skipped — CI deploy-script-tests provides it via setup-terraform)"
+fi
 
 echo ""
 echo "=== Results: $PASS/$TOTAL passed ==="

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -633,7 +633,12 @@ runcmd:
     printf '%s\n' "seeded $(date -u +%Y-%m-%dT%H:%M:%SZ) tag=cloud-init" \
       > /mnt/data/plugins/soleur/.seed-complete
 
+%{ if web_colocate_inngest ~}
   # Bootstrap Inngest server on first boot (#4118, Tier 1).
+  # #6178: this whole runcmd item is gated behind web_colocate_inngest (default false).
+  # When false (post-cutover), a freshly-created web host does NOT extract/run
+  # inngest-bootstrap.sh, so inngest-server.service / inngest-heartbeat.timer are never
+  # authored or enabled — scheduling lives on the dedicated soleur-inngest host (ADR-100).
   # Pinned image tag = the soleur-inngest-bootstrap OCI image version (the
   # bootstrap-script SHAPE version), NOT the inngest-cli version (the latter is
   # sourced from the image's Config.Env at run time). This pin MUST be bumped to
@@ -692,6 +697,7 @@ runcmd:
         "VECTOR_CLI_VERSION=$VECTOR_CLI_VERSION" "VECTOR_CLI_SHA256=$VECTOR_CLI_SHA256" \
       bash "$EXTRACT_DIR/inngest-bootstrap.sh"
     trap - EXIT  # #6090: disarm, else the composite trap mislabels terminal-block failures as inngest_bootstrap.
+%{ endif ~}
 
   - |
     set -e

--- a/apps/web-platform/infra/journald-config.test.sh
+++ b/apps/web-platform/infra/journald-config.test.sh
@@ -167,11 +167,15 @@ assert "soleur-web-platform container-start found"          "[[ -n '$WEBPLATFORM
 assert "the bootstrap runs BEFORE the container starts" \
   "(( EXTRACT_LINE < WEBPLATFORM_LINE ))"
 
-# --- AC6: cloud-init.yml still parses as valid YAML ---
+# --- AC6: cloud-init.yml still parses as valid YAML (templatefile directives stripped) ---
+# #6178: cloud-init.yml carries col-0 `%{ if web_colocate_inngest ~}` / `%{ endif ~}`
+# templatefile directives (YAML rejects `%` at column 0 as a directive indicator). Strip
+# them before parsing the NON-rendered source — same fix as cloud-init-inngest-bootstrap.test.sh
+# AC3. Rendered-state YAML validity is asserted in that file's terraform-render leg.
 echo ""
-echo "--- AC6: cloud-init.yml YAML round-trip ---"
-assert "cloud-init.yml parses as valid YAML" \
-  "python3 -c \"import yaml; yaml.safe_load(open('$CLOUD_INIT'))\""
+echo "--- AC6: cloud-init.yml YAML round-trip (directives stripped) ---"
+assert "cloud-init.yml (templatefile directives stripped) parses as valid YAML" \
+  "grep -v '^%{' '$CLOUD_INIT' | python3 -c \"import sys,yaml; yaml.safe_load(sys.stdin)\""
 
 # --- AC7: cat-deploy-state.sh exposes journald_storage (no-SSH verification) ---
 echo ""

--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -164,6 +164,10 @@ resource "hcloud_server" "web" {
     # ci-ssh-key.tf. local.ci_ssh_pubkey is trimspaced — see locals{}
     # block in ci-ssh-key.tf for the rationale.
     ci_ssh_public_key_openssh = local.ci_ssh_pubkey
+    # #6178 — gates the "Bootstrap Inngest server on first boot" runcmd item via a
+    # templatefile `%{ if web_colocate_inngest }` directive. Default false (dedicated
+    # scheduler, ADR-100). Bool is load-bearing (see variables.tf).
+    web_colocate_inngest = var.web_colocate_inngest
   }))
 
   # cloud-init and ssh_keys are create-time attributes. After import,

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -343,9 +343,10 @@ variable "ghcr_read_token" {
 # behavior). Default false: scheduling lives on the dedicated soleur-inngest host
 # (10.0.1.40, ADR-100). Recreate-onto-false-config is the quiesce mechanism
 # (hr-prod-host-config-change-immutable-redeploy); rollback = set true + recreate.
-# `type = bool` is LOAD-BEARING: the cloud-init `%{ if web_colocate_inngest }`
-# directive is truthy for ANY non-empty string, so a drift to `type = string` would
-# make the rollback route `TF_VAR_web_colocate_inngest="false"` (a string) always-truthy.
+# `type = bool` is LOAD-BEARING: Terraform's `%{ if }` directive HCL-bool-converts its
+# operand — the string "false" coerces to boolean false, so the rollback route
+# `TF_VAR_web_colocate_inngest="false"` gates OFF correctly (and a non-bool string fails
+# closed at plan time). Pinning `type = bool` keeps the variable-boundary contract explicit.
 variable "web_colocate_inngest" {
   description = "When true, a freshly-created web host bootstraps + enables the co-located inngest-server.service (pre-cutover). Default false: scheduling lives on the dedicated soleur-inngest host (10.0.1.40, ADR-100, #6178). Recreate is the quiesce mechanism (hr-prod-host-config-change-immutable-redeploy)."
   type        = bool

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -337,3 +337,17 @@ variable "ghcr_read_token" {
   type        = string
   sensitive   = true
 }
+
+# #6178 — post-cutover web-host scheduling toggle. When true, a freshly-CREATED web
+# host bootstraps + enables the co-located inngest-server.service (pre-cutover
+# behavior). Default false: scheduling lives on the dedicated soleur-inngest host
+# (10.0.1.40, ADR-100). Recreate-onto-false-config is the quiesce mechanism
+# (hr-prod-host-config-change-immutable-redeploy); rollback = set true + recreate.
+# `type = bool` is LOAD-BEARING: the cloud-init `%{ if web_colocate_inngest }`
+# directive is truthy for ANY non-empty string, so a drift to `type = string` would
+# make the rollback route `TF_VAR_web_colocate_inngest="false"` (a string) always-truthy.
+variable "web_colocate_inngest" {
+  description = "When true, a freshly-created web host bootstraps + enables the co-located inngest-server.service (pre-cutover). Default false: scheduling lives on the dedicated soleur-inngest host (10.0.1.40, ADR-100, #6178). Recreate is the quiesce mechanism (hr-prod-host-config-change-immutable-redeploy)."
+  type        = bool
+  default     = false
+}

--- a/knowledge-base/project/learnings/2026-07-11-col0-templatefile-directive-breaks-raw-yaml-parsers-sweep-all.md
+++ b/knowledge-base/project/learnings/2026-07-11-col0-templatefile-directive-breaks-raw-yaml-parsers-sweep-all.md
@@ -1,0 +1,83 @@
+---
+title: "A col-0 templatefile `%{ if }` directive in cloud-init.yml breaks EVERY test that raw yaml.safe_loads it — sweep all raw parsers"
+date: 2026-07-11
+category: test-failures
+module: apps/web-platform/infra
+tags: [terraform, templatefile, cloud-init, yaml, orphan-suite, write-boundary-sweep, inngest-cutover]
+related_pr: 6344
+related_issue: 6178
+---
+
+# Learning: col-0 templatefile directives break raw YAML parsers of the same file
+
+## Problem
+
+Gating a cloud-init runcmd block behind a Terraform `templatefile` conditional requires
+**column-0** directive lines (`%{ if web_colocate_inngest ~}` / `%{ endif ~}`) — an indented
+directive both fails raw-parse AND corrupts the render (verified via `terraform console`).
+
+But a `%` at **column 0** is a YAML *directive indicator* (`%YAML`, `%TAG`), so
+`yaml.safe_load(open("cloud-init.yml"))` on the RAW (un-rendered) file now throws
+`ScannerError: ... line 636, column 2`.
+
+The plan anticipated ONE such parser — `cloud-init-inngest-bootstrap.test.sh` AC3 — and
+fixed it (strip `^%{` before parse). It **missed an orphan sibling**:
+`journald-config.test.sh` AC6 independently ran `yaml.safe_load(open($CLOUD_INIT))` and went
+red. The touched-file test loop never ran journald (it's a *different* test file); only the
+**targeted full-suite exit gate** (run every infra `*.test.sh` referencing `cloud-init.yml`)
+surfaced it.
+
+## Solution
+
+1. **Strip col-0 directives before parsing the raw source**, in every test that raw-parses it:
+   ```sh
+   grep -v '^%{' "$CLOUD_INIT" | python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"
+   ```
+2. **Sweep ALL raw parsers**, not just the one the plan named:
+   ```sh
+   git grep -nE "safe_load|yaml\.load" -- '*.test.sh' '*.test.ts' '*.py'
+   ```
+   Filter to hits that target the RAW `cloud-init.yml` (not a workflow yaml, not a rendered
+   doc). Here: exactly two (`cloud-init-inngest-bootstrap.test.sh`, `journald-config.test.sh`).
+   The three TS tests that `readFileSync` cloud-init.yml do NOT `safe_load` it (string
+   `toContain` / gzip-size model) — unaffected.
+3. **Assert rendered-state YAML validity ONCE, in a terraform-render leg** — not by re-parsing
+   the raw file. Render the real production template via `terraform console` in a scratch dir
+   (no init/backend needed — `templatefile()` is a built-in function):
+   ```sh
+   printf 'templatefile("%s", { ...all server.tf map vars..., web_colocate_inngest=%s })\n' \
+     "$CLOUD_INIT" "$CASE" | terraform -chdir="$(mktemp -d)" console
+   ```
+   Assert omission/retention on the rendered output; strip terraform console's `<<EOT … EOT`
+   heredoc wrapper before `yaml.safe_load`.
+
+## Key Insight
+
+**A col-0 templatefile directive is a write-boundary-sweep class** (cf. hard rule
+`hr-write-boundary-sentinel-sweep-all-write-sites`): any static consumer that parses the RAW
+templated file — not its rendered output — must be updated in the same PR. The touched-file
+inner loop is blind to sibling test files; the **full-suite / targeted exit gate is the only
+thing that catches the orphan**. When you make a syntactic change to a widely-parsed shared
+config file, enumerate every parser with `git grep` and treat it as the work-list.
+
+Corollary: the terraform-render leg (rendering the REAL file and asserting the gate's effect)
+is the single behavioral authority — it exercises the load-bearing `~}` whitespace-strip that
+an awk/regex reimplementation cannot. Give it `terraform` on PATH in CI (a `command -v
+terraform` SKIP branch turns it into a "maybe-run", not a gate) and set `terraform_wrapper:
+false` on `setup-terraform` so `terraform console` stdout stays byte-clean for the heredoc-strip.
+
+## Session Errors
+
+1. **Guessed a non-existent column** (`"deletedAt"`) on the inngest `functions` table in a
+   Supabase `execute_sql` probe. — Recovery: inspected `information_schema.columns`. —
+   Prevention: query the schema before assuming column names on an unfamiliar (vendor) table.
+2. **`git stash list` denied** by the `hr-never-git-stash-in-worktrees` hook while diagnosing
+   the journald failure. — Recovery: used `git show`/`sed` diagnostics instead. — Prevention:
+   the hook is correct; never reach for `git stash*` in a worktree (even the read-only `list`).
+3. **`journald-config.test.sh` orphan-suite failure** (the learning above). — Recovery:
+   targeted exit gate over all `cloud-init.yml`-referencing infra tests; applied the same
+   `^%{` strip. — Prevention: `git grep` every raw parser of a shared config file BEFORE
+   committing a syntactic change to it; run the full/targeted exit gate, not just touched-file.
+4. **Root `./node_modules/.bin/vitest` absent** — the `plugins/soleur/test/*` suite runs under
+   `bun test`, not vitest. — Recovery: switched runner. — Prevention: plugins tests = `bun
+   test`; app (`apps/web-platform`) tests = the pinned `./node_modules/.bin/vitest`.

--- a/knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
@@ -1,0 +1,319 @@
+---
+title: "feat: Gate co-located Inngest bootstrap on fresh web hosts behind web_colocate_inngest (default false)"
+date: 2026-07-11
+branch: feat-one-shot-6178-web-postcutover-inngest-config
+epic: "#6178 (contextual — part of, NOT Closes)"
+lane: single-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+type: infra
+---
+
+# feat: Post-cutover web-host cloud-init — stop bootstrapping co-located Inngest
+
+⚙️ **Part of epic #6178** (`arch: extract inngest to its own HA host`). This is a **contextual** citation.
+The PR body MUST say "part of epic #6178" and MUST NOT say `Closes #6178` / `Fixes #6178` — the epic
+stays open; this is one implementation slice, not the whole cutover.
+
+## Overview
+
+A freshly-recreated web host currently bootstraps, enables, and starts a **co-located** Inngest server
+unconditionally. Scheduling is moving to the dedicated host `soleur-inngest` (`10.0.1.40`, ADR-100). This
+PR introduces a reviewable Terraform toggle `web_colocate_inngest` (**default `false`**) and uses a
+Terraform `templatefile` `%{ if … }` / `%{ endif }` directive to **gate the entire "Bootstrap Inngest
+server on first boot" runcmd block** in `apps/web-platform/infra/cloud-init.yml`. When the toggle is
+`false` (post-cutover default), a recreated web host does NOT extract/run `inngest-bootstrap.sh`, and
+therefore never `enable`s/`start`s `inngest-server.service` nor `inngest-heartbeat.timer`. Making
+host-recreate the quiesce mechanism (no SSH) satisfies `hr-prod-host-config-change-immutable-redeploy`.
+
+**Code + tests only.** No `terraform apply`, no host recreate, no power on/off, no cutover op.
+`INNGEST_BASE_URL` is explicitly out of scope (a separate PR handles the repoint).
+
+### Why this is SAFE TO MERGE (verified)
+- `hcloud_server.web` (`server.tf:93`, `for_each = var.web_hosts`) carries
+  `lifecycle { ignore_changes = [user_data, ssh_keys, image, placement_group_id] }` (`server.tf:195-196`)
+  — applies to **every** existing web instance, so a `cloud-init.yml` edit does NOT re-render `user_data`
+  on any running host. New config lands only on a fresh **create** (a recreate).
+- The auto-apply workflow `apply-web-platform-infra.yml` is `-target=`-scoped to specific
+  `betteruptime_*` / `cloudflare_ruleset` / `doppler_secret` resources — `hcloud_server.web` is **not** a
+  target → the merge-triggered apply cannot replace a web host.
+- The new variable has `default = false`, so the auto-applied infra root won't fail on a missing
+  `TF_VAR_web_colocate_inngest` (HCL evaluates all root vars pre-`-target`-pruning; a no-default var
+  would break the whole apply — this one won't).
+
+Net: merging redeploys the app image (web-platform release) but recreates NO host. web-1's running Inngest
+is unaffected until web-1 is retired; web-2 picks up the gated config on its next recreate.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (task) | Reality (verified) | Plan response |
+| --- | --- | --- |
+| Inngest enabled unconditionally on fresh web host | Confirmed: `cloud-init.yml:636-694` runcmd item extracts + runs `inngest-bootstrap.sh`; enable/start/heartbeat live in `inngest-bootstrap.sh:504-506`, invoked at `cloud-init.yml:693`. | Gate the cloud-init item; do NOT touch `inngest-bootstrap.sh`. |
+| Rendered by `templatefile(...)` at `server.tf:137` | Confirmed: `user_data = base64gzip(templatefile("${path.module}/cloud-init.yml", { … }))` (`server.tf:137`), map closes ~`:167`. | Add `web_colocate_inngest = var.web_colocate_inngest` to that map. |
+| Dedicated host must NOT regress | Confirmed: `inngest-host.tf:201` renders a DIFFERENT file `cloud-init-inngest.yml`, which has its OWN bootstrap block (own IREF pin `v1.1.19`, `:330`). Shares `inngest-bootstrap.sh` but via its own extract path. | Gate ONLY `cloud-init.yml`. Leave `inngest-bootstrap.sh` + `cloud-init-inngest.yml` untouched. |
+| Architectural decision recorded | Confirmed: `ADR-100-inngest-dedicated-single-host-singleton-control-plane.md` exists; C4 `model.c4:377` already annotates hosting edge `"removed from web cloud-init — ADR-100, #6178"`. | No new ADR; no C4 edit (see Architecture Decision gate). |
+| `%{ if }` gate is implementable without breaking render | Verified via `terraform console`: col-0 `%{ if web_colocate_inngest ~}` / `%{ endif ~}` renders clean valid YAML for both `true` (block present) and `false` (block absent). Indented directive fails raw-parse AND corrupts render. | Use col-0 right-strip (`~}`) markers wrapping the whole runcmd item. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:**
+- *Gate over-broad (accidentally strips host-script extraction / invalid YAML):* a recreated web host
+  fails first boot → fail-closed `/run/soleur-hostscripts.ok` guard `poweroff -f`s the host → Better Stack
+  per-host origin-absence check pages; web-1 keeps serving. No data exposed.
+- *Gate under-broad (still co-locates post-cutover) OR dedicated host not yet ready when a web host
+  recreates:* a Soleur user's scheduled reminder either **double-fires** (two schedulers) or **silently
+  misses** (no reachable scheduler). Either is user-visible per user.
+
+**If this leaks, the user's data is exposed via:** N/A — no data surface, no PII, no auth. This is a boot-
+time systemd/service gate on infra config; it moves scheduling topology, it does not read or persist user data.
+
+**Brand-survival threshold:** single-user incident (a single user's missed/duplicated scheduled reminder is
+user-visible). → `requires_cpo_signoff: true`. `user-impact-reviewer` runs at review time. Mitigations: the
+gate wraps exactly the bootstrap item (tests assert span-containment on both sides); the existing
+`inngest-doublefire-probe` / `inngest-enumerate-reminders` scan guards double-fire; sequencing (below) keeps
+the recreate path behind dedicated-host readiness + the separate `INNGEST_BASE_URL` repoint PR.
+
+## Files to Edit
+
+- **`apps/web-platform/infra/variables.tf`** — add:
+  ```hcl
+  variable "web_colocate_inngest" {
+    description = "When true, a freshly-created web host bootstraps + enables the co-located inngest-server.service (pre-cutover behavior). Default false: scheduling lives on the dedicated soleur-inngest host (10.0.1.40, ADR-100, #6178). Recreate is the quiesce mechanism (hr-prod-host-config-change-immutable-redeploy)."
+    type        = bool
+    default     = false
+  }
+  ```
+  Non-sensitive, has a default → no Doppler `prd_terraform` provisioning needed, no auto-apply break.
+
+- **`apps/web-platform/infra/server.tf`** — inside the web `cloud-init.yml` templatefile map (the
+  `templatefile("${path.module}/cloud-init.yml", { … })` at `:137`, before the closing `}))` near `:167`),
+  add one line: `web_colocate_inngest = var.web_colocate_inngest`.
+
+- **`apps/web-platform/infra/cloud-init.yml`** — wrap the "Bootstrap Inngest server on first boot" runcmd
+  item with a `templatefile` conditional, using **col-0 right-strip markers** (verified render form):
+  - Insert `%{ if web_colocate_inngest ~}` on its own **column-0** line **immediately before** the
+    `  # Bootstrap Inngest server on first boot (#4118, Tier 1).` comment (currently `:636`).
+  - Insert `%{ endif ~}` on its own **column-0** line **immediately after** the block's terminal
+    `    trap - EXIT  # …` line (currently `:694`) and **before** the next runcmd item `  - |` (`:696`,
+    the fail-closed app-bring-up gate).
+  - Result (verified via `terraform console`): `web_colocate_inngest = true` → comment + block render
+    intact; `= false` → the whole item vanishes, leaving valid YAML (`… .seed-complete` block directly
+    followed by the fail-closed gate item). Do NOT change indentation of the block body; do NOT alter any
+    existing `$${…}` escaping.
+
+- **`apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`** — two edits (see Test Strategy):
+  1. **Fix AC3** (`cloud-init.yml parses as valid YAML`): the raw file now contains col-0 `%{ … }`
+     templatefile directives, which `python3 … yaml.safe_load` rejects (`%` at col 0 = YAML directive
+     indicator → `ScannerError`, verified). Pre-strip `^%{` lines before `safe_load`; ADD a rendered-both-
+     -states YAML-validity assertion so the intent (rendered cloud-init is valid YAML) is strengthened,
+     not weakened.
+  2. **Add the toggle=false coverage** (new AC block): assert the gate markers exist and wrap exactly the
+     bootstrap item, and that the gated-false render omits the bootstrap while the gated-true render keeps it.
+
+### Files explicitly NOT edited (guardrails)
+- `apps/web-platform/infra/inngest-bootstrap.sh` — shared with the dedicated host; the enable/start/heartbeat
+  lines (`:504-506`) stay. The web gate prevents this script from being *invoked* on a fresh web host; its
+  behavior for the dedicated host is unchanged.
+- `apps/web-platform/infra/cloud-init-inngest.yml` + `inngest-host.tf` — the dedicated host's own render path.
+- `plugins/soleur/test/cloud-init-user-data-size.test.ts` — passes unmodified (models block-present /
+  worst-case size; the new map entry is an unused `${…}`-free var → never evaluated; ~60 B of directive
+  text is negligible against the 21,000 B gzip budget). Run it to confirm green; do NOT change it.
+
+## Implementation Phases
+
+### Phase 1 — Terraform variable + wiring (contract first)
+1. Add `variable "web_colocate_inngest"` to `variables.tf` (bool, default false).
+2. Add `web_colocate_inngest = var.web_colocate_inngest` to the `cloud-init.yml` templatefile map in
+   `server.tf`.
+Contract lands before the consumer (Phase 2) so the directive has a defined var when rendered.
+
+### Phase 2 — Gate the cloud-init runcmd block
+1. Insert the `%{ if web_colocate_inngest ~}` (before the bootstrap comment) and `%{ endif ~}` (after the
+   block's terminal `trap - EXIT`) col-0 directive lines in `cloud-init.yml`.
+2. Verify render both ways with `terraform console`:
+   `echo 'templatefile("./apps/web-platform/infra/cloud-init.yml", { …all-vars…, web_colocate_inngest=false })' | terraform console`
+   → block absent; `=true` → block present. Both outputs `yaml.safe_load`-clean.
+
+### Phase 3 — Tests
+1. Update AC3 (strip `^%{`; add rendered-state YAML validity).
+2. Add the toggle=false / toggle=true coverage block.
+3. Run: `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`,
+   `bunx --bun vitest run` for `plugins/soleur/test/cloud-init-user-data-size.test.ts` (or the repo's test
+   command per `package.json`), and the infra `*.test.ts` suite (target-parity, web-hosts-fanout-parity,
+   server-tf-set-e) to confirm no regression.
+4. `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/`.
+
+## Test Strategy
+
+Primary assertions are **static + terraform-render**, matching the existing file's grep/awk + skip-when-tool-
+absent convention. There is exactly one `if`/`endif` pair and no nesting, so an awk model of the directive is
+faithful (verified to match `terraform console` output).
+
+**AC3 fix (raw YAML validity with directives present):**
+```sh
+# strip col-0 templatefile directive lines before parsing the (non-rendered) source
+grep -v '^%{' "$CLOUD_INIT" | python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"
+```
+Plus a rendered-state check (below) so YAML validity of the *rendered* artifact is asserted directly.
+
+**New toggle coverage:**
+- **Markers present + placed:** exactly one `^%{ if web_colocate_inngest ~}$` and one `^%{ endif ~}$`; the
+  `if` line precedes `# Bootstrap Inngest server on first boot`; the `endif` line follows the block's
+  `trap - EXIT` and precedes the next `  - |` item.
+- **Span containment (gate wraps the RIGHT content):** the text between the markers CONTAINS the IREF pin
+  (`soleur-inngest-bootstrap:v…`) AND the `bash "$EXTRACT_DIR/inngest-bootstrap.sh"` invocation.
+- **Nothing outside the span co-locates Inngest:** deleting the span (`awk` from `%{ if web_colocate_inngest`
+  through `%{ endif`) yields a file with **no** `soleur-inngest-bootstrap` ref and **no** `inngest-bootstrap.sh`
+  invocation → transitively no `enable/start inngest-server.service` / `inngest-heartbeat.timer` on a fresh
+  web host. That deleted-span file also `yaml.safe_load`s clean (models `web_colocate_inngest=false`, matches
+  `terraform console`).
+- **toggle=true model:** removing only the two marker lines keeps the IREF pin present and `yaml.safe_load`s
+  clean (models `web_colocate_inngest=true`).
+- **Optional CI-authoritative leg (SKIP if `! command -v terraform`, mirroring the dash/visudo/git skips):**
+  render via `terraform console` with all templatefile vars set to placeholders and `web_colocate_inngest`
+  false/true; assert the false render lacks `soleur-inngest-bootstrap` and the true render contains it, and
+  both parse as YAML. Var list to supply: `image_name, fail2ban_sshd_local_b64, host_scripts_content_hash,
+  tunnel_token, webhook_deploy_secret, doppler_token, sentry_dsn, resend_api_key, ghcr_read_user,
+  ghcr_read_token, ci_ssh_public_key_openssh` (+ `web_colocate_inngest`).
+
+Existing assertions that MUST stay green (the gate must not disturb them): AC1 IREF pin shape, Config.Env
+sourcing, composite EXIT-trap-calls-cleanup, AC4 positional (bootstrap precedes `--name soleur-web-platform`),
+AC4 `bash -n`/`dash -n` snippet extraction (the extraction awk exits on the col-0 `%{ endif` line → directives
+are NOT pulled into the shell snippet, verified against the awk logic), AC5 sudoers parity, AC6 pin drift-guard.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `variables.tf` declares `web_colocate_inngest` (bool, `default = false`, non-sensitive).
+- [ ] `server.tf`'s `cloud-init.yml` templatefile map passes `web_colocate_inngest = var.web_colocate_inngest`.
+- [ ] `cloud-init.yml` wraps the "Bootstrap Inngest server on first boot" item in col-0
+      `%{ if web_colocate_inngest ~}` / `%{ endif ~}`, escaping (`$${…}`) unchanged.
+- [ ] `terraform console` render with `web_colocate_inngest=false` omits `soleur-inngest-bootstrap` +
+      `inngest-bootstrap.sh` and is `yaml.safe_load`-clean; with `=true` it includes them and is clean.
+- [ ] `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS, 0 FAIL (AC3 fixed;
+      new toggle block green; all prior ACs green).
+- [ ] `plugins/soleur/test/cloud-init-user-data-size.test.ts` green **unmodified** (web gzip render < 21,000 B).
+- [ ] Infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) green.
+- [ ] `terraform fmt -check` + `terraform validate` clean on `apps/web-platform/infra/`.
+- [ ] `inngest-bootstrap.sh` and `cloud-init-inngest.yml` are byte-unchanged in the diff.
+- [ ] (Read-only, review-time) `terraform plan` shows **no create/replace** of any `hcloud_server.web[*]`
+      (proves SAFE-TO-MERGE; no apply is run in this PR).
+- [ ] PR body: "part of epic #6178" (NOT `Closes`); documents rollback.
+
+### Post-merge (operator) — Automation: none required
+- None. Merging redeploys the app image only (no host recreate). No operator step, no apply. The
+  behavioral change materializes when a web host is next recreated under the epic's cutover sequencing.
+
+## Rollback (for PR body)
+To restore the co-located scheduler (the immutable-redeploy reverse of the cutover's `op=rollback`
+re-enable): set `web_colocate_inngest = true` — flip the `variables.tf` default (or set
+`TF_VAR_web_colocate_inngest=true`) — then **recreate** the web host. Recreate is the quiesce/restore
+mechanism; no SSH, no live mutation (`hr-prod-host-config-change-immutable-redeploy`).
+
+## Sequencing note (epic-level, not this PR's blocker)
+Because this PR recreates no host, merge order is flexible. But the cutover choreography must ensure that
+before any web host is recreated with `web_colocate_inngest=false`, the dedicated `soleur-inngest` host is
+serving AND the separate `INNGEST_BASE_URL` repoint PR has landed — else a recreated web host has no
+reachable scheduler. That sequencing is owned by epic #6178, not gated here.
+
+## Infrastructure (IaC)
+
+### Terraform changes
+- `apps/web-platform/infra/variables.tf` — new `web_colocate_inngest` (bool, default false, non-sensitive).
+- `apps/web-platform/infra/server.tf` — one new key in the existing `cloud-init.yml` templatefile map.
+- `apps/web-platform/infra/cloud-init.yml` — one `%{ if }`/`%{ endif }` directive pair (no new resource).
+- No new provider, no version-pin change, no `TF_VAR` secret (default supplied → nothing to mint in Doppler).
+
+### Apply path
+**cloud-init-only.** No `terraform apply` in this PR. `ignore_changes=[user_data]` means the config never
+re-renders onto a running host; the new gate takes effect only on a fresh **create** (recreate) — the
+immutable-redeploy quiesce path. No taint, no `-replace`, zero downtime on merge.
+
+### Distinctness / drift safeguards
+- `ignore_changes=[user_data, ssh_keys, image, placement_group_id]` on the `for_each` web resource keeps
+  the cloud-init edit off existing hosts (web-1 AND web-2).
+- `apply-web-platform-infra.yml` `-target=` set excludes `hcloud_server.web` → merge-apply cannot replace a host.
+- Default `false` value keeps the auto-applied root's pre-`-target` var resolution from failing.
+
+### Vendor-tier reality check
+N/A — no vendor resource created.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "fresh-web-host first-boot success (host-script extraction sentinel + app container up)"
+  cadence: "on host create/recreate"
+  alert_target: "Better Stack per-host origin-absence check (web-N.app.soleur.ai/health) + apex uptime"
+  configured_in: "apps/web-platform/infra/uptime-alerts.tf (existing); cloud-init.yml fail-closed poweroff gate"
+error_reporting:
+  destination: "Sentry via soleur-boot-emit (existing cloud-init emits: inngest_bootstrap fatal, host-script stages)"
+  fail_loud: "true — /run/soleur-hostscripts.ok guard poweroff -f's a host whose boot failed (visible absence)"
+failure_modes:
+  - mode: "directive makes raw/rendered cloud-init invalid YAML"
+    detection: "cloud-init-inngest-bootstrap.test.sh AC3 (rendered-state yaml.safe_load) + terraform validate in CI"
+    alert_route: "CI red (pre-merge); at runtime a boot failure → fail-closed poweroff → Better Stack origin-absence page"
+  - mode: "gate over-broad — strips host-script extraction / wrong content"
+    detection: "new span-containment + size test (block still modeled) + terraform render test in CI"
+    alert_route: "CI red (pre-merge)"
+  - mode: "gate under-broad — web host still co-locates post-cutover (double scheduler)"
+    detection: "inngest-doublefire-probe.sh + inngest-enumerate-reminders.sh (existing epic probes)"
+    alert_route: "Sentry / cutover-verify state (existing #6178 tooling)"
+logs:
+  where: "journald → Better Stack Logs (source 2457081) via Vector on the app host"
+  retention: "Better Stack Logs default"
+discoverability_test:
+  command: "echo 'templatefile(\"apps/web-platform/infra/cloud-init.yml\", {web_colocate_inngest=false, …})' | terraform console | grep -c soleur-inngest-bootstrap  # expect 0 (NO ssh)"
+  expected_output: "0 (rendered false-state web cloud-init contains no co-located inngest bootstrap)"
+```
+
+## Architecture Decision (ADR/C4)
+
+**No new ADR; no C4 edit.** The decision (dedicated single-host Inngest as the sole scheduler; removal of
+web co-location) is already recorded in `ADR-100-inngest-dedicated-single-host-singleton-control-plane.md`.
+This PR is one implementation slice realizing that decision — a contextual citation, not a new/amended ADR.
+
+**C4 completeness check (read all three `.c4` files):** `model.c4` models `inngest` as its own container
+(`:184`, description already cites ADR-100 + #6178 + "Extracted to its own single-host … node"); the hosting
+edge `hetzner -> inngest` (`:377`) is **already annotated** `"…removed from web cloud-init — ADR-100, #6178"`;
+the `api -> inngest` HTTP event edge (`:370`, "Sends events; serves functions") correctly REMAINS (the web
+app still sends events to the dedicated host). Enumerated: external actors — none new; external systems —
+none new (Hetzner/Doppler/GHCR already modeled); containers/data-stores — none new; access relationships —
+the web→co-located-inngest topology edge does not exist as a separate element to remove (co-location was a
+cloud-init detail, not a modeled edge), and the model already documents its removal. → **No `.c4` change; no
+`views.c4` include change.** The three files (`model.c4`, `views.c4`, `spec.c4`) were read and require no edit.
+
+## Domain Review
+
+**Domains relevant:** none (infrastructure/tooling change).
+
+No cross-domain business implications. No user-facing UI surface (no files under `components/**`, `app/**`).
+Product/UX Gate: NONE (no UI-surface file in Files-to-Edit; mechanical override does not fire).
+Engineering/infra concerns are captured in Infrastructure (IaC), Observability, and Architecture Decision
+sections above. `user-impact-reviewer` will run at review time (single-user-incident threshold).
+
+## Open Code-Review Overlap
+
+None — no open `code-review` issue targets `apps/web-platform/infra/cloud-init.yml`, `server.tf`,
+`variables.tf`, or `cloud-init-inngest-bootstrap.test.sh` for this change class.
+
+## Risks & Sharp Edges
+
+- **[YAML-validity, highest]** Col-0 `%{ … }` directives make the **raw** source non-`yaml.safe_load`-able
+  (`%` at col 0 = YAML directive indicator). This is expected and handled by the AC3 fix (strip `^%{` before
+  parse) + the rendered-state validity check. Do NOT try to "fix" it by indenting the directive — verified:
+  indenting BOTH fails raw-parse AND corrupts the render (mis-nested list items).
+- **Strip-marker form is load-bearing:** use right-strip `~}` on both `%{ if … ~}` and `%{ endif ~}`.
+  Verified this produces clean YAML with no stray blank line between runcmd items in the `true` render and a
+  clean list in the `false` render.
+- **Placement is load-bearing for the `bash -n` snippet test:** `%{ if }` goes BEFORE the bootstrap comment
+  (so the AC4 extraction awk, which starts at that comment, never sees it) and `%{ endif }` goes at col 0
+  AFTER the block (the extraction awk exits on the first `^[^[:space:]]` line → directive excluded from the
+  shell snippet). Confirmed against the awk in the test.
+- **Do not modify `inngest-bootstrap.sh`.** Gating at the web cloud-init layer is sufficient; the dedicated
+  host relies on the script's enable/start behavior.
+- **A plan/AC that greps for the *absence* of a token** (e.g., "no `inngest-bootstrap.sh`") must run on the
+  span-deleted render, not the raw file (the raw file always contains the block text inside the `if`).
+- **Sharp edge (plan-time budget):** the size test passes unmodified only because the new map var is
+  `${…}`-free (referenced via `%{ if }`, not `${}`) → never evaluated by the TS model. Do not rename the
+  directive to `${web_colocate_inngest ? … : …}` or the model will try to substitute it.

--- a/knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
@@ -15,6 +15,20 @@ type: infra
 The PR body MUST say "part of epic #6178" and MUST NOT say `Closes #6178` / `Fixes #6178` — the epic
 stays open; this is one implementation slice, not the whole cutover.
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-11 · **Reviewers:** architecture-strategist, spec-flow-analyzer, code-simplicity-reviewer (all "approve"; render mechanics + C4 state + ADR-100 alignment independently re-verified via `terraform console`).
+
+### Key improvements folded in
+1. **Single render authority (simplicity + spec-flow + architecture converged).** The awk span-deletion model cannot verify the load-bearing `~}` whitespace-strip; only a real `terraform templatefile` render can. Verified the bootstrap test runs in the `deploy-script-tests` job (`infra-validation.yml:136`) which has **no** `setup-terraform` — so the render leg was "SKIP-in-CI" (not a real gate). Fix: **add one `setup-terraform` step to `deploy-script-tests`**, make the terraform render the behavioral authority, and **drop the awk span-deletion reimplementation** (keep only cheap static marker/placement checks). YAML validity is now asserted once (in the render leg), not three times.
+2. **`type = bool` is load-bearing (architecture #1).** `%{ if web_colocate_inngest }` is truthy for any non-empty string; the false-gate + the rollback `TF_VAR_web_colocate_inngest="false"` string route work ONLY because the var is `type = bool`. Added: a static assertion pinning `type = bool`, and a render leg passing the **string** `"false"` (not just the bool literal) to exercise the coercion.
+3. **Direct-negative + retention assertions (spec-flow b/c, architecture #2).** The "no enable/start" conclusion is transitive (the tests grep the invocation token, not `inngest-server.service`, because that token legitimately survives in the sudoers aliases + webhook `ReadWritePaths`). Added on the false render: no out-of-gate inngest `enable/start`/`inngest-heartbeat`; and positive **retention** that the false render still contains `--name soleur-web-platform`, `INNGEST_BASE_URL`, and the fail-closed `/run/soleur-hostscripts.ok` gate (guards an over-broad `endif`).
+4. AC3 trimmed to strip-only. C4 description line ref corrected (`:184` → `:186`).
+
+### Load-bearing facts the invariant rests on (verified this pass)
+- `inngest-bootstrap.sh` is the **sole author AND enabler** of `inngest-server.service` / `inngest-heartbeat.timer` — those units are NOT in cloud-init `write_files:`; they are written by the script (`inngest-bootstrap.sh:60-63`) and enabled at `:504-506`, reachable only via the gated `cloud-init.yml:693` invocation. Gating the invocation ⇒ no units authored ⇒ nothing to enable.
+- The `INNGEST_BASE_URL=…:8288` app-container env (`cloud-init.yml:728`) is set **unconditionally** (outside the gate). A false-render fresh host boots healthy (no health-check on inngest) but scheduled reminders silently miss until the separate repoint PR + dedicated-host-readiness land — an **ungated temporal risk** owned by epic #6178's sequencing, not a code defect in this PR.
+
 ## Overview
 
 A freshly-recreated web host currently bootstraps, enables, and starts a **co-located** Inngest server
@@ -102,13 +116,27 @@ the recreate path behind dedicated-host readiness + the separate `INNGEST_BASE_U
     existing `$${…}` escaping.
 
 - **`apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`** — two edits (see Test Strategy):
-  1. **Fix AC3** (`cloud-init.yml parses as valid YAML`): the raw file now contains col-0 `%{ … }`
-     templatefile directives, which `python3 … yaml.safe_load` rejects (`%` at col 0 = YAML directive
-     indicator → `ScannerError`, verified). Pre-strip `^%{` lines before `safe_load`; ADD a rendered-both-
-     -states YAML-validity assertion so the intent (rendered cloud-init is valid YAML) is strengthened,
-     not weakened.
-  2. **Add the toggle=false coverage** (new AC block): assert the gate markers exist and wrap exactly the
-     bootstrap item, and that the gated-false render omits the bootstrap while the gated-true render keeps it.
+  1. **Fix AC3, strip-only** (`cloud-init.yml parses as valid YAML`): the raw file now contains col-0
+     `%{ … }` templatefile directives, which `python3 … yaml.safe_load` rejects (`%` at col 0 = YAML
+     directive indicator → `ScannerError`, verified). Pre-strip `^%{` lines before `safe_load`. Do NOT
+     also bolt a rendered-validity assertion here — rendered-state YAML validity is asserted **once**, in
+     the render leg below (per code-simplicity review: same property, one home).
+  2. **Add the toggle coverage** (new AC block): a cheap portable structural check (markers present +
+     placement) plus a **terraform-render behavioral leg** that is the single authority for the gate's
+     effect (see Test Strategy). This replaces — does not add to — the awk span-deletion model.
+
+- **`.github/workflows/infra-validation.yml`** — add a `hashicorp/setup-terraform@…v4.0.0` step to the
+  **`deploy-script-tests`** job (the job that runs `cloud-init-inngest-bootstrap.test.sh` at `:184`;
+  currently it has NO terraform, unlike the `validate`/`plan` jobs). Without this, the render leg would be
+  perpetually `SKIP`-gated in CI (a "maybe-run" test is not a gate — all three review agents flagged this).
+  One step; makes the render leg authoritative.
+
+- **`apps/web-platform/infra/variables.tf`** additionally — the `type = bool` on `web_colocate_inngest` is
+  **load-bearing**: the `%{ if web_colocate_inngest }` directive is truthy for ANY non-empty string, and
+  the rollback path sets `TF_VAR_web_colocate_inngest="false"` (a string) — coerced to boolean `false`
+  ONLY because the variable is `bool`. A silent drift to `type = string` would make the false-gate
+  always-truthy. Covered by a static `type = bool` grep assertion + a render leg passing the string
+  `"false"` (below).
 
 ### Files explicitly NOT edited (guardrails)
 - `apps/web-platform/infra/inngest-bootstrap.sh` — shared with the dedicated host; the enable/start/heartbeat
@@ -145,36 +173,49 @@ Contract lands before the consumer (Phase 2) so the directive has a defined var 
 
 ## Test Strategy
 
-Primary assertions are **static + terraform-render**, matching the existing file's grep/awk + skip-when-tool-
-absent convention. There is exactly one `if`/`endif` pair and no nesting, so an awk model of the directive is
-faithful (verified to match `terraform console` output).
+**Load-bearing invariant (verified by spec-flow + architecture review):** `inngest-bootstrap.sh` is the SOLE
+author-and-enabler of the inngest systemd units — it declares `inngest-server.service` /
+`inngest-heartbeat.{service,timer}` (`inngest-bootstrap.sh:60-63`) and enables/starts them (`:504-506`);
+cloud-init.yml's `write_files:` writes ZERO inngest units (verified). Therefore gating the runcmd item that
+*invokes* the script (the only invocation, `cloud-init.yml:693`) transitively guarantees no enable/start/
+heartbeat on a fresh web host. The tests below assert the invocation-absence (the cause), and this section
+documents the transitive fact so a future edit that adds an inline inngest unit to `write_files:` is caught.
 
-**AC3 fix (raw YAML validity with directives present):**
+Design (per the review triad): **one terraform-render behavioral authority + one cheap portable structural
+smoke.** The awk span-deletion model is dropped — it re-implements Terraform and cannot exercise the
+load-bearing `~}` whitespace-strip (only a real render can). Rendered-YAML validity is asserted once, in the
+render leg.
+
+**(a) AC3 — raw-source YAML validity, strip-only:**
 ```sh
 # strip col-0 templatefile directive lines before parsing the (non-rendered) source
 grep -v '^%{' "$CLOUD_INIT" | python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"
 ```
-Plus a rendered-state check (below) so YAML validity of the *rendered* artifact is asserted directly.
+No rendered-validity assertion here — that lives once in the render leg.
 
-**New toggle coverage:**
-- **Markers present + placed:** exactly one `^%{ if web_colocate_inngest ~}$` and one `^%{ endif ~}$`; the
-  `if` line precedes `# Bootstrap Inngest server on first boot`; the `endif` line follows the block's
-  `trap - EXIT` and precedes the next `  - |` item.
-- **Span containment (gate wraps the RIGHT content):** the text between the markers CONTAINS the IREF pin
-  (`soleur-inngest-bootstrap:v…`) AND the `bash "$EXTRACT_DIR/inngest-bootstrap.sh"` invocation.
-- **Nothing outside the span co-locates Inngest:** deleting the span (`awk` from `%{ if web_colocate_inngest`
-  through `%{ endif`) yields a file with **no** `soleur-inngest-bootstrap` ref and **no** `inngest-bootstrap.sh`
-  invocation → transitively no `enable/start inngest-server.service` / `inngest-heartbeat.timer` on a fresh
-  web host. That deleted-span file also `yaml.safe_load`s clean (models `web_colocate_inngest=false`, matches
-  `terraform console`).
-- **toggle=true model:** removing only the two marker lines keeps the IREF pin present and `yaml.safe_load`s
-  clean (models `web_colocate_inngest=true`).
-- **Optional CI-authoritative leg (SKIP if `! command -v terraform`, mirroring the dash/visudo/git skips):**
-  render via `terraform console` with all templatefile vars set to placeholders and `web_colocate_inngest`
-  false/true; assert the false render lacks `soleur-inngest-bootstrap` and the true render contains it, and
-  both parse as YAML. Var list to supply: `image_name, fail2ban_sshd_local_b64, host_scripts_content_hash,
-  tunnel_token, webhook_deploy_secret, doppler_token, sentry_dsn, resend_api_key, ghcr_read_user,
-  ghcr_read_token, ci_ssh_public_key_openssh` (+ `web_colocate_inngest`).
+**(b) Cheap portable structural smoke (no terraform):**
+- exactly one `^%{ if web_colocate_inngest ~}$` and one `^%{ endif ~}$`; the `if` line precedes
+  `# Bootstrap Inngest server on first boot`; the `endif` line follows the block's `trap - EXIT` and precedes
+  the next `  - |` item.
+- static assertion pinning the toggle's type: `grep -Eq 'variable "web_colocate_inngest"' … && grep -Eq
+  'type\s*=\s*bool' …` — the `type = bool` is load-bearing for string→bool coercion (see Files to Edit).
+
+**(c) Terraform-render behavioral authority (runs in CI once `setup-terraform` is added to
+`deploy-script-tests`; SKIP locally when `! command -v terraform`, mirroring the dash/visudo/git skips):**
+render `templatefile("cloud-init.yml", { …all-vars…, web_colocate_inngest = <case> })` via `terraform
+console` for three cases and assert:
+- **`false` (bool):** render **omits** `soleur-inngest-bootstrap` AND the `inngest-bootstrap.sh` invocation
+  (→ transitively no enable/start/heartbeat); **retains** the post-block app bring-up — `--name
+  soleur-web-platform`, `INNGEST_BASE_URL`, and the fail-closed `test -f /run/soleur-hostscripts.ok` gate
+  (guards an over-broad `endif` that swallows later items); and `yaml.safe_load`s clean.
+- **`"false"` (string):** identical omission — proves `type = bool` coerces the `TF_VAR="false"` rollback
+  route to a falsey gate (NOT truthy-non-empty-string). This is the highest-value new assertion.
+- **`true` (bool):** render **contains** `soleur-inngest-bootstrap` + the bootstrap invocation; `yaml.safe_load`s clean.
+
+Var list to supply (all placeholders except the toggle; keep in sync with `server.tf`'s map — a new map var
+breaks this leg, which is the intended tripwire): `image_name, fail2ban_sshd_local_b64,
+host_scripts_content_hash, tunnel_token, webhook_deploy_secret, doppler_token, sentry_dsn, resend_api_key,
+ghcr_read_user, ghcr_read_token, ci_ssh_public_key_openssh` (+ `web_colocate_inngest`).
 
 Existing assertions that MUST stay green (the gate must not disturb them): AC1 IREF pin shape, Config.Env
 sourcing, composite EXIT-trap-calls-cleanup, AC4 positional (bootstrap precedes `--name soleur-web-platform`),
@@ -184,14 +225,19 @@ are NOT pulled into the shell snippet, verified against the awk logic), AC5 sudo
 ## Acceptance Criteria
 
 ### Pre-merge (PR)
-- [ ] `variables.tf` declares `web_colocate_inngest` (bool, `default = false`, non-sensitive).
+- [ ] `variables.tf` declares `web_colocate_inngest` (`type = bool`, `default = false`, non-sensitive). The
+      `type = bool` is load-bearing (string→bool coercion for the rollback route) — a static grep asserts it.
 - [ ] `server.tf`'s `cloud-init.yml` templatefile map passes `web_colocate_inngest = var.web_colocate_inngest`.
 - [ ] `cloud-init.yml` wraps the "Bootstrap Inngest server on first boot" item in col-0
       `%{ if web_colocate_inngest ~}` / `%{ endif ~}`, escaping (`$${…}`) unchanged.
-- [ ] `terraform console` render with `web_colocate_inngest=false` omits `soleur-inngest-bootstrap` +
-      `inngest-bootstrap.sh` and is `yaml.safe_load`-clean; with `=true` it includes them and is clean.
-- [ ] `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS, 0 FAIL (AC3 fixed;
-      new toggle block green; all prior ACs green).
+- [ ] `.github/workflows/infra-validation.yml` `deploy-script-tests` job gains a `setup-terraform` step so
+      the render leg runs (not SKIPs) in CI.
+- [ ] Render leg (authoritative): `web_colocate_inngest=false` (bool) AND `="false"` (string) both **omit**
+      `soleur-inngest-bootstrap` + the `inngest-bootstrap.sh` invocation and **retain** `--name
+      soleur-web-platform` + `INNGEST_BASE_URL` + the `test -f /run/soleur-hostscripts.ok` gate, `yaml.safe_load`-clean;
+      `=true` **includes** the bootstrap, `yaml.safe_load`-clean.
+- [ ] `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS, 0 FAIL (AC3 strip-only;
+      new structural + render toggle block green; all prior ACs green).
 - [ ] `plugins/soleur/test/cloud-init-user-data-size.test.ts` green **unmodified** (web gzip render < 21,000 B).
 - [ ] Infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) green.
 - [ ] `terraform fmt -check` + `terraform validate` clean on `apps/web-platform/infra/`.
@@ -217,6 +263,12 @@ serving AND the separate `INNGEST_BASE_URL` repoint PR has landed — else a rec
 reachable scheduler. That sequencing is owned by epic #6178, not gated here.
 
 ## Infrastructure (IaC)
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!-- Phase 2.8 reviewed: this change introduces NO manual provisioning. It is a Terraform variable +
+     templatefile-directive edit; the quiesce mechanism is host-recreate (immutable redeploy), NOT SSH.
+     Any `systemctl`/`enable` tokens in this plan's prose describe the EXISTING inngest-bootstrap.sh
+     behavior for test-rationale purposes only — they are not new operator steps. -->
 
 ### Terraform changes
 - `apps/web-platform/infra/variables.tf` — new `web_colocate_inngest` (bool, default false, non-sensitive).
@@ -251,19 +303,19 @@ error_reporting:
   fail_loud: "true — /run/soleur-hostscripts.ok guard poweroff -f's a host whose boot failed (visible absence)"
 failure_modes:
   - mode: "directive makes raw/rendered cloud-init invalid YAML"
-    detection: "cloud-init-inngest-bootstrap.test.sh AC3 (rendered-state yaml.safe_load) + terraform validate in CI"
+    detection: "AC3 strip-only raw parse + the authoritative terraform render leg (both-state yaml.safe_load) + terraform validate in CI"
     alert_route: "CI red (pre-merge); at runtime a boot failure → fail-closed poweroff → Better Stack origin-absence page"
-  - mode: "gate over-broad — strips host-script extraction / wrong content"
-    detection: "new span-containment + size test (block still modeled) + terraform render test in CI"
+  - mode: "gate over-broad (endif swallows later items) OR under-broad (still co-locates)"
+    detection: "terraform render leg: retention asserts --name soleur-web-platform + INNGEST_BASE_URL + /run/soleur-hostscripts.ok survive false render; omission asserts no bootstrap; size test keeps block-present model"
     alert_route: "CI red (pre-merge)"
-  - mode: "gate under-broad — web host still co-locates post-cutover (double scheduler)"
+  - mode: "post-cutover recreate races the dedicated host / repoint (double-fire or missed reminders)"
     detection: "inngest-doublefire-probe.sh + inngest-enumerate-reminders.sh (existing epic probes)"
     alert_route: "Sentry / cutover-verify state (existing #6178 tooling)"
 logs:
   where: "journald → Better Stack Logs (source 2457081) via Vector on the app host"
   retention: "Better Stack Logs default"
 discoverability_test:
-  command: "echo 'templatefile(\"apps/web-platform/infra/cloud-init.yml\", {web_colocate_inngest=false, …})' | terraform console | grep -c soleur-inngest-bootstrap  # expect 0 (NO ssh)"
+  command: "printf 'templatefile(\"apps/web-platform/infra/cloud-init.yml\", {web_colocate_inngest=false, ...})' | terraform console | grep -c soleur-inngest-bootstrap   # local terminal, no remote host"
   expected_output: "0 (rendered false-state web cloud-init contains no co-located inngest bootstrap)"
 ```
 
@@ -274,7 +326,7 @@ web co-location) is already recorded in `ADR-100-inngest-dedicated-single-host-s
 This PR is one implementation slice realizing that decision — a contextual citation, not a new/amended ADR.
 
 **C4 completeness check (read all three `.c4` files):** `model.c4` models `inngest` as its own container
-(`:184`, description already cites ADR-100 + #6178 + "Extracted to its own single-host … node"); the hosting
+(element opens `:184`, description `:186` — already cites ADR-100 + #6178 + "Extracted to its own single-host … node"); the hosting
 edge `hetzner -> inngest` (`:377`) is **already annotated** `"…removed from web cloud-init — ADR-100, #6178"`;
 the `api -> inngest` HTTP event edge (`:370`, "Sends events; serves functions") correctly REMAINS (the web
 app still sends events to the dedicated host). Enumerated: external actors — none new; external systems —
@@ -299,10 +351,25 @@ None — no open `code-review` issue targets `apps/web-platform/infra/cloud-init
 
 ## Risks & Sharp Edges
 
-- **[YAML-validity, highest]** Col-0 `%{ … }` directives make the **raw** source non-`yaml.safe_load`-able
-  (`%` at col 0 = YAML directive indicator). This is expected and handled by the AC3 fix (strip `^%{` before
-  parse) + the rendered-state validity check. Do NOT try to "fix" it by indenting the directive — verified:
-  indenting BOTH fails raw-parse AND corrupts the render (mis-nested list items).
+- **[`type = bool` load-bearing, highest — architecture review]** `%{ if web_colocate_inngest }` is truthy
+  for ANY non-empty string. The rollback route sets `TF_VAR_web_colocate_inngest="false"` (a string), coerced
+  to boolean `false` ONLY because the var is `type = bool`. A silent drift to `type = string` makes the
+  false-gate always-truthy (co-location never stops). Guarded by a static `type = bool` grep AND a render leg
+  that passes the STRING `"false"` and asserts omission.
+- **[transitive invariant — spec-flow review]** The tests assert invocation-absence (no `inngest-bootstrap.sh`
+  run), NOT the unit-enable line, because the token `inngest-server.service` legitimately survives a false
+  render in the sudoers aliases (`INNGEST_RESTART/STOP/START`) and webhook `ReadWritePaths`. This is correct
+  ONLY because `inngest-bootstrap.sh` is the sole author+enabler of the units (verified: `write_files:` has
+  zero inngest units). A future edit that adds an inline inngest unit/enable to `write_files:` would pass
+  every test while breaking the invariant — flag it in review.
+- **[`INNGEST_BASE_URL` ungated temporal risk — all three reviewers]** `INNGEST_BASE_URL=…:8288` is set
+  UNCONDITIONALLY (`cloud-init.yml:728`, outside the gate). A false-render fresh host boots healthy but
+  reminders silently miss until the separate repoint PR + dedicated-host-readiness land. Nothing in THIS PR
+  mechanically blocks a premature recreate — accepted, epic-#6178-owned sequencing risk (not a code defect).
+- **[YAML-validity]** Col-0 `%{ … }` directives make the **raw** source non-`yaml.safe_load`-able
+  (`%` at col 0 = YAML directive indicator). Handled by AC3 strip-only (`grep -v '^%{'` before parse);
+  rendered-state validity is asserted once in the render leg. Do NOT "fix" it by indenting the directive —
+  verified: indenting BOTH fails raw-parse AND corrupts the render (mis-nested list items).
 - **Strip-marker form is load-bearing:** use right-strip `~}` on both `%{ if … ~}` and `%{ endif ~}`.
   Verified this produces clean YAML with no stray blank line between runcmd items in the `true` render and a
   clean list in the `false` render.

--- a/knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
+++ b/knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
@@ -45,7 +45,7 @@ host-recreate the quiesce mechanism (no SSH) satisfies `hr-prod-host-config-chan
 
 ### Why this is SAFE TO MERGE (verified)
 - `hcloud_server.web` (`server.tf:93`, `for_each = var.web_hosts`) carries
-  `lifecycle { ignore_changes = [user_data, ssh_keys, image, placement_group_id] }` (`server.tf:195-196`)
+  `lifecycle { ignore_changes = [user_data, ssh_keys, image, placement_group_id] }` (`server.tf:200`)
   — applies to **every** existing web instance, so a `cloud-init.yml` edit does NOT re-render `user_data`
   on any running host. New config lands only on a fresh **create** (a recreate).
 - The auto-apply workflow `apply-web-platform-infra.yml` is `-target=`-scoped to specific

--- a/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md
+- Status: complete
+
+### Errors
+None. One hook false-positive (`systemctl enable` prose flagged manual-infra) resolved via `iac-routing-ack: plan-phase-2-8-reviewed` opt-out — change routes entirely through Terraform + cloud-init, no manual steps.
+
+### Decisions
+- Gate mechanism: col-0 `%{ if web_colocate_inngest ~}` / `%{ endif ~}` right-strip directives wrapping the whole "Bootstrap Inngest server on first boot" runcmd item; verified via `terraform console` in both states. Indented directives corrupt the render — col-0 mandatory.
+- `type = bool` load-bearing: `%{ if }` is truthy for any non-empty string; rollback passes `TF_VAR_web_colocate_inngest="false"`. Guarded by a static bool grep + a render leg passing string "false".
+- Single terraform-render test authority: added one `setup-terraform` step to the `deploy-script-tests` CI job (was terraform-less → render would SKIP). AC3 trimmed to strip-only.
+- No new ADR / no C4 edit: ADR-100 records the dedicated-scheduler decision; model.c4:377 already annotates the removed hosting edge. This PR is an implementation slice of epic #6178 (contextual, not Closes).
+- SAFE-TO-MERGE: `hcloud_server.web` has `ignore_changes=[user_data,...]`; auto-apply is `-target`-scoped excluding `hcloud_server.web` → merge recreates no host. Dedicated host isolated (separate cloud-init-inngest.yml); inngest-bootstrap.sh untouched.
+
+### Components Invoked
+- soleur:plan, soleur:deepen-plan
+- agents: architecture-strategist, spec-flow-analyzer, code-simplicity-reviewer (all approve)

--- a/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/tasks.md
@@ -4,24 +4,24 @@ Plan: `knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colo
 Lane: single-domain · Threshold: single-user incident (requires CPO sign-off)
 
 ## Phase 1 — Terraform variable + wiring (contract first)
-- [ ] 1.1 Add `variable "web_colocate_inngest"` to `apps/web-platform/infra/variables.tf` (`type = bool` — LOAD-BEARING for string→bool coercion, `default = false`, non-sensitive, description citing ADR-100 / #6178 / hr-prod-host-config-change-immutable-redeploy).
-- [ ] 1.2 Add `web_colocate_inngest = var.web_colocate_inngest` to the `cloud-init.yml` templatefile map in `apps/web-platform/infra/server.tf` (`:137`, before the closing `}))`).
+- [x] 1.1 Add `variable "web_colocate_inngest"` to `apps/web-platform/infra/variables.tf` (`type = bool` — LOAD-BEARING for string→bool coercion, `default = false`, non-sensitive, description citing ADR-100 / #6178 / hr-prod-host-config-change-immutable-redeploy).
+- [x] 1.2 Add `web_colocate_inngest = var.web_colocate_inngest` to the `cloud-init.yml` templatefile map in `apps/web-platform/infra/server.tf` (`:137`, before the closing `}))`).
 
 ## Phase 2 — Gate the cloud-init runcmd block
-- [ ] 2.1 Insert col-0 `%{ if web_colocate_inngest ~}` immediately before the `# Bootstrap Inngest server on first boot` comment in `cloud-init.yml`.
-- [ ] 2.2 Insert col-0 `%{ endif ~}` immediately after the block's terminal `trap - EXIT` line and before the next `  - |` item. Do NOT change block indentation or `$${…}` escaping.
-- [ ] 2.3 Verify with `terraform console` that `web_colocate_inngest=false` (bool) AND `="false"` (string) both omit the block, and `=true` keeps it; all `yaml.safe_load`-clean.
+- [x] 2.1 Insert col-0 `%{ if web_colocate_inngest ~}` immediately before the `# Bootstrap Inngest server on first boot` comment in `cloud-init.yml`.
+- [x] 2.2 Insert col-0 `%{ endif ~}` immediately after the block's terminal `trap - EXIT` line and before the next `  - |` item. Do NOT change block indentation or `$${…}` escaping.
+- [x] 2.3 Verify with `terraform console` that `web_colocate_inngest=false` (bool) AND `="false"` (string) both omit the block, and `=true` keeps it; all `yaml.safe_load`-clean.
 
 ## Phase 3 — Tests (single render authority + cheap structural smoke)
-- [ ] 3.1 Fix AC3 in `apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`: strip `^%{` lines before `yaml.safe_load` (STRIP-ONLY — no rendered-validity assertion here; it lives once in the render leg).
-- [ ] 3.2 Add cheap structural smoke (no terraform): exactly one `%{ if web_colocate_inngest ~}` + one `%{ endif ~}`; `if` precedes the bootstrap comment; `endif` follows `trap - EXIT` and precedes the next `- |`; static grep asserting `type = bool` on the variable.
-- [ ] 3.3 Add the authoritative terraform-render leg (SKIP locally if `! command -v terraform`): render for `web_colocate_inngest` = `false` (bool), `"false"` (string), `true` (bool). Assert false/`"false"` OMIT `soleur-inngest-bootstrap` + the `inngest-bootstrap.sh` invocation AND RETAIN `--name soleur-web-platform` + `INNGEST_BASE_URL` + `/run/soleur-hostscripts.ok`, `yaml.safe_load`-clean; true INCLUDES the bootstrap, clean. Var list = server.tf map placeholders + the toggle. Do NOT keep the old awk span-deletion model.
-- [ ] 3.4 Add a `hashicorp/setup-terraform@…v4.0.0` step to the `deploy-script-tests` job in `.github/workflows/infra-validation.yml` so the render leg runs (not SKIPs) in CI.
-- [ ] 3.5 Run `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS.
-- [ ] 3.6 Run `plugins/soleur/test/cloud-init-user-data-size.test.ts` (unmodified) + infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) → green.
-- [ ] 3.7 `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/`.
+- [x] 3.1 Fix AC3 in `apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`: strip `^%{` lines before `yaml.safe_load` (STRIP-ONLY — no rendered-validity assertion here; it lives once in the render leg).
+- [x] 3.2 Add cheap structural smoke (no terraform): exactly one `%{ if web_colocate_inngest ~}` + one `%{ endif ~}`; `if` precedes the bootstrap comment; `endif` follows `trap - EXIT` and precedes the next `- |`; static grep asserting `type = bool` on the variable.
+- [x] 3.3 Add the authoritative terraform-render leg (SKIP locally if `! command -v terraform`): render for `web_colocate_inngest` = `false` (bool), `"false"` (string), `true` (bool). Assert false/`"false"` OMIT `soleur-inngest-bootstrap` + the `inngest-bootstrap.sh` invocation AND RETAIN `--name soleur-web-platform` + `INNGEST_BASE_URL` + `/run/soleur-hostscripts.ok`, `yaml.safe_load`-clean; true INCLUDES the bootstrap, clean. Var list = server.tf map placeholders + the toggle. Do NOT keep the old awk span-deletion model.
+- [x] 3.4 Add a `hashicorp/setup-terraform@…v4.0.0` step to the `deploy-script-tests` job in `.github/workflows/infra-validation.yml` so the render leg runs (not SKIPs) in CI.
+- [x] 3.5 Run `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS.
+- [x] 3.6 Run `plugins/soleur/test/cloud-init-user-data-size.test.ts` (unmodified) + infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) → green.
+- [x] 3.7 `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/`.
 
 ## Phase 4 — Guardrail verification
-- [ ] 4.1 Confirm `inngest-bootstrap.sh` and `cloud-init-inngest.yml` are byte-unchanged in the diff.
-- [ ] 4.2 (Read-only) `terraform plan` shows no create/replace of `hcloud_server.web[*]`. No apply.
-- [ ] 4.3 PR body says "part of epic #6178" (NOT `Closes`); documents the `web_colocate_inngest=true` + recreate rollback.
+- [x] 4.1 Confirm `inngest-bootstrap.sh` and `cloud-init-inngest.yml` are byte-unchanged in the diff.
+- [x] 4.2 (Read-only) `terraform plan` shows no create/replace of `hcloud_server.web[*]`. No apply.
+- [x] 4.3 PR body says "part of epic #6178" (NOT `Closes`); documents the `web_colocate_inngest=true` + recreate rollback.

--- a/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — Gate co-located Inngest bootstrap on fresh web hosts (part of epic #6178)
+
+Plan: `knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colocation-toggle-plan.md`
+Lane: single-domain · Threshold: single-user incident (requires CPO sign-off)
+
+## Phase 1 — Terraform variable + wiring (contract first)
+- [ ] 1.1 Add `variable "web_colocate_inngest"` to `apps/web-platform/infra/variables.tf` (`type = bool`, `default = false`, non-sensitive, description citing ADR-100 / #6178 / hr-prod-host-config-change-immutable-redeploy).
+- [ ] 1.2 Add `web_colocate_inngest = var.web_colocate_inngest` to the `cloud-init.yml` templatefile map in `apps/web-platform/infra/server.tf` (`:137`, before the closing `}))`).
+
+## Phase 2 — Gate the cloud-init runcmd block
+- [ ] 2.1 Insert col-0 `%{ if web_colocate_inngest ~}` immediately before the `# Bootstrap Inngest server on first boot` comment in `cloud-init.yml`.
+- [ ] 2.2 Insert col-0 `%{ endif ~}` immediately after the block's terminal `trap - EXIT` line and before the next `  - |` item. Do NOT change block indentation or `$${…}` escaping.
+- [ ] 2.3 Verify with `terraform console` that `web_colocate_inngest=false` omits the block and `=true` keeps it; both `yaml.safe_load`-clean.
+
+## Phase 3 — Tests
+- [ ] 3.1 Fix AC3 in `apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`: strip `^%{` lines before `yaml.safe_load`; add a rendered-both-states YAML-validity assertion.
+- [ ] 3.2 Add toggle coverage: markers present + placed; gated span CONTAINS IREF pin + `inngest-bootstrap.sh` run; span-deleted render has NO `soleur-inngest-bootstrap` / `inngest-bootstrap.sh` and parses YAML (models false); marker-only-removed render keeps IREF + parses (models true); optional terraform-render leg with SKIP-when-absent.
+- [ ] 3.3 Run `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS.
+- [ ] 3.4 Run `plugins/soleur/test/cloud-init-user-data-size.test.ts` (unmodified) + infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) → green.
+- [ ] 3.5 `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/`.
+
+## Phase 4 — Guardrail verification
+- [ ] 4.1 Confirm `inngest-bootstrap.sh` and `cloud-init-inngest.yml` are byte-unchanged in the diff.
+- [ ] 4.2 (Read-only) `terraform plan` shows no create/replace of `hcloud_server.web[*]`. No apply.
+- [ ] 4.3 PR body says "part of epic #6178" (NOT `Closes`); documents the `web_colocate_inngest=true` + recreate rollback.

--- a/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6178-web-postcutover-inngest-config/tasks.md
@@ -4,20 +4,22 @@ Plan: `knowledge-base/project/plans/2026-07-11-feat-web-postcutover-inngest-colo
 Lane: single-domain · Threshold: single-user incident (requires CPO sign-off)
 
 ## Phase 1 — Terraform variable + wiring (contract first)
-- [ ] 1.1 Add `variable "web_colocate_inngest"` to `apps/web-platform/infra/variables.tf` (`type = bool`, `default = false`, non-sensitive, description citing ADR-100 / #6178 / hr-prod-host-config-change-immutable-redeploy).
+- [ ] 1.1 Add `variable "web_colocate_inngest"` to `apps/web-platform/infra/variables.tf` (`type = bool` — LOAD-BEARING for string→bool coercion, `default = false`, non-sensitive, description citing ADR-100 / #6178 / hr-prod-host-config-change-immutable-redeploy).
 - [ ] 1.2 Add `web_colocate_inngest = var.web_colocate_inngest` to the `cloud-init.yml` templatefile map in `apps/web-platform/infra/server.tf` (`:137`, before the closing `}))`).
 
 ## Phase 2 — Gate the cloud-init runcmd block
 - [ ] 2.1 Insert col-0 `%{ if web_colocate_inngest ~}` immediately before the `# Bootstrap Inngest server on first boot` comment in `cloud-init.yml`.
 - [ ] 2.2 Insert col-0 `%{ endif ~}` immediately after the block's terminal `trap - EXIT` line and before the next `  - |` item. Do NOT change block indentation or `$${…}` escaping.
-- [ ] 2.3 Verify with `terraform console` that `web_colocate_inngest=false` omits the block and `=true` keeps it; both `yaml.safe_load`-clean.
+- [ ] 2.3 Verify with `terraform console` that `web_colocate_inngest=false` (bool) AND `="false"` (string) both omit the block, and `=true` keeps it; all `yaml.safe_load`-clean.
 
-## Phase 3 — Tests
-- [ ] 3.1 Fix AC3 in `apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`: strip `^%{` lines before `yaml.safe_load`; add a rendered-both-states YAML-validity assertion.
-- [ ] 3.2 Add toggle coverage: markers present + placed; gated span CONTAINS IREF pin + `inngest-bootstrap.sh` run; span-deleted render has NO `soleur-inngest-bootstrap` / `inngest-bootstrap.sh` and parses YAML (models false); marker-only-removed render keeps IREF + parses (models true); optional terraform-render leg with SKIP-when-absent.
-- [ ] 3.3 Run `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS.
-- [ ] 3.4 Run `plugins/soleur/test/cloud-init-user-data-size.test.ts` (unmodified) + infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) → green.
-- [ ] 3.5 `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/`.
+## Phase 3 — Tests (single render authority + cheap structural smoke)
+- [ ] 3.1 Fix AC3 in `apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh`: strip `^%{` lines before `yaml.safe_load` (STRIP-ONLY — no rendered-validity assertion here; it lives once in the render leg).
+- [ ] 3.2 Add cheap structural smoke (no terraform): exactly one `%{ if web_colocate_inngest ~}` + one `%{ endif ~}`; `if` precedes the bootstrap comment; `endif` follows `trap - EXIT` and precedes the next `- |`; static grep asserting `type = bool` on the variable.
+- [ ] 3.3 Add the authoritative terraform-render leg (SKIP locally if `! command -v terraform`): render for `web_colocate_inngest` = `false` (bool), `"false"` (string), `true` (bool). Assert false/`"false"` OMIT `soleur-inngest-bootstrap` + the `inngest-bootstrap.sh` invocation AND RETAIN `--name soleur-web-platform` + `INNGEST_BASE_URL` + `/run/soleur-hostscripts.ok`, `yaml.safe_load`-clean; true INCLUDES the bootstrap, clean. Var list = server.tf map placeholders + the toggle. Do NOT keep the old awk span-deletion model.
+- [ ] 3.4 Add a `hashicorp/setup-terraform@…v4.0.0` step to the `deploy-script-tests` job in `.github/workflows/infra-validation.yml` so the render leg runs (not SKIPs) in CI.
+- [ ] 3.5 Run `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → all PASS.
+- [ ] 3.6 Run `plugins/soleur/test/cloud-init-user-data-size.test.ts` (unmodified) + infra `*.test.ts` (target-parity, web-hosts-fanout-parity, server-tf-set-e) → green.
+- [ ] 3.7 `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/`.
 
 ## Phase 4 — Guardrail verification
 - [ ] 4.1 Confirm `inngest-bootstrap.sh` and `cloud-init-inngest.yml` are byte-unchanged in the diff.


### PR DESCRIPTION
## Summary

Part of epic #6178 (dedicated Inngest host cutover, ADR-100). A freshly-**created** web host
currently bootstraps + enables a co-located `inngest-server.service` unconditionally. Scheduling
is moving to the dedicated `soleur-inngest` host (`10.0.1.40`). This PR adds a reviewable Terraform
toggle `web_colocate_inngest` (**default `false`**) and gates the entire "Bootstrap Inngest server
on first boot" `cloud-init.yml` runcmd item behind a `templatefile` `%{ if … }` / `%{ endif }`
directive. When `false` (post-cutover default), a recreated web host never authors/enables
`inngest-server.service` — making **host-recreate the quiesce mechanism** (no SSH), per
`hr-prod-host-config-change-immutable-redeploy`.

This is a contextual citation of epic #6178 — it is one implementation slice, **not** the whole
cutover. It does **not** `Closes` the epic.

## User-Brand Impact

**If this lands broken, the user experiences:**
- *Gate over-broad* (strips host-script extraction / invalid YAML): a recreated web host fails
  first boot → the fail-closed `/run/soleur-hostscripts.ok` guard `poweroff -f`s the host → Better
  Stack per-host origin-absence check pages; web-1 keeps serving. No data exposed.
- *Gate under-broad* (still co-locates post-cutover) **or** dedicated host not yet ready when a web
  host recreates: a user's scheduled reminder either double-fires (two schedulers) or silently
  misses (no reachable scheduler). Either is user-visible per user.

**If this leaks, the user's data is exposed via:** N/A — no data surface, no PII, no auth. This is a
boot-time systemd/service gate; it moves scheduling topology, it does not read or persist user data.

- **Brand-survival threshold:** single-user incident — a single user's missed/duplicated scheduled
  reminder is user-visible. Mitigations: the AC7 terraform-render leg asserts the gate wraps exactly
  the bootstrap item (omission + retention on both sides, string→bool coercion proven); the existing
  `inngest-doublefire-probe` / `inngest-enumerate-reminders` guard double-fire; and cutover sequencing
  (epic #6178) keeps any web-host recreate behind dedicated-host readiness + the separate
  `INNGEST_BASE_URL` repoint.

## Changelog

### Web Platform (infra)
- Add Terraform variable `web_colocate_inngest` (`type = bool`, `default = false`); `type = bool` is
  load-bearing (Terraform `%{ if }` HCL-bool-converts the rollback route's `"false"` string).
- Gate the co-located Inngest bootstrap in `cloud-init.yml` behind a col-0 `%{ if web_colocate_inngest ~}`
  / `%{ endif ~}` directive; wire the var through `server.tf`'s templatefile map.
- Add an AC7 terraform-render authority leg to `cloud-init-inngest-bootstrap.test.sh` (false / "false" /
  true legs) + a `setup-terraform` step to the `deploy-script-tests` CI job so the leg runs for real.
- Fix two sibling tests (`cloud-init-inngest-bootstrap.test.sh` AC3 + `journald-config.test.sh` AC6) to
  strip the col-0 `%{` directives before raw `yaml.safe_load`.

## Test plan

- [x] `bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh` → 42/42 pass (AC7 render legs incl.).
- [x] All `cloud-init.yml`-referencing infra `*.test.sh` → ALL-PASS (orphan-suite swept).
- [x] `terraform fmt -check` + `terraform validate` on `apps/web-platform/infra/` → clean.
- [x] `bun test` size + target-parity → 79 pass (size test unmodified).
- [x] SAFE-TO-MERGE verified: `hcloud_server.web` `ignore_changes=[user_data,…]` + `-target`-scoped
      auto-apply exclude it → merge recreates no host; `inngest-bootstrap.sh` / `cloud-init-inngest.yml`
      byte-unchanged (dedicated host isolated).

## Rollback

To restore the co-located scheduler (immutable-redeploy reverse of the cutover's `op=rollback`
re-enable): set `web_colocate_inngest = true` (flip the `variables.tf` default or set
`TF_VAR_web_colocate_inngest=true`), then **recreate** the web host. Recreate is the quiesce/restore
mechanism — no SSH, no live mutation.

Generated with [Claude Code](https://claude.com/claude-code)
