### PR TITLE
fix(infra): harden shared deploy tunnel against registry-origin dial storms (#6357)

### DIFF
--- a/apps/web-platform/infra/tunnel.tf
+++ b/apps/web-platform/infra/tunnel.tf
@@ -54,9 +54,24 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "web" {
     # form for zot's plain-HTTP registry — crane/docker then speak HTTP over the raw forward
     # (127.0.0.1:5000 is auto-insecure to docker). The CF Access app + service-token policy are
     # unchanged (identical shape to the working ssh app); only the ingress transport was wrong.
+    #
+    # NOT STALE (#6357): this rule is the LIVE registry-push path — do NOT remove or repoint it.
+    # #6288 moved the zot registry REGION nbg1→hel1 and recreated its store volume, but the origin
+    # private IP `10.0.1.30:5000` is UNCHANGED (the 10.0.1.0/24 net spans hel1; zot-registry.tf
+    # `registry_private_ip = "10.0.1.30"`). Removing this rule breaks CI registry push; repointing
+    # is a no-op. A `dial tcp 10.0.1.30:5000: operation was canceled` here means the origin is
+    # transiently DOWN (registry stability = #6288), NOT that the config is wrong.
     ingress_rule {
       hostname = "registry.${var.app_domain_base}"
       service  = "tcp://${local.registry_endpoint}"
+      origin_request {
+        # Fail-fast so a DOWN registry origin (#6288) doesn't pile up ~30s-held dials that
+        # saturate the shared tunnel daemon's HA-stream budget and degrade the sibling
+        # deploy-webhook route (the 2026-07-11 502; #6357). Mitigation, not cure — root cause is
+        # registry stability (#6288); full deploy-tunnel decoupling + metrics are #6178.
+        connect_timeout   = 5    # INTEGER seconds (NOT "5s") — bounds the TCP dial only
+        no_happy_eyeballs = true # origin is a v4 literal → drop the v4/v6 parallel-dial fan-out
+      }
     }
     # Catch-all rule (required by Cloudflare)
     ingress_rule {

--- a/knowledge-base/engineering/operations/post-mortems/2026-07-11-deploy-tunnel-registry-dial-storm-502-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/2026-07-11-deploy-tunnel-registry-dial-storm-502-postmortem.md
@@ -1,0 +1,159 @@
+---
+title: "Registry-origin dial storm on the shared cloudflared tunnel → transient POST /hooks/deploy 502 (~10 min)"
+date: 2026-07-11
+incident_pr: 6358
+incident_window: "2026-07-11 ~21:06Z–21:16Z (502 window); deploys blocked until ~21:44Z self-recovery"
+recovery_at: "2026-07-11 ~21:44Z"
+suspected_change: "zot registry container transiently DOWN during the #6288 OOM/region-migration (nbg1→hel1) window; dial storm on the shared tunnel degraded the sibling deploy-webhook route"
+brand_survival_threshold: aggregate pattern
+status: resolved
+triggers:
+  - availability (prod deploy-pipeline blocked; prod app stayed healthy)
+art_33_triggered: false
+art_34_triggered: false
+art_33_deadline: "n/a — no personal-data breach; availability-only incident (deploy-pipeline), no confidentiality event"
+---
+
+## Actor key
+
+- `agent` — Claude Code did this autonomously (no operator ack required).
+- `agent-with-ack` — Claude Code did this AFTER operator confirmed via menu option per `hr-menu-option-ack-not-prod-write-auth`.
+- `human` — Operator did this directly.
+
+# Incident Overview
+
+On 2026-07-11, `cloudflared` on web-1 logged continuous `dial tcp 10.0.1.30:5000: operation was canceled`
+for ingressRule=2 (`registry.soleur.ai`) — the zot registry origin was transiently DOWN (registry
+container OOM/restart-loop during the #6288 nbg1→hel1 region migration, whose fresh hel1 volume was
+re-filling from GHCR). The registry, deploy-webhook, and SSH routes all share ONE cloudflared daemon on
+the small web-1 host, so the pile-up of ~30s-held registry dials degraded a sibling route: `POST
+deploy.soleur.ai/hooks/deploy` returned **HTTP 502 at the tunnel edge** for ~10 minutes, blocking two
+prod deploy jobs. The prod app itself stayed healthy throughout — this was a deploy-pipeline-availability
+incident, not a user-facing outage.
+
+## Status
+
+resolved
+
+## Symptom
+
+`POST deploy.soleur.ai/hooks/deploy` → **502** at the CF tunnel layer (~21:06–21:16Z); the packets never
+reached the webhook binary (on-host `curl localhost:9000` processed POST/GET, returning 403/500 on bad
+sig — proving the app was healthy and the drop was above L7-app, at the edge/daemon). `restart-inngest-server.yml`
+(21:06Z) and `web-platform-release.yml`'s `deploy` step (21:12Z, 21:16Z re-run) failed on the 502.
+
+## Incident Timeline
+
+- **Start time (detected):** 2026-07-11 ~21:06Z (first failed deploy job)
+- **End time (recovered):** 2026-07-11 ~21:44Z (re-run of the release `deploy` returned 202, deployed v0.212.3 via the GHCR fallback path)
+- **Duration (MTTR):** ~38 min from first failed deploy to a green re-run (502 window itself was ~10 min)
+
+| Actor | Time (UTC) | Action |
+|---|---|---|
+| system | 2026-07-11 ~21:06Z | `restart-inngest-server.yml` deploy hook POST → 502 at the tunnel edge. |
+| system | 2026-07-11 ~21:12Z | `web-platform-release.yml` `deploy` step → 502; re-run at 21:16Z also 502. |
+| agent | 2026-07-11 ~21:16Z | Self-pulled evidence: `systemctl is-active cloudflared webhook inngest-server` all `active`; `journalctl -u cloudflared` shows repeated `dial tcp 10.0.1.30:5000: operation was canceled` for `registry.soleur.ai`; webhook binary healthy (403/500 on bad-sig localhost POST). |
+| system | 2026-07-11 ~21:44Z | 502 window self-cleared (registry dial storm drained); a release `deploy` re-run returned 202 and deployed `v0.212.3` (GHCR fallback; `ZOT_GATE_DEGRADED: probe_unreachable`). |
+
+## Participants and Systems Involved
+
+The shared web-1 `cloudflared` daemon (registry + deploy-webhook + SSH ingress on one tunnel), the zot
+registry origin (`10.0.1.30:5000`), the prod deploy webhook binary, and GitHub Actions release/restart
+workflows. No operator action was required for recovery (self-recovered).
+
+## Detection (+ MTTD)
+
+- **How detected:** system — two consecutive GitHub Actions deploy jobs went red on a tunnel-layer 502. No independent deploy-path monitor exists today (tracked → #6178).
+- **MTTD:** ~immediate (the failed deploy jobs were the signal).
+
+## Triggered by
+
+provider/system — the zot registry container was transiently unavailable during the #6288 OOM/region-migration window; the dial storm on the shared tunnel daemon degraded the sibling deploy route.
+
+## Root-cause hypothesis (triage)
+
+| Hypothesis | Supporting evidence | Disconfirming evidence | Status |
+|---|---|---|---|
+| Registry origin DOWN → dial storm saturates the shared cloudflared daemon's HA-stream budget → sibling deploy-webhook 502 | `journalctl` shows continuous `dial…canceled` for `registry.soleur.ai` only; webhook binary healthy in-window; 502 at edge not app; self-recovery when the storm drained | cloudflared `--metrics` (`ha_connections`, `concurrent_requests_per_tunnel`) were NOT captured → the saturation MECHANISM is unverified (observability gap → #6178) | LIKELY (mechanism unverified) |
+
+## Resolution
+
+Self-recovered on 2026-07-11 when the registry stabilized and the dial storm drained; a release re-run
+deployed `v0.212.3` via the GHCR fallback. The **durable mitigation** (this PR, #6358): a fail-fast
+`origin_request { connect_timeout = 5; no_happy_eyeballs = true }` scoped to the registry ingress rule in
+`apps/web-platform/infra/tunnel.tf`, bounding the TCP dial so a DOWN registry origin can no longer pile up
+~30s-held dials against the shared daemon. The PR also corrects the issue's false "stale rule" premise
+in-line (the origin is the LIVE ADR-096/#6122 registry-push path; #6288 moved the region, not the IP).
+This is a blast-radius mitigation, NOT a cure — the root cause (registry stability) is #6288, and the
+architectural fix (decouple the deploy webhook from sibling tunnel traffic + add an independent monitor +
+cloudflared metrics) is #6178.
+
+## Recovery verification
+
+The 2026-07-11 ~21:44Z release re-run returned 202 and deployed `v0.212.3` (self-recovery confirmed by a
+green deploy). The mitigation is verified statically pre-merge: `terraform fmt -check` + `terraform
+validate` pass against the v4-pinned root (validate confirms the integer `connect_timeout`). Post-merge,
+the `apply-web-platform-infra.yml` auto-apply lands the edge-config change, and the no-SSH
+`deploy.soleur.ai/hooks/deploy-status` probe (bad-sig POST returns 403/500, not 502) confirms the
+tunnel→webhook path is healthy.
+
+---
+
+# Incident Post-Mortem Analysis
+
+## Root Cause(s) — 5-Whys
+
+1. **Why did prod deploys fail?** `POST /hooks/deploy` returned 502 at the tunnel edge.
+2. **Why did the tunnel edge 502?** The web-1 cloudflared daemon could not get a healthy origin stream for the deploy-webhook route.
+3. **Why couldn't it?** The registry origin (`10.0.1.30:5000`) was DOWN, and each retry/probe held an edge HA-stream slot for the full ~30s default `connect_timeout`, saturating the shared daemon's stream/CPU budget on the small host.
+4. **Why was the registry origin down?** The zot container was OOM/restart-looping during the #6288 nbg1→hel1 region migration (fresh hel1 volume re-filling from GHCR).
+5. **Why did a registry problem break the deploy path?** The registry, deploy-webhook, and SSH ingress all share ONE cloudflared daemon/tunnel — a per-route origin failure has cross-route blast radius (architectural coupling → #6178).
+
+## Versions of Components
+
+- **Version(s) that triggered the outage:** `tunnel.tf` registry ingress rule with the default ~30s `connect_timeout` (no `origin_request` override); zot registry mid-#6288-migration.
+- **Version(s) that restored the service:** self-recovery deployed `v0.212.3`; durable mitigation in PR #6358.
+
+## Impact details
+
+### Services Impacted
+
+Prod deploy pipeline — `POST /hooks/deploy` unreachable for ~10 min; two deploy jobs blocked until ~21:44Z self-recovery. The prod web-platform app served traffic normally throughout (no runtime cutover was in flight during the window).
+
+### Customer Impact (by role)
+
+- Prospect: none (marketing site + app unaffected).
+- Authenticated app user: none — the running app was healthy; only the ability to ship NEW deploys was blocked.
+- Legal-document signer: none.
+- Admin via Access: none.
+- Billing customer: none.
+- OAuth installation owner: none.
+
+### Revenue Impact
+
+None (single-user / tenant-zero stage; deploy-pipeline availability only).
+
+### Team Impact
+
+~minimal — self-recovered without operator intervention; the evidence was self-pulled during triage.
+
+## Lessons Learned
+
+### Where we got lucky
+
+The 502 hit a short window with no runtime cutover pending, and the registry stabilized on its own before any operator action — so the shared-daemon coupling caused no user-facing outage this time.
+
+### What went well
+
+The failure was fully self-diagnosable from telemetry (journalctl + on-host service state), the fail-closed deploy jobs correctly blocked rather than shipping through a degraded path, and the GHCR fallback let the re-run deploy succeed once the storm drained.
+
+### What went wrong
+
+A single DOWN origin on the shared cloudflared tunnel degraded a sibling route (no blast-radius bound), there is no independent monitor for the deploy path (the 502 surfaced only via CI failure), and the issue that filed the incident mis-attributed the cause to a "stale ingress rule," inviting a destructive removal that would have broken CI registry push.
+
+## Action Items & Follow-ups
+
+| Issue | Action | Status |
+|---|---|---|
+| #6288 | Fix the zot registry container OOM/restart-loop (the true root cause) and un-pause the registry liveness heartbeat. | open |
+| #6178 | Decouple the deploy webhook from sibling tunnel traffic + add an independent deploy-path monitor + export cloudflared `--metrics` (verifies the shared-daemon HA-stream saturation mechanism). | open |

--- a/knowledge-base/project/learnings/workflow-patterns/2026-07-12-remove-request-issue-verify-stale-premise-before-acting.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-07-12-remove-request-issue-verify-stale-premise-before-acting.md
@@ -1,0 +1,77 @@
+---
+title: "A 'remove the stale/dead X' infra issue is a premise to VERIFY, not an instruction to execute"
+date: 2026-07-12
+issue: 6357
+pr: 6358
+category: workflow-patterns
+tags: [infra, terraform, cloudflare-tunnel, premise-verification, incident-derived]
+---
+
+## Problem
+
+Issue #6357 (incident-derived, filed after a transient 2026-07-11 deploy-tunnel 502)
+asked to **remove or repoint** a `registry.soleur.ai → tcp://10.0.1.30:5000` Cloudflare
+tunnel ingress rule, on the stated premise that it was a **"stale leftover pointing at a
+dead origin"** from a "registry migration nbg1→hel1 (#6288)."
+
+Executing that ask literally would have **broken CI registry push**: the rule is the LIVE
+ADR-096/#6122 registry-push path, and removing it takes down `cloudflared access tcp
+--hostname registry.<base>`.
+
+## Root Cause / Reality
+
+The issue's premise was false on every sub-claim, verified against git history + config:
+- **"Stale leftover"** → the rule was deliberately added in #6120/#6122 (ADR-096) with a
+  dedicated CF Access app + service token; `git log tunnel.tf` shows active work through #6202.
+- **"Dead origin, moved to a new host per #6288"** → #6288 moved the registry **region**
+  (nbg1→hel1) and recreated the store volume, but the **private IP `10.0.1.30:5000` is
+  unchanged** (`10.0.1.0/24` spans hel1; `zot-registry.tf:40 registry_private_ip="10.0.1.30"`).
+  Repointing is a no-op.
+- **"#6288 is a migration PR"** → #6288 is an **OPEN issue** ("zot registry restart-loops ~4/min,
+  likely OOM"); it is the registry-**stability** tracker. The `dial … canceled` errors mean the
+  origin was transiently **down**, not that the config is wrong.
+
+## Solution
+
+Re-scope from *remove* to *correct-the-premise + fail-fast hardening* (a 2-field, in-place
+`tunnel.tf` edit):
+1. Correct the false "stale rule" comment in-line so the next reader does not delete the live
+   push path (defuse the destructive-mis-fix footgun the issue itself requested).
+2. Add `origin_request { connect_timeout = 5; no_happy_eyeballs = true }` scoped to the
+   registry ingress rule — bounds the TCP dial so a DOWN origin can't pile up ~30s-held dials
+   that saturate the shared tunnel daemon and degrade the sibling deploy-webhook route.
+3. Root cause (registry stability) → #6288; deploy-tunnel decoupling + metrics → #6178. Neither
+   fixed here.
+
+## Key Insight
+
+An incident-derived "delete/repoint the stale/dead thing" issue is a **claim to verify against
+git history + the actual config**, not an instruction to execute — the same class as
+`hr-verify-repo-capability-claim-before-assert` and the go-routing "external-bug claim is a
+claim to VERIFY" sharp edge, applied to *remove-requests*. Before removing infra an issue calls
+"stale": `git log --oneline -- <file>` the rule to find its introducing PR/ADR, and grep the
+origin address (`registry_private_ip`, endpoint locals) to confirm the "moved/dead" claim.
+Cheapest gate; the downside of skipping it is a self-inflicted outage on the exact path the
+issue thought it was cleaning up.
+
+## Session Errors
+
+- **Local `terraform plan` failed twice during pre-merge verification.** — Recovery: (1) first
+  attempt omitted `--name-transformer tf-var`, so every `var.*` was "No value for required
+  variable" — the CI workflow (`apply-web-platform-infra.yml`) injects vars via
+  `doppler run -c prd_terraform --name-transformer tf-var --`; (2) the corrected attempt then hit
+  "No valid credential sources found" because the R2 state backend + providers need the full CI
+  AWS-SSO credential set, not replicable in a local session. — Prevention: for an infra-only edge-
+  config change, `terraform validate` + `fmt -check` + the AC greps are the authoritative LOCAL
+  gates (the plan itself designates `validate` as the arbiter for the `connect_timeout` type); the
+  live plan+apply is exercised by the merge-triggered apply workflow — do not burn cycles
+  replicating the CI cred env locally.
+- **Orphan plan draft from a mid-run date rollover.** — Recovery: `/plan` wrote
+  `2026-07-11-...plan.md`; the date rolled to 07-12 before `/deepen-plan`, which emitted a NEW
+  canonical `2026-07-12-...` file (referenced by `tasks.md`) and left the 07-11 draft untracked.
+  Removed the orphan during /work so a single plan file remains. — Prevention: on a
+  plan→deepen-plan run that crosses UTC midnight, expect two dated plan files; keep the deepened
+  one (matches `tasks.md` `plan:` frontmatter) and drop the orphan.
+- **Forwarded (plan/deepen phase, one-off):** an SSH-in-command grep false-positive matched the
+  prose "without SSH" in the Observability `expected_output` (reworded); `connect_timeout` type
+  disagreement between research sources (resolved: integer, verified by `terraform validate`).

--- a/knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
@@ -12,6 +12,28 @@ date: 2026-07-12
 
 # 🐛 fix(infra): harden shared deploy tunnel against registry-origin dial storms (#6357)
 
+## Deepen-Plan Enhancement Summary
+
+**Deepened:** 2026-07-12 · **Panel:** CTO/platform-strategist, framework-docs, repo-research, learnings + plan-review (DHH, Kieran, code-simplicity).
+
+**Key corrections applied (from research + review):**
+1. **Premise falsified** — the issue's "stale/dead/migrated" origin is wrong: #6288 kept the private IP `10.0.1.30:5000`; the rule is the live ADR-096/#6122 push path. Re-scoped *remove* → *harden + correct comment*.
+2. **`connect_timeout` is an INTEGER (`5`), not `"5s"`** (Kieran, verified vs v4 provider docs; `terraform validate` is the arbiter). framework-docs initially reported a duration string — the disagreement is resolved in-plan.
+3. **Deploy-tunnel monitor deferred to #6178** — the cheap `cloudflare_notification_policy` is structurally blind to a daemon-up sibling 502; the real CF-Access synthetic is over-scope for a transient, CI-detected, self-recovered incident. Scope tightened to a single in-place `tunnel.tf` edit.
+4. **Dropped prose-testing** (comment-string drift-test + ACs) per DHH + simplicity; kept one behavioral removal-guard AC.
+
+**Gate status:** User-Brand Impact ✓ (aggregate pattern) · Observability ✓ (no-SSH probe) · PAT-halt ✓ (none) · UI-wireframe ✓ (no UI surface) · Network-outage deep-dive ✓ (below) · Precedent ✓ (`origin_request` is novel in-repo — `git grep` returned no existing use; framework-docs-verified v4 schema). Citations verified live: #6357/#6288/#6178/#6122 all OPEN.
+
+## Network-Outage Deep-Dive (L3→L7)
+
+The `## Hypotheses` section already sequences L3→L7 with the issue's self-pulled evidence as the verification artifact. Layer status:
+- **L3 firewall / private-net:** verified — dial-canceled scoped to `registry.soleur.ai` only; origin transiently absent during #6288 ForceNew region-migrate. No firewall/egress-IP drift (registry is deny-all-public + reached over the private net, not a public allowlist).
+- **L3 DNS/routing:** verified — deploy/ssh/registry share one `cfargotunnel.com` CNAME (single daemon).
+- **L7 TLS/edge:** primary hypothesis (shared-daemon HA-stream saturation) is **UNVERIFIED** — cloudflared `--metrics` were not captured; this is the observability gap deferred to #6178. `connect_timeout` mitigates every candidate mechanism.
+- **L7 app:** ruled out — the webhook binary returned 403/500 (not 502) in-window; the 502 packets never reached it.
+
+No firewall/egress-IP verification is required before implementation: the fix is an edge-config timeout, not a host-reachability change. This satisfies `hr-ssh-diagnosis-verify-firewall` (L3 verified before any L7 fix).
+
 ## Overview
 
 On 2026-07-11 (~21:06–21:16 UTC) `POST deploy.soleur.ai/hooks/deploy` returned **HTTP 502 at the
@@ -274,7 +296,7 @@ logs:
   retention: Cloudflare default; GitHub Actions run logs (90d)
 discoverability_test:
   command: 'curl -s -H "X-Signature-256: <hmac>" https://deploy.soleur.ai/hooks/deploy-status  # returns last deploy state; bad-sig POST /hooks/deploy → 403/500 not 502'
-  expected_output: last deploy state JSON (healthy) / 403 on bad sig — proves tunnel→webhook path alive without SSH
+  expected_output: last deploy state JSON (healthy) / 403 on bad sig — proves tunnel→webhook path alive without host shell access
 ```
 
 **Affected-surface note:** the true diagnostic signal for the L7-edge saturation hypothesis is
@@ -347,6 +369,11 @@ None. `gh issue list --label code-review --state open` returned no open scope-ou
   on daemon degradation, not on a single ingress route returning 502 while the daemon is up — so the
   #6357 failure mode would not be caught. The real detector (CF-Access-authed synthetic 502) carries a
   secret-surface cost. Both deferred to **#6178** rather than shipping blind detection.
+- **No in-repo `origin_request` precedent** (precedent-diff gate) — `git grep origin_request -- 'apps/**/*.tf'`
+  returns nothing; this is the first use of a per-ingress `origin_request` block in the repo. Pattern is
+  **novel**, so `terraform validate` + the captured `terraform plan` (Phase 3) are the load-bearing
+  correctness gates rather than a sibling diff. The v4 schema for the two fields was framework-docs +
+  Kieran-verified.
 - **`Closes #6357` at merge would false-resolve** — the real fix lands at **post-merge apply**; use
   `Ref #6357` + a post-apply `gh issue close` (ops-remediation close pattern).
 - **Deferred work has trackers already:** registry stability → **#6288** (open); tunnel decoupling +

--- a/knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
@@ -1,0 +1,374 @@
+---
+title: "fix(infra): harden shared deploy tunnel against registry-origin dial storms (#6357)"
+issue: 6357
+type: fix
+classification: infra
+lane: cross-domain   # spec.md absent for this branch — defaulted to cross-domain (fail-closed)
+brand_survival_threshold: aggregate pattern
+provider: cloudflare ~> 4.0
+status: ready-for-work
+date: 2026-07-12
+---
+
+# 🐛 fix(infra): harden shared deploy tunnel against registry-origin dial storms (#6357)
+
+## Overview
+
+On 2026-07-11 (~21:06–21:16 UTC) `POST deploy.soleur.ai/hooks/deploy` returned **HTTP 502 at the
+Cloudflare tunnel layer** for ~10 minutes, blocking two prod deploy jobs
+(`restart-inngest-server.yml`, `web-platform-release.yml#deploy`). It self-recovered by ~21:44 UTC;
+a re-run deployed `v0.212.3` via the GHCR fallback path. Concurrently, `cloudflared` on web-1 was
+logging continuous `dial tcp 10.0.1.30:5000: operation was canceled` for ingressRule=2
+(`registry.soleur.ai`).
+
+**Issue #6357 proposes removing (or repointing) the `registry.soleur.ai → tcp://10.0.1.30:5000`
+ingress rule, on the premise that it is a "stale leftover" pointing at a "dead origin" from a
+"registry migration nbg1→hel1 (#6288)."** Research falsifies that premise (see Research
+Reconciliation). The correct #6357 deliverable is **not** a removal — it is:
+
+1. **Correct the false "stale rule" premise in `tunnel.tf`** so no future agent/operator deletes the
+   live registry-push path (the highest-leverage, lowest-risk change — it defuses a destructive
+   mis-fix footgun).
+2. **Reduce the blast radius** a down registry origin has on the *shared* tunnel daemon by adding a
+   minimal fail-fast `origin_request { connect_timeout = 5; no_happy_eyeballs = true }` scoped to
+   the registry ingress rule.
+3. **Close the observability gap** that let the 502 go undetected except via CI failure, by adding an
+   independent edge-side/synthetic monitor for the deploy tunnel path.
+
+The true **root cause** (registry container instability during the #6288 OOM/region-migration window)
+is tracked in **#6288**; the proper **architectural** fix (decouple the deploy webhook from
+co-located/sibling tunnel traffic) is tracked in **#6178** ("pollutes the deploy tunnel"). This plan
+deliberately does neither — it lands the cheap, durable edge-hardening + premise correction.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue #6357 claim | Reality (verified) | Plan response |
+|---|---|---|
+| The rule is a **"stale leftover"** | It was added deliberately in **#6122 / ADR-096** as the registry **PUSH** ingress, with a dedicated CF Access app + service token + Doppler secrets (`tunnel.tf:44-60,133-209`). `git log tunnel.tf` shows active work through #6202 (2026-07). | **Do NOT remove.** Correct the "stale" comment; keep the rule. |
+| Origin `10.0.1.30:5000` is **"dead"** because the registry **"moved to a new host per #6288"** | #6288 (`registry-region-migrate`) moved the registry **region** nbg1→hel1 and recreated the store **volume**, but the **private IP stayed `10.0.1.30`** — the `10.0.1.0/24` net spans hel1 (`variables.tf:45`; `zot-registry.tf:40 registry_private_ip="10.0.1.30"`). The origin address is **unchanged and correct**. | **Do NOT repoint** — repointing is a no-op. |
+| #6288 is a **"registry migration"** PR | #6288 is an **OPEN issue**: *"zot registry container restart-loops (~4/min) post-disk-fix — likely OOM."* `closedByPullRequestsReferences: []`. It is the registry-**stability** tracker, not a migration record. | Root cause = registry transiently **down** during the OOM/ForceNew window (empty hel1 volume re-filling from GHCR). Link #6288; do not re-fix here. |
+| "Remove the rule to fix the deploy 502" | Removing it breaks the CI registry-**push** path (`cloudflared access tcp --hostname registry.<base>`; `dns.tf:52-66`). Deploys still work via the GHCR fallback (`ci-deploy.sh` `ZOT_GATE_DEGRADED`), but push CI would fail. | Fix the **coupling**, not the rule: fail-fast `origin_request` + an independent deploy-path monitor. |
+
+**Premise Validation note:** Cited refs checked — #6357 (target, OPEN), #6288 (OPEN issue, not a
+migration PR), #6178 (OPEN, architectural tunnel-decoupling), #6122 (feat), ADR-096 (in-repo). The
+central "stale/migrated origin" premise is **stale/misattributed**; the plan re-scopes from *remove*
+to *harden + correct*. In a headless one-shot this challenge is also recorded in
+`decision-challenges.md` for `ship` to surface.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the operator (Soleur's non-technical founder) cannot
+ship — a too-tight `connect_timeout` on the registry rule would fail-close the CI registry-**push**
+(deploys degrade to the GHCR fallback, non-fatal), and a malformed tunnel-config apply could 502 the
+deploy webhook itself, blocking all prod releases until reverted.
+
+**If this leaks, the user's data / workflow / money is exposed via:** N/A — this change moves no user
+data; it tunes an edge→origin timeout and adds a synthetic monitor. No new secret surface (the CF
+Access deploy service token already exists in TF state).
+
+**Brand-survival threshold:** aggregate pattern — the blast radius is prod-**deploy-pipeline
+availability** (fleet-wide shipping capability), not any single user's data. No `single-user incident`
+→ no CPO plan-time sign-off required; section present for the ship-time gate. `tunnel.tf` is a
+sensitive path, so this threshold line is load-bearing for preflight Check 6.
+
+## Hypotheses (L3→L7 — network-outage checklist)
+
+The incident evidence was **self-pulled and captured in the issue** (no operator action); it is the
+verification artifact for the lower layers. Ordering per
+`plan-network-outage-checklist.md` (triggered by `502` / `timeout` / dial-`canceled`).
+
+1. **L3 — firewall / private-net reachability to the origin.** `10.0.1.30:5000` is deny-all-public;
+   web-1's `cloudflared` reaches it as a `10.0.1.0/24` member (`dns.tf:57-58`, `network.tf:55-60`).
+   During #6288's ForceNew region-migrate the registry host/volume was **recreated** → the origin was
+   transiently **absent**, producing `dial … operation was canceled`. **[verified via issue journal
+   evidence: repeated dial-canceled for `registry.soleur.ai` only]**
+2. **L3 — DNS / routing.** `deploy`, `ssh`, and `registry` all CNAME to the **same** tunnel
+   `${tunnel.web.id}.cfargotunnel.com` (`dns.tf:31-66`) → they share **one** `cloudflared` daemon.
+   Routing itself was healthy. **[verified: single shared tunnel confirmed in dns.tf/tunnel.tf]**
+3. **L7 — TLS / edge (proxy) layer.** The 502 originated at the **CF tunnel edge**, i.e. the edge
+   could not get a healthy origin stream from the web-1 daemon. **Primary hypothesis:** the registry
+   dial storm (CI push retries + probes) piled up concurrent goroutines each holding an edge HA-stream
+   slot for the full ~30s default `connect_timeout`, saturating the shared stream budget /
+   CPU on the small cx host → no slot for the deploy-webhook stream → sibling 502. Self-recovery when
+   the storm drained fits this. **[UNVERIFIED mechanism — cloudflared `--metrics` were not captured;
+   this is the observability gap this plan closes. Alternative co-mechanisms: host CPU/mem starvation;
+   edge-side origin-health marking. `connect_timeout` reduction mitigates all three.]**
+4. **L7 — application (webhook binary).** RULED OUT as the drop point: on-host evidence showed
+   `webhook`/`cloudflared`/`inngest-server` all `active`, and `localhost:9000` processed POST/GET
+   (403/500 on bad sig). A request that **reaches** the binary returns 403/500, **not** 502 → the 502
+   packets never reached the app. **[verified: absence of an app-layer signal is itself the signal —
+   the drop is above L7-app, at the edge/daemon layer]**
+
+**Opt-out (L7-app deeper trace):** justified — the binary was proven healthy in-window by the issue's
+self-pulled evidence; no service-layer hypothesis is warranted.
+
+## Implementation Phases
+
+### Phase 1 — Correct the false "stale rule" premise in `tunnel.tf` (highest leverage)
+
+Edit the comment block above the `registry.${var.app_domain_base}` ingress rule
+(`apps/web-platform/infra/tunnel.tf:44-60`) to state, in-line, that this rule is the **live** ADR-096
+/ #6122 registry-**push** path and is **NOT** stale:
+
+- The `10.0.1.30:5000` origin is the current zot registry; #6288 moved the registry **region**
+  nbg1→hel1 but the **private IP is unchanged** (10.0.1.0/24 spans hel1).
+- **Do NOT remove or repoint** this rule — removal breaks CI registry push (`cloudflared access tcp
+  --hostname registry.<base>`); repointing is a no-op.
+- `dial … operation was canceled` here means the **origin is transiently down** (registry stability =
+  #6288), not that the config is wrong.
+
+**Purpose:** permanently defuse the "delete the stale rule" mis-fix the next reader would otherwise
+attempt (the exact class of destructive change #6357 requested).
+
+### Phase 2 — Fail-fast `origin_request` on the registry ingress rule (blast-radius reduction)
+
+In the same `ingress_rule` block (`tunnel.tf:57-60`), add a **minimal** nested block (verified v4
+schema — `cloudflare/cloudflare ~> 4.0`, per-ingress overrides config-level):
+
+```hcl
+ingress_rule {
+  hostname = "registry.${var.app_domain_base}"
+  service  = "tcp://${local.registry_endpoint}"
+  origin_request {
+    # Fail-fast so a DOWN registry origin (see #6288) does not pile up ~30s-held
+    # dials that saturate the shared tunnel daemon's HA-stream budget and degrade
+    # the sibling deploy-webhook route (the 2026-07-11 502; #6357). Mitigation,
+    # not cure — root cause is registry stability (#6288); decoupling is #6178.
+    connect_timeout   = 5        # INTEGER seconds (NOT "5s") — bounds the TCP dial only
+    no_happy_eyeballs = true     # origin is a v4 literal → removes the v4/v6 parallel-dial fan-out
+  }
+}
+```
+
+Constraints (from CTO + framework-docs research + Kieran plan-review):
+- **`connect_timeout` is an INTEGER (seconds) in the CF provider schema, not a Go-duration string.**
+  Use `connect_timeout = 5`, NOT `"5s"` — the string form fails `terraform validate` (number
+  conversion) and is the wrong grep literal. Kieran verified against the v4 provider docs; framework
+  research initially reported a duration-string form, so **Phase 3 `terraform validate` is the
+  arbiter** — if v4 unexpectedly rejects the integer, fall back to the duration string, but the
+  integer is the verified form.
+- `connect_timeout` bounds the **TCP handshake only** — a cold zot still `accept()`s immediately, and
+  large-layer pushes are unaffected (no total-duration bound introduced). **Do NOT go below 5**
+  (seconds) — host accept-queue backpressure could false-fail a valid push.
+- **Do NOT** add `keep_alive_*` / `tcp_keep_alive` / `proxy_type` / `http_host_header` — HTTP/pool
+  semantics that are no-ops (best case) or schema friction (worst) for a raw `tcp://` bridge.
+
+### Phase 3 — Pre-apply validation
+
+Run `terraform fmt -check` + `terraform validate` (v4 provider) against the edited root **before**
+merge — this is the arbiter for the `connect_timeout` integer-vs-string question and catches any
+`origin_request` schema mismatch at config-phase (the v4-vs-v5 resource-name learning applies).
+Capture the `terraform plan` diff to confirm the **only** change is a single **in-place update** to
+`cloudflare_zero_trust_tunnel_cloudflared_config.web`, **0 to destroy**.
+
+### Deferred (NOT in this PR) — independent deploy-tunnel monitor → #6178
+
+The deploy webhook path has no independent monitor today (the 502 was noticed only via CI failure).
+Plan-review converged that adding one here is **out of scope**:
+- The cheap Terraform-native option (`cloudflare_notification_policy` for tunnel-health) is
+  **structurally unlikely to detect this failure mode** — a sibling-route 502 while the daemon stays
+  *up* (Kieran) — so it would ship green-but-blind.
+- The option that *does* detect it (a CF-Access-authed synthetic 502 monitor) requires wiring the
+  deploy service-token secret into a third party (Better Stack), a real secret-surface cost (DHH +
+  simplicity: over-scope for a transient, self-recovered, already-CI-detected incident).
+
+So the monitor + the richer cloudflared `--metrics` export are **deferred to #6178** (which already
+owns deploy-tunnel decoupling + telemetry). This plan keeps the `## Observability` section (existing
+signals + the no-SSH `deploy-status` discoverability probe) but adds **no** new monitor resource —
+hence Phases 1–2 touch only the already-`-target`ed tunnel config resource and need **no** workflow
+edit.
+
+## Files to Edit
+
+- `apps/web-platform/infra/tunnel.tf` — Phase 1 comment correction + Phase 2 `origin_request` block on
+  the registry ingress rule (existing resource `cloudflare_zero_trust_tunnel_cloudflared_config.web`,
+  already in the apply `-target=` allow-list at `apply-web-platform-infra.yml:313`).
+
+## Files to Create
+
+None. (The deploy-tunnel monitor and cloudflared metrics export are deferred to #6178; no drift-test
+file — its two greps live in Acceptance Criteria, and testing a comment string is brittle prose-testing
+per plan-review.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `apps/web-platform/infra/tunnel.tf` registry `ingress_rule` block contains
+      `origin_request { connect_timeout = 5 ... no_happy_eyeballs = true }` (integer, not `"5s"`) and
+      **no** `keep_alive_*` / `proxy_type` / `http_host_header` field. Verify:
+      `awk '/hostname = "registry/,/^    }/' apps/web-platform/infra/tunnel.tf | grep -c connect_timeout`
+      ≥ 1 and `... | grep -c keep_alive` = 0.
+- [ ] Removal-guard (the one behavioral guard, kept per Kieran): the registry ingress rule still routes
+      to the endpoint — `grep -c 'tcp://\${local.registry_endpoint}' apps/web-platform/infra/tunnel.tf`
+      ≥ 1. (Loosened from `= 1` so a Phase-1 comment that names the same interpolated token does not
+      false-fail.)
+- [ ] `terraform fmt -check` passes and `terraform validate` passes against the v4-pinned root (this is
+      the arbiter for the `connect_timeout` type).
+- [ ] `terraform plan` (captured in PR) shows a single **in-place update** to
+      `cloudflare_zero_trust_tunnel_cloudflared_config.web` and **0 to destroy** (no net-new resource,
+      no `-target=` workflow edit).
+- [ ] PR body uses **`Ref #6357`** (not `Closes`) — this is an ops-remediation whose real close
+      happens post-apply (see below). Also `Ref #6288`, `Ref #6178`.
+
+### Post-merge (operator / automated)
+
+- [ ] Merge to `main` auto-applies via `apply-web-platform-infra.yml` (tunnel config resource is in the
+      `-target=` set). **Automation: feasible** — no operator SSH; the workflow applies the remote
+      tunnel config. Confirm the workflow run is green.
+- [ ] No-SSH deploy-path health probe returns healthy: `GET deploy.soleur.ai/hooks/deploy-status`
+      (HMAC via `X-Signature-256`, handler `cat-deploy-state.sh`) returns the last deploy state, and a
+      bad-sig `POST deploy.soleur.ai/hooks/deploy` returns the webhook's **403/500** (not 502) —
+      proving the tunnel→webhook path is healthy. **Automation: feasible** (curl + HMAC; no SSH).
+- [ ] Close #6357 via `gh issue close 6357` only **after** the apply is green and the probe passes
+      (ops-remediation close pattern).
+
+## Infrastructure (IaC)
+
+### Terraform changes
+- `apps/web-platform/infra/tunnel.tf`: **single** in-place `origin_request` block on
+  `cloudflare_zero_trust_tunnel_cloudflared_config.web` (existing resource) + a comment correction. No
+  net-new resource.
+- Providers/pins: `cloudflare/cloudflare ~> 4.0` (existing). **No new provider, no new no-default
+  `TF_VAR_*`, no new secret.** (The registry-push CF Access token is already provisioned.)
+
+### Apply path
+(b) cloud-init + idempotent bootstrap → **N/A**; this is a **Cloudflare-managed remote tunnel config**
+(`config_src = "cloudflare"`) pushed by Terraform. Chosen path: **merge-triggered auto-apply**
+(`apply-web-platform-infra.yml`, `-target`-scoped; the tunnel config resource is already targeted at
+line 313, so **no workflow edit is needed**). Expected blast-radius: an in-place edge-config update —
+no host reboot, no container restart, no downtime.
+
+### Distinctness / drift safeguards
+- No `dev`/`prd` split concern (single prod tunnel). `lifecycle.ignore_changes = [secret, config_src]`
+  on the tunnel resource (`tunnel.tf:21-23`) is unaffected — we edit the **config** resource, not the
+  tunnel resource. State holds no new secret. Re-run `terraform plan` immediately pre-merge to confirm
+  no accumulated unrelated drift rides along (drift-runbook learning).
+
+### Vendor-tier reality check
+- N/A — no net-new monitored resource (the deploy-tunnel monitor is deferred to #6178). No tier gate.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: post-apply confirmation the deploy tunnel→webhook path is healthy (no-SSH probe)
+  cadence: post-merge (apply green) + on-demand; independent deploy-tunnel monitor deferred to #6178
+  alert_target: ops@jikigai.com (existing Better Stack team member / CF notification email)
+  configured_in: apps/web-platform/infra/hooks.json.tmpl (deploy-status endpoint, existing); monitor → #6178
+error_reporting:
+  destination: GitHub Actions run status (deploy jobs) today; independent page deferred → #6178
+  fail_loud: yes — a failed deploy job goes red; the #6178 monitor will add an independent page
+failure_modes:
+  - mode: registry origin down → dial-storm degrades sibling deploy route (the #6357 incident)
+    detection: no-SSH deploy-status probe (below) returns 502; deploy jobs go red; independent monitor → #6178
+    alert_route: GitHub Actions run status; ops@jikigai.com (post-#6178 monitor)
+  - mode: registry origin down (root cause) — registry container OOM/restart-loop
+    detection: betteruptime_heartbeat.registry_prd (exists; currently PAUSED — un-pause tracked in #6288)
+    alert_route: ops@jikigai.com
+  - mode: registry-PUSH broken by too-tight connect_timeout
+    detection: CI release push step fails / falls back to GHCR (ZOT_GATE_DEGRADED in workflow logs)
+    alert_route: GitHub Actions run status (release workflow)
+logs:
+  where: Cloudflare tunnel edge (GraphQL/Logpush, edge-side); cloudflared --metrics on host (deferred → #6178)
+  retention: Cloudflare default; GitHub Actions run logs (90d)
+discoverability_test:
+  command: 'curl -s -H "X-Signature-256: <hmac>" https://deploy.soleur.ai/hooks/deploy-status  # returns last deploy state; bad-sig POST /hooks/deploy → 403/500 not 502'
+  expected_output: last deploy state JSON (healthy) / 403 on bad sig — proves tunnel→webhook path alive without SSH
+```
+
+**Affected-surface note:** the true diagnostic signal for the L7-edge saturation hypothesis is
+cloudflared `--metrics` (`concurrent_requests_per_tunnel`, `ha_connections`, origin-dial errors). That
+export **and** the independent deploy-tunnel monitor are a larger lift (metrics-port reachability;
+CF-Access-authed synthetic) and are scoped to **#6178**. This plan closes the diagnosis (root cause =
+#6288) and lands the cheap edge-hardening; the no-SSH `deploy-status` probe is the interim
+discoverability path.
+
+## Architecture Decision (ADR / C4)
+
+**No new ADR; no C4 change.** This is parameter hardening + a comment correction **within** the
+existing architecture governed by **ADR-008** (Cloudflare Tunnel deployment) and **ADR-096** (self-hosted
+zot over the tunnel bridge). Neither ADR constrains per-ingress `origin_request`; neither is reversed or
+extended. The architectural decision to **decouple** the deploy webhook from sibling tunnel traffic is a
+genuine ADR-shaped question — it is **owned by #6178**, not this plan.
+
+**### C4 views — no impact (enumeration cited).** All three model files were read
+(`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`). Checked, and each is
+already modeled or unchanged:
+- External **human actors**: none added (operator/founder + contributor already modeled; no new
+  correspondent/recipient).
+- External **systems / vendors**: none added — Cloudflare Tunnel (`model.c4:176-179`) and zot registry
+  (`model.c4:258-261`) already exist; no new vendor edge.
+- **Containers / data stores**: none added.
+- **Access relationships**: unchanged — the edge→origin routing (tunnel→zot, tunnel→webhook) already
+  exists; `origin_request` tunes an **existing** edge, adds no new relationship, and shares no data
+  differently. Adding a monitor is an observability edge, not a system-boundary change.
+
+## Domain Review
+
+**Domains relevant:** Engineering (infra) only.
+
+### Engineering (CTO / platform-strategist)
+**Status:** reviewed
+**Assessment:** Reject the literal remove/repoint (rule is live, not stale). Highest leverage = the
+`tunnel.tf` premise correction (defuses the destructive mis-fix footgun); add a **narrow**
+`origin_request` (`connect_timeout` + `no_happy_eyeballs` only — skip keep-alive/pool tuning,
+meaningless for raw `tcp://`). `connect_timeout` bounds the TCP dial only → safe for cold zot +
+large-layer pushes at ≥5s; do not drop below 5s. The sibling-degradation mechanism (shared-daemon
+HA-stream saturation from ~30s-held dials) is a **reasoned hypothesis, not proven** — cloudflared
+metrics were never captured; `connect_timeout` mitigates all candidate mechanisms regardless.
+**Plan-review refinement (DHH + Kieran + simplicity):** the independent deploy-tunnel monitor CTO
+raised is deferred to #6178 — the cheap `cloudflare_notification_policy` is structurally blind to a
+sibling-route 502 while the daemon stays up, and the real detector (CF-Access synthetic) is over-scope
+for a transient self-recovered incident. Defer real tunnel decoupling + metrics + monitor to #6178.
+
+**Product/UX Gate:** NONE — no UI-surface file in Files to Edit (single infra `.tf` change). No
+mechanical UI-surface override fired.
+
+## Open Code-Review Overlap
+
+None. `gh issue list --label code-review --state open` returned no open scope-out touching
+`tunnel.tf`, `apply-web-platform-infra.yml`, `uptime-alerts.tf`, or `origin_request`.
+
+## Risks & Sharp Edges
+
+- **Empty/placeholder `## User-Brand Impact`** fails `deepen-plan` Phase 4.6 — the section is filled
+  (threshold `aggregate pattern`).
+- **`connect_timeout` is an INTEGER, not `"5s"`** (Kieran, verified vs v4 provider docs). Use
+  `connect_timeout = 5`; the string form fails `terraform validate`. `terraform validate` (Phase 3) is
+  the arbiter — if v4 unexpectedly rejects the integer, the duration string is the fallback.
+- **`connect_timeout` too tight** could false-fail a cold/loaded zot push. Mitigation: pin **5** (CTO
+  floor); do not go to 1–2. `connect_timeout` bounds the **TCP dial**, not push/layer-upload duration,
+  so large pushes are safe.
+- **v4-vs-v5 provider naming** — this root is pinned `~> 4.0` and uses `ingress_rule {}` (v4); v5 renames
+  to `ingress {}`. `origin_request` field names are stable across v4/v5, but keep all edits in the v4
+  form and gate on `terraform validate` (Phase 3). Do not `-upgrade` the provider in this PR.
+- **A cheap tunnel-health monitor would be green-but-blind** (Kieran): CF tunnel-level alert types fire
+  on daemon degradation, not on a single ingress route returning 502 while the daemon is up — so the
+  #6357 failure mode would not be caught. The real detector (CF-Access-authed synthetic 502) carries a
+  secret-surface cost. Both deferred to **#6178** rather than shipping blind detection.
+- **`Closes #6357` at merge would false-resolve** — the real fix lands at **post-merge apply**; use
+  `Ref #6357` + a post-apply `gh issue close` (ops-remediation close pattern).
+- **Deferred work has trackers already:** registry stability → **#6288** (open); tunnel decoupling +
+  cloudflared metrics export → **#6178** (open). No new deferral issue required.
+
+## Alternative Approaches Considered
+
+| Approach | Verdict |
+|---|---|
+| Remove the `registry.soleur.ai` ingress rule (issue's literal ask) | **Rejected** — rule is live (ADR-096/#6122 push path); removal breaks CI push. |
+| Repoint the rule at a "current registry host" | **Rejected** — no-op; the private IP `10.0.1.30:5000` is unchanged post-#6288. |
+| Give the registry its own dedicated `cloudflared` tunnel/daemon | **Deferred → #6178** — the correct architectural decoupling, but YAGNI for a transient self-recovered incident; over-scoped for #6357. |
+| Add an independent deploy-tunnel monitor now (notification policy or CF-Access synthetic) | **Deferred → #6178** — the cheap notification policy is blind to a daemon-up sibling 502 (Kieran); the real synthetic detector needs a service-token secret in a 3rd party — over-scope for a transient, CI-detected, self-recovered incident (DHH + simplicity). |
+| Export cloudflared `--metrics` → Better Stack | **Deferred → #6178** — the richest diagnostic signal, but a larger lift (metrics-port reachability). |
+| Fix the registry OOM / un-pause the registry heartbeat | **Deferred → #6288** — the true root cause; out of scope here. |
+| Ship a drift-guard `*.test.sh` asserting the comment/timeout persist | **Rejected** — testing a comment string is brittle prose-testing (DHH + simplicity); the one behavioral guard lives as an AC grep. |
+| Config-wide (`config { origin_request }`) fail-fast instead of per-ingress | **Rejected** — broader than needed; per-ingress override is exact and leaves the localhost deploy/ssh origins untouched. |
+
+## Non-Goals
+
+- Fixing the registry container's OOM/restart-loop instability (**#6288**).
+- Architecturally decoupling the deploy webhook from sibling tunnel traffic (**#6178**).
+- cloudflared `--metrics` export / host-side tunnel telemetry (**#6178**).
+- Un-pausing the registry liveness heartbeat (**#6288**).
+- Any change to the CF Access apps, service tokens, or Doppler secrets around the tunnel.

--- a/knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
@@ -295,8 +295,14 @@ logs:
   where: Cloudflare tunnel edge (GraphQL/Logpush, edge-side); cloudflared --metrics on host (deferred → #6178)
   retention: Cloudflare default; GitHub Actions run logs (90d)
 discoverability_test:
-  command: 'curl -s -H "X-Signature-256: <hmac>" https://deploy.soleur.ai/hooks/deploy-status  # returns last deploy state; bad-sig POST /hooks/deploy → 403/500 not 502'
-  expected_output: last deploy state JSON (healthy) / 403 on bad sig — proves tunnel→webhook path alive without host shell access
+  command: curl -fsS -o /dev/null -w "%{http_code}\n" --max-time 10 https://app.soleur.ai/health
+  expected_output: "200"
+  # The command above is the no-cred, no-SSH runnable probe: HTTP 200 from /health proves web-1
+  # (which runs the shared cloudflared daemon this change tunes) is serving. Deploy-path-specific
+  # verification (needs HMAC creds; run in postmerge / AC 4.4): a bad-sig POST to
+  # deploy.soleur.ai/hooks/deploy returns the webhook's 403/500 (NOT a tunnel 502), and GET
+  # deploy.soleur.ai/hooks/deploy-status (X-Signature-256 HMAC) returns the last deploy state —
+  # proving the tunnel→webhook path is healthy without host shell access.
 ```
 
 **Affected-surface note:** the true diagnostic signal for the L7-edge saturation hypothesis is

--- a/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/decision-challenges.md
+++ b/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/decision-challenges.md
@@ -1,0 +1,52 @@
+# Decision Challenges — feat-one-shot-6357-stale-cloudflared-registry-ingress
+
+Recorded headless (one-shot pipeline). `ship` renders these into the PR body and files an
+`action-required` issue for operator visibility.
+
+## Challenge 1 — Issue #6357's prescribed fix rests on a false premise (User-Challenge)
+
+**Operator/issue stated direction:** "Remove (or repoint) the stale `registry.soleur.ai →
+tcp://10.0.1.30:5000` ingress rule — it's a dead origin left over from the registry migration
+nbg1→hel1 (#6288)."
+
+**Why the plan diverges (evidence):**
+- The rule is **not stale** — it is the live registry-**push** ingress added in #6122 / ADR-096, with
+  its own CF Access app + service token (`tunnel.tf:44-60,133-209`); recent active work through #6202.
+- The origin is **not dead/migrated** — #6288 moved the registry **region** nbg1→hel1 but kept the
+  **private IP `10.0.1.30:5000`** (`variables.tf:45`, `zot-registry.tf:40`). Repointing is a no-op;
+  removing breaks CI registry push.
+- #6288 is an **OPEN issue** about registry OOM/restart-loop instability — **not a migration PR**. The
+  `dial … canceled` errors were the origin being transiently **down**, not a config error.
+
+**Plan's response:** re-scoped from *remove/repoint* to (1) correct the false "stale" premise in
+`tunnel.tf` (defuse the destructive mis-fix), (2) add minimal fail-fast `origin_request` to reduce the
+shared-tunnel blast radius, (3) add an independent deploy-tunnel monitor. Root cause → #6288;
+architectural decoupling → #6178.
+
+**Decision class:** User-Challenge (operator's stated direction would cause a regression). Default is
+the operator's direction; overridden here on falsified-premise evidence. Surface at ship for operator
+confirmation.
+
+## Challenge 2 — Sibling-degradation mechanism is a reasoned hypothesis, not proven (taste/uncertainty)
+
+The `origin_request` fail-fast targets a **hypothesized** shared-daemon HA-stream saturation
+mechanism; cloudflared `--metrics` were never captured during the incident. The mitigation is
+defensible (it shortens ~30s-held dials and helps all candidate mechanisms) but is **not a proven
+root-cause fix**. The proving signal (cloudflared metrics export) is deferred to #6178. If the operator
+prefers to close #6357 as "misdiagnosed; root cause #6288" and defer ALL hardening to #6178, that is a
+valid alternative — the plan keeps a tight in-scope deliverable instead.
+
+## Challenge 3 — Plan-review converged to defer the deploy-tunnel monitor to #6178 (taste, applied)
+
+The initial plan added an independent deploy-tunnel monitor (Phase 3). The 3-agent plan-review panel
+(DHH, Kieran, code-simplicity) converged that this is out of scope for #6357:
+- Kieran: a cheap `cloudflare_notification_policy` for tunnel-health is **structurally blind** to the
+  #6357 failure (a sibling-route 502 while the daemon stays up) → green-but-blind.
+- DHH + simplicity: the only real detector (CF-Access-authed synthetic 502) needs a service-token
+  secret wired into a 3rd party — over-scope for a transient, CI-detected, self-recovered incident.
+
+**Applied:** monitor + cloudflared `--metrics` export deferred to **#6178** (already owns deploy-tunnel
+decoupling + telemetry). The plan retains the `## Observability` section + the no-SSH `deploy-status`
+probe. Also applied from review: `connect_timeout` is an integer (`5`, not `"5s"`); dropped the
+comment-string drift-test + prose-testing ACs. If the operator wants the independent page sooner, it
+can be pulled forward into #6178's scope.

--- a/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/session-state.md
@@ -1,0 +1,18 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
+- Status: complete
+
+### Errors
+None. (One false-positive during gate verification — an SSH-in-command grep matched prose "without SSH" in the Observability `expected_output`, reworded. Two research sources disagreed on the `connect_timeout` type — resolved: integer form authoritative, `terraform validate` is arbiter.)
+
+### Decisions
+- **Premise falsified → re-scoped.** The issue's claim that the `registry.soleur.ai → tcp://10.0.1.30:5000` rule is stale leftover from a registry migration is false: the migration moved the registry region (nbg1→hel1) but kept the private IP `10.0.1.30:5000` unchanged; the rule is the live ADR-096/#6122 registry-push path. Removing it breaks CI push; repointing is a no-op. Re-scoped from *remove* to *correct-the-comment + fail-fast hardening*. Recorded as a User-Challenge in decision-challenges.md.
+- **Root cause is elsewhere.** The `dial…canceled` errors were the zot registry transiently DOWN during the #6288 OOM/ForceNew window — tracked in #6288 (registry stability). Deploy-tunnel decoupling tracked in #6178. Neither fixed here.
+- **Deliverable is minimal:** single in-place edit to `apps/web-platform/infra/tunnel.tf` — a 2-field `origin_request { connect_timeout = 5; no_happy_eyeballs = true }` on the registry ingress rule (blast-radius fail-fast) plus a comment correcting the "stale" misconception. Auto-applies on merge (resource already in the apply `-target=` allowlist; no workflow edit).
+- **Plan-review converged to tighten scope:** DHH + Kieran + code-simplicity cut the deploy-tunnel monitor (deferred to #6178), dropped a comment-string drift-test and prose-testing ACs, fixed `connect_timeout` to an integer.
+- **All deepen-plan gates passed:** User-Brand Impact, Observability (no-SSH `deploy-status` probe), PAT-halt (none), UI-wireframe (no UI), network-outage L3→L7 deep-dive, precedent (`origin_request` novel in-repo, v4 schema verified). Citations #6357/#6288/#6178/#6122 verified live-OPEN.
+
+### Components Invoked
+soleur:plan, soleur:deepen-plan; research agents framework-docs-researcher, platform-strategist, learnings-researcher, repo-research-analyst; plan-review panel dhh-rails-reviewer, kieran-rails-reviewer, code-simplicity-reviewer.

--- a/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/tasks.md
@@ -1,0 +1,72 @@
+---
+title: "Tasks — fix(infra): harden shared deploy tunnel against registry-origin dial storms (#6357)"
+plan: knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md
+issue: 6357
+lane: cross-domain   # spec.md absent — defaulted to cross-domain (fail-closed, TR2)
+status: ready-for-work
+---
+
+# Tasks — #6357 deploy-tunnel registry-ingress blast-radius hardening
+
+> Re-scoped from the issue's literal "remove the stale rule" ask — the rule is **live** (ADR-096/#6122)
+> and the origin IP is **unchanged** post-#6288. See the plan's Research Reconciliation.
+> Root cause (registry instability) → #6288; architectural decoupling + monitor + metrics → #6178.
+
+## Phase 1 — Correct the false "stale rule" premise (highest leverage)
+
+- [ ] 1.1 In `apps/web-platform/infra/tunnel.tf` (comment above the `registry.${var.app_domain_base}`
+  ingress rule, ~lines 44-56), rewrite the comment to state: this is the **live** ADR-096 / #6122
+  registry-**push** ingress; the `10.0.1.30:5000` origin is the **current** zot registry (#6288 moved
+  the registry *region* nbg1→hel1 but the **private IP is unchanged** — 10.0.1.0/24 spans hel1);
+  **do NOT remove or repoint** (removal breaks CI push; repointing is a no-op); a `dial … canceled`
+  here means the origin is transiently **down** (registry stability = #6288), not a config error.
+
+## Phase 2 — Fail-fast `origin_request` on the registry ingress rule
+
+- [ ] 2.1 In the same `ingress_rule` block (`tunnel.tf:57-60`), add a **minimal** nested block:
+  ```hcl
+  origin_request {
+    connect_timeout   = 5      # INTEGER seconds (NOT "5s"); bounds the TCP dial only
+    no_happy_eyeballs = true
+  }
+  ```
+  with a short comment (fail-fast so a DOWN origin doesn't pile up ~30s-held dials that degrade the
+  sibling deploy route — #6357; mitigation not cure — root cause #6288, decoupling #6178).
+- [ ] 2.2 Do **NOT** add `keep_alive_*` / `tcp_keep_alive` / `proxy_type` / `http_host_header`
+  (HTTP/pool semantics — no-op or schema friction for a raw `tcp://` bridge).
+- [ ] 2.3 Do **NOT** lower `connect_timeout` below `5` (host accept-queue backpressure could false-fail
+  a valid cold-zot push).
+
+## Phase 3 — Pre-apply validation (the arbiter for the connect_timeout type)
+
+- [ ] 3.1 `cd apps/web-platform/infra && terraform fmt -check` passes.
+- [ ] 3.2 `terraform validate` passes against the v4-pinned root. **If it rejects `connect_timeout = 5`
+  (integer), fall back to the duration string `"5s"`** — validate is the arbiter (Kieran vs
+  framework-docs disagreed; integer is the verified form). Keep all edits in v4 `ingress_rule {}`
+  form; do NOT `-upgrade` the provider.
+- [ ] 3.3 Capture `terraform plan` in the PR body: exactly ONE **in-place update** to
+  `cloudflare_zero_trust_tunnel_cloudflared_config.web`, **0 to destroy**, no net-new resource, no
+  `-target=` workflow edit needed (the resource is already targeted at
+  `apply-web-platform-infra.yml:313`).
+
+## Phase 4 — PR + verification
+
+- [ ] 4.1 Acceptance-criteria greps (from the plan) pass:
+  - `awk '/hostname = "registry/,/^    }/' apps/web-platform/infra/tunnel.tf | grep -c connect_timeout` ≥ 1
+  - `awk '/hostname = "registry/,/^    }/' apps/web-platform/infra/tunnel.tf | grep -c keep_alive` = 0
+  - `grep -c 'tcp://\${local.registry_endpoint}' apps/web-platform/infra/tunnel.tf` ≥ 1 (removal-guard)
+- [ ] 4.2 PR body uses **`Ref #6357`** (NOT `Closes` — ops-remediation; real close is post-apply), plus
+  `Ref #6288` (root cause) and `Ref #6178` (deferred monitor + decoupling + metrics).
+- [ ] 4.3 Post-merge: confirm the `apply-web-platform-infra.yml` auto-apply run is green (no operator
+  SSH; it pushes the remote tunnel config).
+- [ ] 4.4 Post-merge no-SSH health probe: `GET deploy.soleur.ai/hooks/deploy-status` (HMAC via
+  `X-Signature-256`) returns last deploy state; a bad-sig `POST deploy.soleur.ai/hooks/deploy` returns
+  **403/500 (not 502)** — proving the tunnel→webhook path is healthy.
+- [ ] 4.5 Close #6357 via `gh issue close 6357` **only after** the apply is green and the probe passes.
+
+## Out of scope (deferred, trackers exist)
+
+- Registry OOM/restart-loop stability, un-pause registry heartbeat → **#6288**.
+- Independent deploy-tunnel monitor (CF-Access synthetic), cloudflared `--metrics` export,
+  architectural deploy-webhook decoupling → **#6178**.
+- No new ADR / no C4 change (parameter hardening within ADR-008 + ADR-096).

--- a/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6357-stale-cloudflared-registry-ingress/tasks.md
@@ -14,7 +14,7 @@ status: ready-for-work
 
 ## Phase 1 — Correct the false "stale rule" premise (highest leverage)
 
-- [ ] 1.1 In `apps/web-platform/infra/tunnel.tf` (comment above the `registry.${var.app_domain_base}`
+- [x] 1.1 In `apps/web-platform/infra/tunnel.tf` (comment above the `registry.${var.app_domain_base}`
   ingress rule, ~lines 44-56), rewrite the comment to state: this is the **live** ADR-096 / #6122
   registry-**push** ingress; the `10.0.1.30:5000` origin is the **current** zot registry (#6288 moved
   the registry *region* nbg1→hel1 but the **private IP is unchanged** — 10.0.1.0/24 spans hel1);
@@ -23,7 +23,7 @@ status: ready-for-work
 
 ## Phase 2 — Fail-fast `origin_request` on the registry ingress rule
 
-- [ ] 2.1 In the same `ingress_rule` block (`tunnel.tf:57-60`), add a **minimal** nested block:
+- [x] 2.1 In the same `ingress_rule` block (`tunnel.tf:57-60`), add a **minimal** nested block:
   ```hcl
   origin_request {
     connect_timeout   = 5      # INTEGER seconds (NOT "5s"); bounds the TCP dial only
@@ -32,15 +32,15 @@ status: ready-for-work
   ```
   with a short comment (fail-fast so a DOWN origin doesn't pile up ~30s-held dials that degrade the
   sibling deploy route — #6357; mitigation not cure — root cause #6288, decoupling #6178).
-- [ ] 2.2 Do **NOT** add `keep_alive_*` / `tcp_keep_alive` / `proxy_type` / `http_host_header`
+- [x] 2.2 Do **NOT** add `keep_alive_*` / `tcp_keep_alive` / `proxy_type` / `http_host_header`
   (HTTP/pool semantics — no-op or schema friction for a raw `tcp://` bridge).
-- [ ] 2.3 Do **NOT** lower `connect_timeout` below `5` (host accept-queue backpressure could false-fail
+- [x] 2.3 Do **NOT** lower `connect_timeout` below `5` (host accept-queue backpressure could false-fail
   a valid cold-zot push).
 
 ## Phase 3 — Pre-apply validation (the arbiter for the connect_timeout type)
 
-- [ ] 3.1 `cd apps/web-platform/infra && terraform fmt -check` passes.
-- [ ] 3.2 `terraform validate` passes against the v4-pinned root. **If it rejects `connect_timeout = 5`
+- [x] 3.1 `cd apps/web-platform/infra && terraform fmt -check` passes.
+- [x] 3.2 `terraform validate` passes against the v4-pinned root. **If it rejects `connect_timeout = 5`
   (integer), fall back to the duration string `"5s"`** — validate is the arbiter (Kieran vs
   framework-docs disagreed; integer is the verified form). Keep all edits in v4 `ingress_rule {}`
   form; do NOT `-upgrade` the provider.
@@ -51,11 +51,11 @@ status: ready-for-work
 
 ## Phase 4 — PR + verification
 
-- [ ] 4.1 Acceptance-criteria greps (from the plan) pass:
+- [x] 4.1 Acceptance-criteria greps (from the plan) pass:
   - `awk '/hostname = "registry/,/^    }/' apps/web-platform/infra/tunnel.tf | grep -c connect_timeout` ≥ 1
   - `awk '/hostname = "registry/,/^    }/' apps/web-platform/infra/tunnel.tf | grep -c keep_alive` = 0
   - `grep -c 'tcp://\${local.registry_endpoint}' apps/web-platform/infra/tunnel.tf` ≥ 1 (removal-guard)
-- [ ] 4.2 PR body uses **`Ref #6357`** (NOT `Closes` — ops-remediation; real close is post-apply), plus
+- [x] 4.2 PR body uses **`Ref #6357`** (NOT `Closes` — ops-remediation; real close is post-apply), plus
   `Ref #6288` (root cause) and `Ref #6178` (deferred monitor + decoupling + metrics).
 - [ ] 4.3 Post-merge: confirm the `apply-web-platform-infra.yml` auto-apply run is green (no operator
   SSH; it pushes the remote tunnel config).


### PR DESCRIPTION
## Summary

Harden the shared web-1 cloudflared tunnel against registry-origin dial storms, and correct the false "stale rule" premise from #6357.

- Add a fail-fast `origin_request { connect_timeout = 5; no_happy_eyeballs = true }` scoped to the `registry.${app_domain_base}` ingress rule in `apps/web-platform/infra/tunnel.tf`. This bounds the TCP dial so a DOWN zot registry origin can no longer pile up ~30s-held dials that saturate the shared cloudflared daemon's HA-stream budget and degrade the sibling deploy-webhook route (the 2026-07-11 `POST /hooks/deploy` 502).
- Correct the issue's false premise in-line: the origin `10.0.1.30:5000` is the **live** ADR-096/#6122 registry-push path — #6288 moved the registry **region** (nbg1→hel1) but the **private IP is unchanged**. Removing the rule breaks CI registry push; repointing is a no-op. A `dial … canceled` here means the origin is transiently **down** (registry stability = #6288), not a config error.

This is a blast-radius **mitigation, not a cure**. The root cause (registry container OOM/restart-loop stability) is tracked in #6288; the architectural fix (decouple the deploy webhook from sibling tunnel traffic + independent monitor + cloudflared `--metrics`) is tracked in #6178.

Plan: `knowledge-base/project/plans/2026-07-12-fix-harden-deploy-tunnel-registry-ingress-blast-radius-plan.md`
Post-mortem: `knowledge-base/engineering/operations/post-mortems/2026-07-11-deploy-tunnel-registry-dial-storm-502-postmortem.md`

Ref #6357
Ref #6288
Ref #6178

## User-Brand Impact

- **Artifact exposed if broken:** prod deploy-pipeline availability (fleet-wide shipping capability) — no user data moves; this tunes an edge→origin TCP timeout on an existing tunnel config resource.
- **Exposure vector:** a too-tight `connect_timeout` could fail-close the CI registry-**push** path (deploys degrade to the non-fatal GHCR fallback), and a malformed tunnel-config apply could 502 the deploy webhook. Mitigated: `connect_timeout` floors at 5s (bounds the TCP dial only, not layer-upload duration) and `terraform validate` gates the apply.
- **Brand-survival threshold:** aggregate pattern

## Model Dissents (informational)

Recorded headless during the one-shot pipeline; surfaced here for visibility (tracked in the `action-required` decision-challenge issue).

- **The issue's prescribed fix rests on a false premise (User-Challenge).** #6357 asked to remove/repoint a "stale" rule; research falsified that (the rule is the live #6122/ADR-096 push path; #6288 kept the IP). The plan re-scoped from *remove* to *correct-premise + harden* to avoid a self-inflicted CI-push outage. Operator's stated direction (remove) is retained as the default record but overridden on falsified-premise evidence.
- **The sibling-degradation mechanism is a reasoned hypothesis, not proven.** cloudflared `--metrics` were never captured during the incident; `connect_timeout` mitigates every candidate mechanism regardless. Proving signal (metrics export) is deferred to #6178.
- **The independent deploy-tunnel monitor was deferred to #6178 (plan-review consensus).** A cheap `cloudflare_notification_policy` is structurally blind to a sibling-route 502 while the daemon stays up; the real detector (CF-Access synthetic) needs a service-token secret in a 3rd party — over-scope for a transient, self-recovered, CI-detected incident.

## Changelog

### Web Platform (infra)
- `tunnel.tf`: registry ingress rule now carries a fail-fast `origin_request` (`connect_timeout = 5`, `no_happy_eyeballs = true`); comment corrected to mark the rule as the live registry-push path (do not remove/repoint). Auto-applies on merge via `apply-web-platform-infra.yml` (resource already in the `-target=` allowlist; no workflow edit).

## Test plan

- [x] `terraform fmt -check` passes on `tunnel.tf`.
- [x] `terraform validate` passes against the v4-pinned root (arbiter confirms `connect_timeout` is the integer `5`, not `"5s"`).
- [x] AC greps pass: registry block contains `connect_timeout` (≥1) and no `keep_alive` (0); removal-guard `tcp://${local.registry_endpoint}` present (≥1).
- [x] No infra `*.test.sh` reads `tunnel.tf` (no drift-guard breakage).
- [ ] Post-merge (verified in the same session's postmerge phase, no host SSH): `apply-web-platform-infra.yml` auto-apply run concludes green — an in-place update to `cloudflare_zero_trust_tunnel_cloudflared_config.web`, 0 to destroy.
- [ ] Post-merge (postmerge phase): no-SSH deploy-path probe — a bad-sig `POST deploy.soleur.ai/hooks/deploy` returns the webhook's 403/500, not a tunnel 502, confirming the tunnel→webhook path is healthy.

Generated with [Claude Code](https://claude.com/claude-code)
