### PR TITLE
fix(infra): mark webhook.service ReadWritePaths /var/lib/inngest -optional to unwedge fresh web-2 boots (#6090)

### DIFF
--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -242,7 +242,12 @@ write_files:
       # NOT escape the mount namespace, so without these explicit
       # ReadWritePaths the inngest bootstrap fails with cryptic chown error
       # messages. See #4017 substrate audit (2026-05-19).
-      ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /etc/sudoers.d /etc/webhook /var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
+      # `-/var/lib/inngest` is OPTIONAL (`-` prefix, like -/var/lib/vector):
+      # web_colocate_inngest=false (default) gates the inngest-bootstrap runcmd
+      # block that CREATES the dir, so a mandatory token would 226/NAMESPACE this
+      # unit on fresh boot (:9000 never binds). systemd ignores it while absent;
+      # it becomes a real ReadWritePath once inngest-bootstrap creates it (#6090).
+      ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /etc/sudoers.d /etc/webhook -/var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
       ReadOnlyPaths=/etc/default/webhook-deploy
       TimeoutStopSec=180
 

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -411,11 +411,21 @@ CLOUD_INIT="$SCRIPT_DIR/cloud-init.yml"
 WEBHOOK_SERVICE="$SCRIPT_DIR/webhook.service"
 assert "cloud-init.yml + webhook.service exist" "[[ -f '$CLOUD_INIT' && -f '$WEBHOOK_SERVICE' ]]"
 
+# Exactly ONE ReadWritePaths= line per file — makes the head -1 extraction below safe.
+# systemd ACCUMULATES RWP directives, so a future 2nd (mandatory) `/var/lib/inngest` line
+# would slip past the token asserts and silently re-open the 226/NAMESPACE bug; a REMOVED
+# line would abort under set -e/pipefail instead of a labeled FAIL. (#6363 review: security
+# + architecture + code-quality converged.)
+CI_RWP_COUNT="$(grep -cE '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" || true)"
+WS_RWP_COUNT="$(grep -cE '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" || true)"
+assert "cloud-init.yml has exactly one ReadWritePaths= line (head -1 safety)" "[[ \"\$CI_RWP_COUNT\" -eq 1 ]]"
+assert "webhook.service has exactly one ReadWritePaths= line (head -1 safety)" "[[ \"\$WS_RWP_COUNT\" -eq 1 ]]"
+
 # CI_RWP/WS_RWP are consumed inside assert's `eval "$condition"` (SC can't see through eval).
 # shellcheck disable=SC2034
-CI_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
+CI_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//' || true)"
 # shellcheck disable=SC2034
-WS_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
+WS_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//' || true)"
 
 assert "cloud-init RWP marks /var/lib/inngest optional (-prefix)" \
   "grep -qE -- '(^|[[:space:]])-/var/lib/inngest([[:space:]]|\$)' <<< \"\$CI_RWP\""

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -411,8 +411,10 @@ CLOUD_INIT="$SCRIPT_DIR/cloud-init.yml"
 WEBHOOK_SERVICE="$SCRIPT_DIR/webhook.service"
 assert "cloud-init.yml + webhook.service exist" "[[ -f '$CLOUD_INIT' && -f '$WEBHOOK_SERVICE' ]]"
 
-# shellcheck disable=SC2034  # CI_RWP/WS_RWP are consumed inside assert's `eval "$condition"` (SC can't see through eval)
+# CI_RWP/WS_RWP are consumed inside assert's `eval "$condition"` (SC can't see through eval).
+# shellcheck disable=SC2034
 CI_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
+# shellcheck disable=SC2034
 WS_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
 
 assert "cloud-init RWP marks /var/lib/inngest optional (-prefix)" \

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -396,6 +396,35 @@ RESTART_LINE=$(grep -nE '^systemctl restart inngest-server.service' "$BOOTSTRAP_
 assert "bootstrap runs inngest-redis-bootstrap.sh (REDIS_READY probe) BEFORE the inngest-server restart" \
   "[[ -n '$REDIS_RUN_LINE' && -n '$RESTART_LINE' && '$REDIS_RUN_LINE' -lt '$RESTART_LINE' ]]"
 
+# --- #6090: webhook.service ReadWritePaths /var/lib/inngest must be `-`-optional ---
+# On web_colocate_inngest=false (default since the co-located-inngest gate), the
+# inngest-bootstrap runcmd block that CREATES /var/lib/inngest is gated off, so a
+# MANDATORY RWP token makes systemd fail webhook.service with 226/NAMESPACE on a
+# fresh host (:9000 never binds -> ok_peer_fanout_degraded -> web-2 undeployed).
+# The `-` prefix marks the dir optional (systemd ignores it if absent), mirroring
+# the -/var/lib/vector precedent (PR #4257). Both lockstep copies must match:
+#   - cloud-init.yml (baked at first boot)
+#   - webhook.service (base64-delivered to running web-1 via deploy_pipeline_fix).
+echo ""
+echo "--- #6090: webhook RWP /var/lib/inngest -optional (both lockstep copies) ---"
+CLOUD_INIT="$SCRIPT_DIR/cloud-init.yml"
+WEBHOOK_SERVICE="$SCRIPT_DIR/webhook.service"
+assert "cloud-init.yml + webhook.service exist" "[[ -f '$CLOUD_INIT' && -f '$WEBHOOK_SERVICE' ]]"
+
+CI_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
+WS_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
+
+assert "cloud-init RWP marks /var/lib/inngest optional (-prefix)" \
+  "grep -qE -- '(^|[[:space:]])-/var/lib/inngest([[:space:]]|\$)' <<< \"\$CI_RWP\""
+assert "cloud-init RWP has NO mandatory (bare) /var/lib/inngest" \
+  "! grep -qE -- '(^|[[:space:]])/var/lib/inngest([[:space:]]|\$)' <<< \"\$CI_RWP\""
+assert "webhook.service RWP marks /var/lib/inngest optional (-prefix)" \
+  "grep -qE -- '(^|[[:space:]])-/var/lib/inngest([[:space:]]|\$)' <<< \"\$WS_RWP\""
+assert "webhook.service RWP has NO mandatory (bare) /var/lib/inngest" \
+  "! grep -qE -- '(^|[[:space:]])/var/lib/inngest([[:space:]]|\$)' <<< \"\$WS_RWP\""
+assert "RWP token lists byte-identical across both lockstep copies" \
+  "[[ -n \"\$CI_RWP\" && \"\$CI_RWP\" == \"\$WS_RWP\" ]]"
+
 # --- `terraform fmt -check` for HCL hygiene ---
 echo ""
 echo "--- terraform fmt -check ---"

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -416,7 +416,9 @@ assert "cloud-init.yml + webhook.service exist" "[[ -f '$CLOUD_INIT' && -f '$WEB
 # would slip past the token asserts and silently re-open the 226/NAMESPACE bug; a REMOVED
 # line would abort under set -e/pipefail instead of a labeled FAIL. (#6363 review: security
 # + architecture + code-quality converged.)
+# shellcheck disable=SC2034  # consumed via assert's eval, below
 CI_RWP_COUNT="$(grep -cE '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" || true)"
+# shellcheck disable=SC2034
 WS_RWP_COUNT="$(grep -cE '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" || true)"
 assert "cloud-init.yml has exactly one ReadWritePaths= line (head -1 safety)" "[[ \"\$CI_RWP_COUNT\" -eq 1 ]]"
 assert "webhook.service has exactly one ReadWritePaths= line (head -1 safety)" "[[ \"\$WS_RWP_COUNT\" -eq 1 ]]"

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -411,6 +411,7 @@ CLOUD_INIT="$SCRIPT_DIR/cloud-init.yml"
 WEBHOOK_SERVICE="$SCRIPT_DIR/webhook.service"
 assert "cloud-init.yml + webhook.service exist" "[[ -f '$CLOUD_INIT' && -f '$WEBHOOK_SERVICE' ]]"
 
+# shellcheck disable=SC2034  # CI_RWP/WS_RWP are consumed inside assert's `eval "$condition"` (SC can't see through eval)
 CI_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$CLOUD_INIT" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
 WS_RWP="$(grep -E '^[[:space:]]*ReadWritePaths=' "$WEBHOOK_SERVICE" | head -1 | sed -E 's/^[[:space:]]*ReadWritePaths=//')"
 

--- a/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
@@ -524,8 +524,10 @@ fi
 # The seed pull (AC19) + app pull (AC20) bakes weren't enough: soleur-host-bootstrap.sh had a
 # THIRD unhardened `timeout 15 doppler secrets get GHCR_READ_*` login for the inngest-bootstrap
 # image pull. On a cold host it skipped docker login → anonymous inngest pull → /var/lib/inngest
-# never created → webhook.service 226/NAMESPACE → :9000 unbound → peer fan-out degraded. Fix:
-# bootstrap prefers the baked /etc/default/soleur-ghcr-read, hardened doppler fallback.
+# never created. (The "→ webhook.service 226/NAMESPACE → :9000 unbound → peer fan-out degraded"
+# downstream is SEVERED as of #6090 — webhook.service now marks /var/lib/inngest `-`-optional; an
+# absent dir no longer wedges the unit. This bake still matters when web_colocate_inngest is ON.)
+# Fix: bootstrap prefers the baked /etc/default/soleur-ghcr-read, hardened doppler fallback.
 if grep -qF '/etc/default/soleur-ghcr-read' "$BOOT"; then
   ok "AC21: soleur-host-bootstrap ghcr_login prefers the baked /etc/default/soleur-ghcr-read"
 else

--- a/apps/web-platform/infra/soleur-host-bootstrap.sh
+++ b/apps/web-platform/infra/soleur-host-bootstrap.sh
@@ -189,8 +189,11 @@ STAGE=ghcr_login
   # cold host even when Doppler answers EMPTY at the boot instant — the same failure class the
   # cloud-init ghcr_login (#6090) and the ci-deploy prelude (#6161) already bake against. An
   # empty fetch here skipped docker login → anonymous inngest pull → /var/lib/inngest never
-  # created → webhook.service fails 226/NAMESPACE (it ReadWritePaths=/var/lib/inngest) → :9000
-  # never binds → the peer fan-out degrades. Hardened Doppler fallback (timeout 45 + 3-try retry).
+  # created. (The old downstream "→ webhook.service 226/NAMESPACE → :9000 never binds → peer
+  # fan-out degrades" chain is SEVERED as of #6090: webhook.service now marks /var/lib/inngest
+  # `-`-optional, so an absent dir no longer wedges the unit. This baked-creds path still matters
+  # when web_colocate_inngest is ON — the inngest pull itself needs auth.) Hardened Doppler
+  # fallback (timeout 45 + 3-try retry).
   GHCR_USER=""; GHCR_TOKEN=""
   if [ -r /etc/default/soleur-ghcr-read ]; then
     # shellcheck disable=SC1091

--- a/apps/web-platform/infra/webhook.service
+++ b/apps/web-platform/infra/webhook.service
@@ -29,20 +29,23 @@ PrivateTmp=true
 # initial `printf >` redirect actually failed but chown still ran).
 # Surfaced 2026-05-19 via #4017 — PR-F's inngest substrate was never installed
 # in production because the webhook deploy of the bootstrap image failed at
-# the chown step inside this sandbox. The /var/lib/inngest entry is required
-# because mkdir+chown for SQLite's data dir runs ahead of the systemd unit's
-# own ReadWritePaths.
+# the chown step inside this sandbox. /var/lib/inngest is `-`-optional (see the
+# `-` prefix note below): when web_colocate_inngest is on, inngest-bootstrap's
+# mkdir+chown for SQLite's data dir runs ahead of this unit's own ReadWritePaths.
 # /etc/vector + /var/lib/vector added 2026-05-21 (TR9 PR-5): inngest-bootstrap.sh
 # now also installs Vector (observability shipper) alongside the inngest CLI;
 # its config + state dirs need bootstrap-time write access from inside this
 # namespace. Surfaced via v1.1.1 deploy diagnostic capture
 # (reason="mkdir: cannot create directory /etc/vector: Read-only file system").
-# `-` prefix on /var/lib/vector + /etc/vector marks them optional:
-# systemd silently ignores the path if absent, instead of refusing to set up
-# the mount namespace (which on prior PR #4257 took webhook.service down
-# entirely until the dirs were created). Once inngest-bootstrap.sh creates
-# them on first v1.1.x deploy, they become real ReadWritePaths.
-ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /etc/sudoers.d /etc/webhook /var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
+# `-` prefix on /var/lib/inngest + /var/lib/vector + /etc/vector marks them
+# optional: systemd silently ignores the path if absent, instead of refusing to
+# set up the mount namespace (which on prior PR #4257 took webhook.service down
+# entirely until the dirs were created). Once inngest-bootstrap.sh creates them
+# (only when web_colocate_inngest is on), they become real ReadWritePaths.
+# /var/lib/inngest got the `-` in #6090: web_colocate_inngest=false (default)
+# gates off the dir-creator, so a mandatory token 226/NAMESPACE'd fresh web-2
+# boots (:9000 never bound -> ok_peer_fanout_degraded).
+ReadWritePaths=/mnt/data /var/lock /etc/systemd/system /etc/default /etc/sudoers.d /etc/webhook -/var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
 ReadOnlyPaths=/etc/default/webhook-deploy
 TimeoutStopSec=180
 

--- a/knowledge-base/project/learnings/best-practices/2026-07-12-config-gate-half-fix-and-unmasked-deterministic-deadlock.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-12-config-gate-half-fix-and-unmasked-deterministic-deadlock.md
@@ -1,0 +1,96 @@
+---
+name: config-gate-half-fix-and-unmasked-deterministic-deadlock
+description: A feature gate that removes a resource's CREATOR but leaves a hard consumer requirement on that resource turns a flaky race into a deterministic deadlock; and an early-abort fix upstream can unmask a second, previously-hidden failure the paused arc never saw.
+metadata:
+  type: project
+---
+
+# Config-gate half-fix + the unmasked deterministic deadlock (#6090 / #6178)
+
+## Problem
+
+Fresh web-2 hosts (weight-0 warm standby) failed every `web-2-recreate`: `webhook.service`
+died with systemd **226/NAMESPACE**, `:9000` never bound, and every deploy fan-out reported
+`ok_peer_fanout_degraded` → the standby was undeployable. This blocked the #6178 Inngest
+cutover, whose runbook step-1a needs a clean web-2 recreate.
+
+The #6090 arc had already peeled and merged four earlier causes (three GHCR cold-boot auth
+layers + a config-phase apt hang) and was **PAUSED (2026-07-07)** blocked on #6178, with the
+remaining cause named as "the inngest co-location itself" — a circular-looking entanglement.
+
+## Root cause (two composing facts)
+
+1. `webhook.service`'s `ReadWritePaths=` listed `/var/lib/inngest` as a **mandatory** token
+   (no `-` prefix). systemd fails a unit with 226/NAMESPACE if a mandatory `ReadWritePaths`
+   target is absent.
+2. PR-1 #6344 (`web_colocate_inngest`, default **false**) gated OFF the **only** runcmd block
+   that CREATES `/var/lib/inngest` (the inngest-bootstrap). So on a default fresh host the dir
+   is never created, yet the webhook still hard-required it.
+
+⟹ #6344 **converted a previously-flaky `/var/lib/inngest` ordering race into a DETERMINISTIC
+deadlock** by removing the dir-creator while leaving the hard consumer requirement in place.
+
+## Why the paused arc never saw it
+
+The arc's last diagnosis (2026-07-07) predates #6344 (2026-07-11). Separately, a
+`deploy-fanout tag_malformed` bug (#6353/#6354) was aborting the fan-out at the tag stage —
+BEFORE it ever reached the `:9000` bind poll. Fixing #6354 **unmasked** the deadlock: the first
+post-#6344, post-#6354 recreate (run `29169983049`) was the first to get past the tag abort and
+observe web-2 die at `:9000` (502 for the full 1800s). That deterministic-deadlock signal was
+NEW evidence the paused arc never had.
+
+## Solution
+
+Mark `/var/lib/inngest` `-`-optional (`-/var/lib/inngest`) in **both** lockstep copies —
+`cloud-init.yml` (baked at boot) and the standalone `webhook.service` (base64-delivered to
+running web-1 via `server.tf` `deploy_pipeline_fix.triggers_replace`). The `-` prefix means
+"ignore if absent"; when present (colocate=on) it is still a real ReadWritePath, so no
+regression. `inngest-server.service` (the dir's OWNER) correctly keeps the mandatory form.
+
+Chose `-`-optional over a templatefile `%{ if web_colocate_inngest }` guard **because the
+standalone `webhook.service` reaches web-1 via raw `file()`, not `templatefile()`** — a
+`%{ if }` directive would ship literally as text and break the unit. `-`-optional is also the
+more correct expression: it states a flag-independent property ("this unit does not own the
+dir") and matches the adjacent `-/var/lib/vector` precedent (PR #4257).
+
+## Key insights (generalizable)
+
+1. **A feature gate that removes a resource's CREATOR must also relax every hard CONSUMER
+   requirement on that resource** — otherwise the gate flips a tolerable race into a permanent
+   failure. When adding/flipping a `%{ if flag }` gate around a `mkdir`/create step, grep every
+   `ReadWritePaths=`/`Requires=`/`After=`/mount/FK that references the created path and confirm
+   each tolerates absence in the gated-off state.
+2. **An upstream early-abort bug MASKS every failure downstream of the abort point.** When you
+   fix an early abort (a malformed-tag reject, a failed precondition, a 401), re-run the
+   newly-unblocked path to capture fresh signal BEFORE trusting a paused arc's last diagnosis —
+   the arc only ever saw the FIRST broken step (cf. the review "multi-step saga fix" class).
+3. **systemd `-` prefix on `ReadWritePaths`** = optional (skip if absent); bare = mandatory
+   (226/NAMESPACE if absent). Ownership rule: only the unit that CREATES a dir should
+   hard-require it; consumer units that merely reference it should mark it `-`-optional.
+4. **Two byte-identical config copies delivered by different mechanisms are a lockstep contract**
+   — guard with a byte-identity parity test, and assert exactly ONE `ReadWritePaths=` line per
+   file so `head -1` extraction can't be silently defeated by a future second (systemd
+   accumulates the directive).
+
+## Session Errors
+
+1. **Planning subagent: IaC-routing PreToolUse hook rejected the initial plan Write** (prose
+   quoted `systemctl`). Recovery: added the `iac-routing-ack: plan-phase-2-8-reviewed` opt-out
+   (the fix IS Terraform/cloud-init-routed; the `systemctl` tokens are quotes of managed
+   behavior). Prevention: when a plan's prose must quote a managed host command, add the
+   iac-routing-ack up front. (Recurring class, already covered by the opt-out mechanism.)
+2. **shellcheck SC2034 on `eval`-consumed test vars** (`CI_RWP`/`WS_RWP`/`*_COUNT`). shellcheck
+   can't see through `assert`'s `eval "$condition"`. Recovery: `# shellcheck disable=SC2034`.
+   Prevention: annotate eval-consumed helper vars with the disable directive at write time.
+3. **`# shellcheck disable` is per-line (next line only)** — the first fix covered CI_RWP but
+   not the adjacent WS_RWP. Recovery: a directive before each assignment. Prevention: one
+   directive per silenced line, not one for a block.
+4. **`cloud-init schema -c cloud-init.yml` returns "Invalid schema: user-data"** — this is
+   EXPECTED, not a regression: the file is a Terraform templatefile (`${...}`, `%{ if }`,
+   `$${...}`) that is not valid raw cloud-init until rendered. Prevention: before treating a
+   cloud-init schema failure as a regression, run it against `git show origin/main:<file>` — an
+   identical failure proves it's the template artifact, not your diff.
+
+## Tags
+category: best-practices
+module: apps/web-platform/infra

--- a/knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
@@ -20,6 +20,27 @@ date: 2026-07-12
 
 🐛 **Bug** · P1 · `apps/web-platform/infra` · closes #6090 (this peel)
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-12 · **Threshold:** aggregate pattern · **Lane:** cross-domain (TR2 default)
+
+**Hard gates (all PASS):** 4.6 User-Brand Impact ✓ · 4.7 Observability (5-field, no-SSH discoverability) ✓ ·
+4.8 PAT-shaped scan (none) ✓ · 4.9 UI-wireframe (no UI surface → skip) ✓. Conditional gates fired &
+satisfied: **4.5 Network-Outage** (SSH/firewall in Hypotheses) and **4.55 Downtime & Cutover** (web-2
+`-replace`) — subsections added below; telemetry emitted.
+
+### Key improvements over the plan draft
+1. **Precedent-diff (Phase 4.4) grounded:** the `-`-optional fix is not novel — `webhook.service:40-44`
+   already documents the identical `-/var/lib/vector` / `-/etc/vector` treatment (PR #4257). Side-by-side
+   diff added under Design Decision Research Insights.
+2. **Lockstep discovery elevated to a first-class risk:** two byte-identical RWP copies
+   (`cloud-init.yml:245` templated + `webhook.service:45` non-templated) — the reason Option A is rejected.
+3. **Network-Outage Deep-Dive + Downtime & Cutover** subsections prove the change is neither a
+   connectivity fault nor a serving-surface outage (web-2 is a weight-0, no-ingress standby; blue-green
+   by construction).
+4. All load-bearing line citations (245 / 578 / 581 / 636 / `variables.tf:350` / workflow `:1209`)
+   re-verified live in this pass.
+
 ## Overview
 
 A fresh web-2 boot dies with a deterministic systemd **226/NAMESPACE** unit failure: `webhook.service`'s
@@ -115,6 +136,39 @@ the baked-DSN `webhook_bound` beacon. The L3→L7 ladder is explicitly ruled out
 Diagnosis is **off-host only** (baked-DSN boot beacons + Better Stack markers). **No SSH to the deny-all
 hosts** (`hr-no-ssh-fallback-in-runbooks`).
 
+### Network-Outage Deep-Dive (Phase 4.5 — gate fired)
+
+The gate fired on the "SSH"/"firewall" substrings. Resource-shape sub-trigger also considered: the
+`web-2-recreate` apply `-replace`s `hcloud_server.web["web-2"]`, and `deploy_pipeline_fix` carries `file`
++ `remote-exec` provisioners — BUT the web-2 verification is deliberately **off-host** (web-2 has no
+public ingress; the fan-out + acceptance run over web-1's `/hooks/deploy-status`, no SSH into web-2).
+Layer-by-layer verification status:
+
+| Layer | Status | Artifact / rationale |
+| --- | --- | --- |
+| L3 firewall allow-list | **not implicated** | `:9000` is a local bind that never occurs; no outbound at the failing step. `hcloud_firewall.web` unchanged (this PR touches only the systemd unit). |
+| L3 DNS / routing | **not implicated** | no name resolution / route exercised by the webhook enable step. |
+| L7 TLS / proxy | **not implicated** | no HTTPS in the failing path. |
+| L7 application (systemd) | **root cause** | `226/NAMESPACE` = config-time mount-namespace refusal, not connectivity. Off-host signal = baked-DSN `webhook_bound` beacon + web-1 deploy-status `reason`. |
+
+No firewall/egress mutation is proposed; per `hr-ssh-diagnosis-verify-firewall` the L3 layer is verified
+(unchanged) before the service-layer fix.
+
+## Downtime & Cutover (Phase 4.55 — gate fired)
+
+**Offline-inducing operation:** `apply_target=web-2-recreate` performs a scoped `terraform -replace` of
+`hcloud_server.web["web-2"]` (a host-replace, which triggers the reboot/replace class).
+
+**Surface affected:** web-2 only — a **weight-0 warm-standby with no public ingress** that is **not
+currently serving traffic** (it never bound `:9000`, which is the bug). web-1 continues serving throughout.
+
+**Zero-downtime path (default, satisfied by construction):** blue-green. web-2 is born fresh from cloud-init
+into the private network / placement group; there is no user traffic to drain (weight-0, no ingress), and
+web-1 is untouched. The `-replace` is scoped to the single web-2 address set — nothing else is destroyed
+or rebooted. Per-stage rollback: if the recreate fails, web-2 simply stays absent (its prior state), web-1
+unaffected; re-run is idempotent. **Residual user-facing downtime: none.** No maintenance window or
+operator sign-off required — no serving surface goes offline.
+
 ## Design Decision — `-`-optional (Option B), not a templatefile guard (Option A)
 
 The task offered two shapes. **Choose Option B (`-/var/lib/inngest`) decisively.**
@@ -142,6 +196,31 @@ The task offered two shapes. **Choose Option B (`-/var/lib/inngest`) decisively.
 
 Not ADR-worthy: this restores an existing boot invariant using an established in-file precedent; no
 ownership / substrate / resolver / trust-boundary changes (see Architecture Decision below).
+
+### Research Insights — precedent diff (Phase 4.4)
+
+The `-`-optional form is the canonical in-repo pattern for a `ReadWritePaths` target that a later
+bootstrap step creates. Verbatim precedent at `apps/web-platform/infra/webhook.service:40-44`:
+
+```
+# `-` prefix on /var/lib/vector + /etc/vector marks them optional:
+# systemd silently ignores the path if absent, instead of refusing to set up
+# the mount namespace (which on prior PR #4257 took webhook.service down
+# entirely until the dirs were created). Once inngest-bootstrap.sh creates
+# them on first v1.1.x deploy, they become real ReadWritePaths.
+```
+
+Side-by-side (current → fixed), identical token in both lockstep files:
+
+```
+- ReadWritePaths=… /etc/webhook /var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
++ ReadWritePaths=… /etc/webhook -/var/lib/inngest -/var/lib/vector -/etc/vector /usr/local/bin
+```
+
+`/var/lib/inngest` is created by the **same** `inngest-bootstrap.sh` that creates the vector dirs
+(`inngest-bootstrap.sh:123` `mkdir -p /var/lib/inngest`) — so it belongs in the same optional class. The
+fix simply extends the #4257 decision to the one sibling token that was left mandatory. **Not novel; no
+"pattern is novel" caveat needed.**
 
 ## Implementation Phases
 

--- a/knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
@@ -336,9 +336,15 @@ logs:
   where: "Sentry events (baked DSN); web-1 /hooks/deploy-status; GH Actions run log for web-2-recreate"
   retention: "Sentry default; deploy-status is live/transient"
 discoverability_test:
-  command: "gh run view <web-2-recreate-run-id> --log  # off-host acceptance step must show reason flip ok_peer_fanout_degraded → ok; NO ssh"
-  expected_output: "web-2 :9000 bound; web-1 deploy-status reason=ok; no webhook_bound fatal in Sentry"
+  command: "curl -fsS -o /dev/null -w '%{http_code}' --max-time 10 https://soleur.ai"
+  expected_output: "200"
 ```
+
+The `discoverability_test.command` is a runnable, no-SSH **baseline** probe (prod reachable → the
+observability layer that will carry the fix's green signal is up). The **fix-specific** acceptance
+is inherently post-merge and non-pre-runnable: after merge, `gh run view <web-2-recreate run id>
+--log` must show the off-host acceptance step's `reason` flip `ok_peer_fanout_degraded → ok` (web-2
+`:9000` bound) with no `webhook_bound` fatal in Sentry — tracked in `tasks.md` Phase 6.
 
 Affected-surface note (§2.9.2): web-2 fresh boot is a deny-all blind surface. The `webhook_bound` beacon
 is emitted **from** the host (in-surface probe via the baked DSN), with a `stage` structured tag that

--- a/knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
@@ -1,0 +1,344 @@
+---
+title: "fix(infra): webhook.service ReadWritePaths hard-requires /var/lib/inngest → 226/NAMESPACE on colocate=false fresh web boots"
+issue: 6090
+branch: feat-one-shot-6090-webhook-inngest-readwritepath
+type: bug
+classification: infra-config-change
+lane: cross-domain  # no spec.md on branch → TR2 fail-closed default (change is genuinely single-domain infra)
+brand_survival_threshold: aggregate pattern
+date: 2026-07-12
+---
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!-- Phase 2.8 reviewed: this fix is ROUTED THROUGH TERRAFORM (cloud-init templatefile re-render on -replace
+     + the standalone webhook.service delivered via terraform_data.deploy_pipeline_fix's triggers_replace push).
+     The `systemctl` / cloud-init tokens in the prose below are QUOTES of existing cloud-init-managed runcmd
+     lines (evidence of the bug), NOT new manual/SSH operator steps. No operator SSH, no hand-run systemctl.
+     See the ## Infrastructure (IaC) section for the full apply path. -->
+
+# fix(infra): webhook.service ReadWritePaths hard-requires `/var/lib/inngest` → deterministic 226/NAMESPACE on fresh `web_colocate_inngest=false` boots
+
+🐛 **Bug** · P1 · `apps/web-platform/infra` · closes #6090 (this peel)
+
+## Overview
+
+A fresh web-2 boot dies with a deterministic systemd **226/NAMESPACE** unit failure: `webhook.service`'s
+`ReadWritePaths=` list hard-requires `/var/lib/inngest` (no leading `-`), but on a host where
+`web_colocate_inngest=false` (the default since the co-located-inngest bootstrap gate merged 2026-07-11,
+ADR-100 / #6178) **nothing ever creates that directory** — the only creator, `inngest-bootstrap.sh:123`
+(`mkdir -p /var/lib/inngest`), lives inside the `%{ if web_colocate_inngest ~}` runcmd block at
+`cloud-init.yml:636` and is skipped entirely. systemd refuses to set up the mount namespace for a
+non-optional `ReadWritePaths` target that is absent, so the cloud-init-managed webhook enable step
+(`cloud-init.yml:578`) fails, `:9000` never binds, and every deploy fan-out reports
+`ok_peer_fanout_degraded` — the weight-0 warm-standby never becomes deployable. This is the last
+remaining blocker for the #6178 Inngest cutover, whose runbook step-1a needs a clean, green web-2 recreate.
+
+**The fix is a one-character change per file, applied to BOTH lockstep copies of the unit:** prefix the
+`/var/lib/inngest` token with `-` (making it `-`-optional), exactly matching the adjacent
+`-/var/lib/vector` / `-/etc/vector` tokens that were made optional for the identical reason in PR #4257.
+When the directory is absent, systemd silently ignores it (namespace sets up, `:9000` binds); when it is
+present (a colocate host after `inngest-bootstrap.sh` has run), it "becomes a real ReadWritePath" on the
+next namespace setup — the exact semantics documented at `webhook.service:40-44`.
+
+`cloud-init.yml` is templatefile-injected (not baked into the image), so the change applies on the next
+`-replace`; the standalone `webhook.service` file is delivered to running hosts via the
+`deploy_pipeline_fix` webhook push (`server.tf:856-859`). No operator SSH, no hand-run commands.
+
+## Research Reconciliation — Premise vs. Codebase
+
+All premises in the task framing were verified against the branch before planning. No stale premises.
+
+| Premise (as stated) | Verified reality | Plan response |
+| --- | --- | --- |
+| `webhook.service` RWP hard-requires `/var/lib/inngest` (no `-`) around L245 | ✅ `cloud-init.yml:245` — exact token `/var/lib/inngest` with no leading `-`, adjacent to `-/var/lib/vector -/etc/vector` | Prefix with `-` |
+| `/var/lib/inngest` created only by the inngest-bootstrap runcmd, gated behind `web_colocate_inngest` | ✅ sole creator is `inngest-bootstrap.sh:123`; invoked only inside `cloud-init.yml:636 %{ if web_colocate_inngest ~}` | Confirmed — dir never exists on colocate=false |
+| `web_colocate_inngest` default false | ✅ `variables.tf:350-353` `type = bool`, `default = false` | Confirmed |
+| webhook enabled around L578 | ✅ `cloud-init.yml:578` (webhook binary installed L567-576) — a cloud-init runcmd line | Confirmed |
+| #6090 OPEN with a merged predecessor PR | ✅ OPEN; `closedByPullRequestsReferences` = PR **#6125** (merged, earlier probe-and-harden arc). **COLLISION acknowledged — operator confirmed genuinely new scope (deterministic post-gate 226/NAMESPACE deadlock). Proceeding past the merged-linked-PR check per instruction.** | Continue |
+| #6178 (Inngest cutover) / #5933 (fresh-boot observability) OPEN | ✅ both OPEN | Verification + observability wired against them |
+| **NEW (not in task): a SECOND copy of the RWP line exists** | ⚠️ **`apps/web-platform/infra/webhook.service:45`** carries the byte-identical RWP line (standalone unit, base64-delivered to running web-1 via `infra-config-apply.sh` + hashed in `deploy_pipeline_fix.triggers_replace`, `server.tf:859`). It is **NOT** templatefile-rendered. | **Fix BOTH copies with the `-` form (only Option that keeps the non-templated copy in lockstep — see Design Decision).** |
+| **NEW: the earlier-arc diagnosis comments reference the now-severed 226 chain** | ⚠️ `soleur-host-bootstrap.sh:191-193` and `soleur-host-bootstrap-observability.test.sh:526` explain a failed GHCR pull → `/var/lib/inngest` never created → "webhook.service fails 226/NAMESPACE → :9000 never binds". After this fix that causal link is **broken** (a missing dir no longer fails webhook). | Annotate both comments so future debuggers are not misled (GHCR rationale stays; the 226 clause is marked severed). |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** no direct user-facing artifact changes — web-2 is a
+weight-0 warm-standby with **no public ingress**. The realized impact is *aggregate resilience*: the
+warm-standby never becomes deployable, so there is no failover capacity if web-1 fails, and the #6178
+Inngest cutover stays blocked.
+
+**If this leaks, the user's data / workflow / money is exposed via:** N/A — `webhook.service` runs on an
+internal host reachable only via loopback + the `10.0.1.0/24` private net (`hcloud_firewall.web`
+default-denies `:9000` on the public interface). The change stores no data and opens no new surface; it
+only governs whether an internal host completes first boot.
+
+**Brand-survival threshold:** `aggregate pattern` — the failure degrades fleet-wide availability
+(loss of warm-standby / blocked cutover), not a single user's data or workflow. No per-PR CPO sign-off
+required; section present per gate.
+
+## Root Cause (verified)
+
+1. `webhook.service` runs `ProtectSystem=strict` + `PrivateTmp` in a mount namespace. `ReadWritePaths=`
+   whitelists the paths the webhook-driven `deploy <component>` handlers may write (via `sudo`, which
+   elevates UID but does **not** escape the namespace).
+2. A `ReadWritePaths` token **without** a leading `-` is **mandatory**: if the target is absent at unit
+   start, systemd refuses to construct the namespace and the unit fails with `226/NAMESPACE`. A token
+   **with** a leading `-` is optional: an absent target is silently skipped.
+3. `/var/lib/inngest` is the SQLite data dir for the co-located inngest server. Its sole creator is
+   `inngest-bootstrap.sh:123`, invoked only inside the `%{ if web_colocate_inngest ~}` block
+   (`cloud-init.yml:636-700`).
+4. With `web_colocate_inngest=false` (default), that block is skipped → `/var/lib/inngest` is **never**
+   created → the mandatory `ReadWritePaths=… /var/lib/inngest …` token has no target → the
+   cloud-init-managed webhook enable step (`cloud-init.yml:578`) fails `226/NAMESPACE` → `:9000` never
+   binds → `ok_peer_fanout_degraded`.
+
+**Why now / why deterministic:** the earlier #6090 arc (PRs through #6125) treated this as a *flaky
+ordering race* — on a colocate host the dir is created late (bootstrap at L636 runs *after* webhook is
+enabled at L578), and a failed anonymous GHCR pull could leave it absent (see the now-stale diagnosis at
+`soleur-host-bootstrap.sh:191-193`). The colocate gate (merged 2026-07-11) removed the dir-creating path
+entirely on the default config, converting the intermittent race into a **permanent** failure that no
+amount of GHCR-auth hardening can fix. Fresh reproduction: run **29169983049** (2026-07-11), the first
+post-gate web-2 recreate past the merged deploy-fanout `tag_malformed` fix.
+
+## Hypotheses (network-outage gate — `hr-ssh-diagnosis-verify-firewall`)
+
+The feature description contains the substring "SSH" (in "Do NOT SSH the deny-all hosts"), so the L3→L7
+network-outage checklist gate fires. **The failure is NOT a network outage** — it is a local systemd
+mount-namespace unit failure, deterministically established from unit semantics and off-host-confirmed via
+the baked-DSN `webhook_bound` beacon. The L3→L7 ladder is explicitly ruled out:
+
+- **L3 firewall / egress allow-list:** not implicated — `:9000` is a *local bind* that never happens; no
+  outbound connection is attempted at the failing step. `hcloud_firewall.web` is unchanged.
+- **L4/DNS/routing:** not implicated — no name resolution or route is exercised by the enable step.
+- **L7 sshd/fail2ban/service:** the service **is** the subject, but the failure mode is systemd namespace
+  construction (`226/NAMESPACE`), a config-time refusal, not a connectivity fault.
+
+Diagnosis is **off-host only** (baked-DSN boot beacons + Better Stack markers). **No SSH to the deny-all
+hosts** (`hr-no-ssh-fallback-in-runbooks`).
+
+## Design Decision — `-`-optional (Option B), not a templatefile guard (Option A)
+
+The task offered two shapes. **Choose Option B (`-/var/lib/inngest`) decisively.**
+
+- **Option A** — wrap the token in `%{ if web_colocate_inngest ~}/var/lib/inngest %{ endif ~}`:
+  - ✗ **Fatal:** works only for the templatefile-rendered `cloud-init.yml:245`. The **standalone
+    `webhook.service:45`** is read by `file()` and base64-delivered to running hosts — it is **not**
+    templated, so the `%{ if }` directive is impossible there. The two lockstep copies would **diverge**,
+    and the running-host copy would keep hard-requiring the dir (re-opening the bug on any redeploy).
+    `server.tf:793-794` explicitly requires the two to stay in lockstep.
+  - ✗ Even on colocate=true it does not fix the documented *ordering race* (dir created at L636, after
+    webhook is enabled at L578) — it only narrows it.
+- **Option B** — prefix the token with `-` in **both** files:
+  - ✓ **Uniform** across the templated and non-templated copies → lockstep preserved (no divergence, the
+    `triggers_replace` hash stays a single source of truth).
+  - ✓ **Exact in-repo precedent:** the adjacent `-/var/lib/vector` / `-/etc/vector` tokens already ship
+    this way for the identical reason (PR #4257 took webhook.service down entirely until the dirs existed);
+    rationale documented verbatim at `webhook.service:40-44`.
+  - ✓ Fixes **both** the colocate=false permanent failure **and** the latent colocate=true ordering race:
+    when `inngest-bootstrap.sh` later creates the dir, it "becomes a real ReadWritePath" on the next
+    namespace setup (webhook.service:43-44) — the webhook-driven inngest deploy's `chown` works exactly as
+    before once the dir exists.
+  - ✓ No regression for colocate=true: the first inngest install runs under cloud-init as root (not in the
+    webhook namespace); later webhook-driven deploys occur after the dir already exists.
+
+Not ADR-worthy: this restores an existing boot invariant using an established in-file precedent; no
+ownership / substrate / resolver / trust-boundary changes (see Architecture Decision below).
+
+## Implementation Phases
+
+### Phase 1 — RED: regression test locking the `-`-optional + lockstep invariant
+
+Add an infra test (home: `apps/web-platform/infra/inngest.test.sh`, which already reasons about the
+webhook namespace and `/var/lib/inngest`; deepen-plan to confirm the exact assert host) that:
+
+1. Asserts `cloud-init.yml`'s webhook.service `ReadWritePaths` contains `-/var/lib/inngest` (optional
+   form) and does **not** contain the bare mandatory ` /var/lib/inngest ` token.
+2. Asserts the standalone `webhook.service` `ReadWritePaths` contains `-/var/lib/inngest`.
+3. **Lockstep parity:** asserts the two `ReadWritePaths=` lines are byte-identical (modulo the YAML block
+   indent), so a future edit cannot silently diverge the templated and delivered copies.
+
+Run it first, confirm it FAILS on the current (mandatory) form (`cq-write-failing-tests-before`).
+
+### Phase 2 — GREEN: apply the `-` prefix + comment alignment (both lockstep copies)
+
+1. `cloud-init.yml:245` — `… /etc/webhook -/var/lib/inngest -/var/lib/vector -/etc/vector …`; update the
+   comment block (L239-244) so `/var/lib/inngest` shares the "optional because created later by
+   inngest-bootstrap.sh; becomes a real ReadWritePath once present" rationale rather than the current
+   "hard-required" wording.
+2. `webhook.service:45` — identical one-char change; fold `/var/lib/inngest` into the existing
+   `-`-optional rationale at L32-34 + L40-44 (extend the vector-paths explanation to cover inngest;
+   cite #4257 + #6090).
+
+Re-run Phase 1 test → GREEN.
+
+### Phase 3 — Comment-accuracy sweep (severed-causal-chain references)
+
+The `-`-optional fix breaks the "missing `/var/lib/inngest` → webhook 226/NAMESPACE → `:9000` unbound"
+chain that two earlier-arc comments assert as fact. Annotate (do not delete the still-valid GHCR
+rationale):
+
+1. `soleur-host-bootstrap.sh:191-193` — mark the 226/NAMESPACE clause severed by #6090's `-`-optional fix.
+2. `soleur-host-bootstrap-observability.test.sh:526` — same annotation (it is a comment inside the test).
+
+### Phase 4 — Verify emit coverage of the death stage (observability)
+
+Confirm the systemd-namespace death is named off-host. `cloud-init.yml:581`
+(`soleur-wait-ready port 9000 webhook_bound || exit 1`) POSTs a named `stage=webhook_bound` fatal to
+Sentry via the **baked DSN** when `:9000` never binds — the in-surface, no-SSH discoverability signal.
+Verify that the `226/NAMESPACE` abort at the webhook enable step (L578) does **not** short-circuit runcmd
+*before* reaching the L581 beacon (i.e., that the failure still surfaces a named emit, not an anonymous
+abort). If L578 can abort ahead of L581 under an active `set -e`/EXIT trap, add a named baked-DSN emit at
+the enable step so the systemd-namespace death is named (relates to #5933, #6090 observability). This is a
+verification task, not a presumed new beacon.
+
+### Phase 5 — Post-merge: fresh web-2-recreate + off-host green verification (automated apply)
+
+Trigger `gh workflow run apply-web-platform-infra.yml -f apply_target=web-2-recreate` (scoped `-replace`
+of web-2 to re-run first-boot cloud-init and bind `:9000`; ingress-safe, weight-0, nothing irreversible).
+The run's off-host acceptance step ("Wait for web-2 :9000 + verify off-host — no SSH — shared poll",
+`apply-web-platform-infra.yml:1209`) must go fully green: web-1's `/hooks/deploy-status` `reason` flips
+off `ok_peer_fanout_degraded` to `ok`, and **no** `webhook_bound` fatal appears in Sentry for the recreate.
+
+## Files to Edit
+
+- `apps/web-platform/infra/cloud-init.yml` — L245 `-/var/lib/inngest`; comment L239-244.
+- `apps/web-platform/infra/webhook.service` — L45 `-/var/lib/inngest`; comment L32-34 + L40-44.
+- `apps/web-platform/infra/soleur-host-bootstrap.sh` — L191-193 comment accuracy (severed 226 clause).
+- `apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh` — L526 comment accuracy.
+- `apps/web-platform/infra/inngest.test.sh` — ADD `-`-optional + lockstep parity assertions (Phase 1).
+
+## Files to Create
+
+None (regression assertions land in the existing `inngest.test.sh`).
+
+## Infrastructure (IaC)
+
+### Terraform changes
+No new resources, variables, providers, or secrets. The edit is to `cloud-init.yml` (consumed via
+`templatefile()` in `server.tf` for `hcloud_server.web` `user_data`) and the standalone `webhook.service`
+(read via `file()`, hashed into `terraform_data.deploy_pipeline_fix.triggers_replace`, `server.tf:856-859`).
+
+### Apply path
+- **Fresh hosts:** `cloud-init.yml` re-renders on the next `-replace` — delivered by
+  `apply_target=web-2-recreate` (scoped `-replace` of web-2 only; `hcloud_server.web["web-2"]` has
+  `ignore_changes=[user_data]`, so a plain apply will NOT re-deliver — the `-replace` is required).
+- **Running hosts (web-1):** the `webhook.service` change flows through the `deploy_pipeline_fix` webhook
+  push (its `triggers_replace` hash includes `file("webhook.service")`), which rewrites the unit +
+  restarts the listener. No SSH.
+- Chosen path: cloud-init re-render via `web-2-recreate` for the standby; `deploy_pipeline_fix` push for
+  web-1. Downtime/blast-radius: web-2 is weight-0 (no ingress); web-1 sees only a sub-second listener
+  restart, already an accepted `deploy_pipeline_fix` behavior.
+
+### Distinctness / drift safeguards
+No `dev`/`prd` divergence (this infra is prd-only). The lockstep parity test (Phase 1) is the drift
+safeguard preventing the templated and delivered copies from diverging.
+
+### Vendor-tier reality check
+N/A — no vendor resource created.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "webhook :9000 bind confirmed by soleur-wait-ready (cloud-init.yml:581) → baked-DSN Sentry emit; steady-state by web-1 /hooks/deploy-status reason=ok"
+  cadence: "once per fresh boot (wait-ready poll); deploy-status reason on every fan-out"
+  alert_target: "Sentry (baked DSN) + web-1 deploy-status reason (Better Stack marker)"
+  configured_in: "apps/web-platform/infra/cloud-init.yml:581 (soleur-wait-ready), soleur-host-bootstrap.sh (_sentry_emit boundary)"
+error_reporting:
+  destination: "Sentry via baked DSN (host-emitted, no SSH)"
+  fail_loud: "yes — soleur-wait-ready … || exit 1 emits a named stage=webhook_bound fatal and aborts boot"
+failure_modes:
+  - mode: "webhook.service fails 226/NAMESPACE (the bug) → :9000 never binds"
+    detection: "in-surface baked-DSN emit stage=webhook_bound (fatal), emitted FROM the booting host; off-host visible as web-1 deploy-status reason=ok_peer_fanout_degraded"
+    alert_route: "Sentry (stage tag) + apply-web-platform-infra.yml:1209 off-host acceptance step"
+  - mode: "webhook enable step (L578) aborts before reaching the L581 beacon"
+    detection: "Phase-4 verification confirms a named emit at the enable step (or the L581 beacon still fires); no anonymous abort"
+    alert_route: "Sentry named stage tag"
+logs:
+  where: "Sentry events (baked DSN); web-1 /hooks/deploy-status; GH Actions run log for web-2-recreate"
+  retention: "Sentry default; deploy-status is live/transient"
+discoverability_test:
+  command: "gh run view <web-2-recreate-run-id> --log  # off-host acceptance step must show reason flip ok_peer_fanout_degraded → ok; NO ssh"
+  expected_output: "web-2 :9000 bound; web-1 deploy-status reason=ok; no webhook_bound fatal in Sentry"
+```
+
+Affected-surface note (§2.9.2): web-2 fresh boot is a deny-all blind surface. The `webhook_bound` beacon
+is emitted **from** the host (in-surface probe via the baked DSN), with a `stage` structured tag that
+discriminates the systemd-namespace death from later cloud-init stages — satisfying the blind-surface
+probe requirement.
+
+## Architecture Decision (ADR/C4)
+
+**No new ADR or C4 change.** This is a bug fix restoring an existing boot invariant using an established
+in-file precedent (`-`-optional `ReadWritePaths`, PR #4257); it makes no ownership/tenancy, substrate,
+resolver, or trust-boundary decision, and does not reverse or extend an ADR (it operates *within*
+ADR-100 / #6178's dedicated-inngest-host direction — colocate=false is exactly that state).
+
+C4 completeness check (read against `model.c4` + `views.c4`): no **external human actor**, no **external
+system/vendor**, no **container/data-store**, and no **actor↔surface access relationship** is
+added/removed/changed. `web-2` and `webhook.service` are existing internal elements; the fix only governs
+whether an already-modeled host completes first boot. → **no C4 impact.**
+
+## Domain Review
+
+**Domains relevant:** none (engineering is the self-domain of the change).
+
+No cross-domain implications detected — infrastructure/tooling change. Product/UX Gate: **NONE** — no
+file under `components/**`, `app/**/page.tsx`, or `app/**/layout.tsx`; no UI-surface term matches. No
+GDPR/regulated-data surface (systemd unit + cloud-init; no schema/auth/API/`.sql`).
+
+## Open Code-Review Overlap
+
+None — no open `code-review`-labelled issue references the files in scope
+(`cloud-init.yml`, `webhook.service`, `soleur-host-bootstrap.sh`, `inngest.test.sh`). (Re-verify at
+deepen-plan against the finalized Files-to-Edit list.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] **AC1** `grep -c -- '-/var/lib/inngest' apps/web-platform/infra/cloud-init.yml` returns `1`; the
+  mandatory bare token is gone: `grep -Ec '[^-]/var/lib/inngest -/var/lib/vector' apps/web-platform/infra/cloud-init.yml` returns `0`.
+- [ ] **AC2** `grep -c -- '-/var/lib/inngest' apps/web-platform/infra/webhook.service` returns `1`.
+- [ ] **AC3** Lockstep parity: the `ReadWritePaths=` token list (trimmed) is byte-identical between
+  `cloud-init.yml:245` and `webhook.service:45` — asserted by the new `inngest.test.sh` case.
+- [ ] **AC4** The new regression test FAILS on the pre-fix (mandatory) form and PASSES on the `-` form.
+- [ ] **AC5** `bash apps/web-platform/infra/inngest.test.sh` passes; existing infra tests
+  (`infra-config-apply.test.sh`, `infra-config-install.test.sh`) still pass (no assertion regressed).
+- [ ] **AC6** `soleur-host-bootstrap.sh:191-193` and `soleur-host-bootstrap-observability.test.sh:526`
+  comments no longer assert the (now-severed) "missing dir → webhook 226/NAMESPACE" chain as live fact.
+- [ ] **AC7** Phase-4 emit-coverage check documented: the death stage surfaces a named baked-DSN emit
+  (either the existing L581 `webhook_bound` beacon fires, or a named emit is added at L578).
+- [ ] **AC8** PR body uses `Closes #6090` (the code fix lands pre-merge; the post-merge recreate is
+  verification of the already-merged fix, not the fix itself).
+
+### Post-merge (operator / automated)
+- [ ] **AC9** `gh workflow run apply-web-platform-infra.yml -f apply_target=web-2-recreate -f reason='#6090 verify webhook RWP inngest -optional'` completes green.
+  Automation: `gh` CLI (feasible in-session/CI once merged). The `-replace` re-runs first-boot cloud-init;
+  ingress-safe, weight-0, reversible.
+- [ ] **AC10** The run's off-host acceptance step (`apply-web-platform-infra.yml:1209`) shows web-1
+  `/hooks/deploy-status` `reason` flipped off `ok_peer_fanout_degraded` to `ok`; `:9000` bound on web-2.
+- [ ] **AC11** No `stage=webhook_bound` fatal in Sentry for the web-2-recreate boot (baked DSN; off-host).
+
+## Test Scenarios
+
+1. **Pre-fix RED:** current mandatory token → new test fails; documents the 226/NAMESPACE deadlock.
+2. **Post-fix GREEN (colocate=false):** `-`-optional token, dir absent → namespace sets up, `:9000` binds.
+3. **Colocate=true regression:** dir present (post-`inngest-bootstrap.sh`) → `-`-optional still writable →
+   webhook-driven inngest deploy `chown` unaffected (matches vector-path precedent semantics).
+4. **Lockstep:** an edit that changes one copy's RWP list but not the other fails the parity assertion.
+5. **Live off-host verify:** web-2-recreate run → reason flip → no `webhook_bound` fatal.
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, placeholder, or omits the threshold fails
+  `deepen-plan` Phase 4.6 — this section is filled (threshold `aggregate pattern`).
+- **Two lockstep copies, not one.** `cloud-init.yml:245` (templated, fresh hosts) and `webhook.service:45`
+  (non-templated, delivered to running hosts) must both change and stay byte-identical — this is why
+  Option A (templatefile-only guard) is rejected and the parity test exists.
+- **`ignore_changes=[user_data]`** means a plain `terraform apply` will NOT re-deliver the cloud-init
+  change to an existing web host; the `-replace` (via `web-2-recreate`) is required for fresh delivery,
+  and web-1 gets the standalone-unit change via the `deploy_pipeline_fix` push — not via cloud-init.
+- **Do NOT SSH the deny-all hosts.** Diagnose only via baked-DSN boot beacons + Better Stack / deploy-status
+  markers (`hr-no-ssh-fallback-in-runbooks`).
+- `inngest-server.service`'s own `ReadWritePaths=/var/lib/inngest /var/lock` (`inngest-bootstrap.sh:431`)
+  is **out of scope** — that unit legitimately owns the dir (its bootstrap creates it first) and must keep
+  the hard requirement. Only `webhook.service`'s copy is the bug.

--- a/knowledge-base/project/rule-metrics.json
+++ b/knowledge-base/project/rule-metrics.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "generated_at": "2026-07-11T18:27:13Z",
+  "generated_at": "2026-07-12T08:42:22Z",
   "rules": [
     {
       "id": "cm-challenge-reasoning-instead-of",
@@ -705,19 +705,6 @@
       "rule_text_prefix": " → core"
     },
     {
-      "id": "hr-weigh-every-decision-against-target-user-impact",
-      "section": "Hard Rules",
-      "hit_count": 0,
-      "bypass_count": 0,
-      "applied_count": 0,
-      "warn_count": 0,
-      "fire_count": 0,
-      "prevented_errors": 0,
-      "last_hit": null,
-      "first_seen": null,
-      "rule_text_prefix": " → core"
-    },
-    {
       "id": "hr-when-a-command-exits-non-zero-or-prints",
       "section": "Hard Rules",
       "hit_count": 0,
@@ -1285,14 +1272,27 @@
       "warn_count": 0,
       "fire_count": 1,
       "prevented_errors": 0,
-      "last_hit": "2026-07-11T17:44:38Z",
-      "first_seen": "2026-07-11T17:44:38Z",
+      "last_hit": "2026-07-12T08:18:29Z",
+      "first_seen": "2026-07-12T08:18:29Z",
+      "rule_text_prefix": " → core"
+    },
+    {
+      "id": "hr-weigh-every-decision-against-target-user-impact",
+      "section": "Hard Rules",
+      "hit_count": 0,
+      "bypass_count": 0,
+      "applied_count": 1,
+      "warn_count": 0,
+      "fire_count": 1,
+      "prevented_errors": 0,
+      "last_hit": "2026-07-12T08:18:29Z",
+      "first_seen": "2026-07-12T08:18:29Z",
       "rule_text_prefix": " → core"
     }
   ],
   "summary": {
     "total_rules_tagged": 99,
-    "rules_unused_over_8w": 98,
+    "rules_unused_over_8w": 97,
     "rules_bypassed_over_baseline": 0,
     "orphan_rule_ids": [],
     "drops_jq_fail_count": 0,

--- a/knowledge-base/project/specs/feat-one-shot-6090-webhook-inngest-readwritepath/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6090-webhook-inngest-readwritepath/session-state.md
@@ -1,0 +1,22 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md
+- Status: complete
+
+### Errors
+- One recoverable block: the initial plan Write was rejected by the IaC-routing PreToolUse hook (`hr-all-infrastructure-provisioning-servers`) because the prose quoted `systemctl`. Resolved with the `iac-routing-ack: plan-phase-2-8-reviewed` opt-out — the fix IS routed through Terraform/cloud-init; the `systemctl` tokens are quotes of existing managed behavior, not new manual steps. Plan carries a full `## Infrastructure (IaC)` section.
+- No other errors. All premises validated; all deepen-plan hard gates passed.
+
+### Decisions
+- **Root cause confirmed** at `cloud-init.yml:245`: `/var/lib/inngest` is a mandatory `ReadWritePaths` token; on `web_colocate_inngest=false` (default) the only dir-creator (`inngest-bootstrap.sh:123`) is gated off, so `webhook.service` fails `226/NAMESPACE` → `:9000` never binds → `ok_peer_fanout_degraded`.
+- **Chose Option B (`-`-optional) over Option A (templatefile guard).** Decisive finding: a SECOND byte-identical copy of the RWP line lives in standalone `webhook.service:45`, base64-delivered to running hosts via `deploy_pipeline_fix.triggers_replace` — NOT templatefile-rendered, so `%{ if }` is impossible there. Only the `-` prefix keeps both lockstep copies uniform, matching in-file precedent (`-/var/lib/vector` / `-/etc/vector`, PR #4257).
+- **Scope**: both lockstep files, comment-accuracy sweep of two now-stale earlier-arc comments (`soleur-host-bootstrap.sh:191-193` + its observability test) asserting the now-severed 226 causal chain, a regression + lockstep-parity test, and Phase-4 emit-coverage verification of the `webhook_bound` baked-DSN beacon.
+- **Threshold**: aggregate pattern (weight-0 no-ingress standby; degrades fleet resilience, not per-user data). Verification off-host only via `web-2-recreate` + deploy-status reason flip (no SSH).
+- No new ADR/C4 (restores an existing invariant within ADR-100/#6178); Product/UX NONE; collision with merged predecessor PR #6125 acknowledged and passed per operator confirmation.
+
+### Components Invoked
+- `soleur:plan` (Skill)
+- `soleur:deepen-plan` (Skill) — hard gates 4.6/4.7/4.8/4.9 passed; conditional gates 4.5 (network-outage) + 4.55 (downtime) fired, satisfied, telemetry emitted; precedent-diff (4.4) grounded
+- `gh` CLI (premise validation: #6090/#6178/#5933 states, PR #6125 collision)
+- Git commit + push (plan + tasks.md, then deepened plan)

--- a/knowledge-base/project/specs/feat-one-shot-6090-webhook-inngest-readwritepath/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6090-webhook-inngest-readwritepath/tasks.md
@@ -1,0 +1,32 @@
+# Tasks — fix(infra) webhook.service ReadWritePaths `/var/lib/inngest` 226/NAMESPACE deadlock (#6090)
+
+Plan: `knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md`
+Lane: cross-domain (TR2 fail-closed default — no spec.md on branch; change is genuinely single-domain infra)
+
+## Phase 1 — RED: regression test (lock the invariant before fixing)
+- [ ] 1.1 Add assertions to `apps/web-platform/infra/inngest.test.sh` (confirm exact host at /work):
+  - [ ] 1.1.1 `cloud-init.yml` webhook.service `ReadWritePaths` contains `-/var/lib/inngest` and NOT the bare ` /var/lib/inngest ` token
+  - [ ] 1.1.2 standalone `webhook.service` `ReadWritePaths` contains `-/var/lib/inngest`
+  - [ ] 1.1.3 lockstep parity: the two `ReadWritePaths=` token lists are byte-identical (modulo YAML indent)
+- [ ] 1.2 Run the test; confirm it FAILS on the current mandatory form (`cq-write-failing-tests-before`)
+
+## Phase 2 — GREEN: apply the `-` prefix + comment alignment (both lockstep copies)
+- [ ] 2.1 `apps/web-platform/infra/cloud-init.yml:245` → `-/var/lib/inngest`; update comment L239-244 to the "optional; becomes real ReadWritePath once inngest-bootstrap creates it" rationale
+- [ ] 2.2 `apps/web-platform/infra/webhook.service:45` → `-/var/lib/inngest`; fold inngest into the existing vector `-`-optional rationale (L32-34 + L40-44), cite #4257 + #6090
+- [ ] 2.3 Re-run Phase 1 test → GREEN
+
+## Phase 3 — Comment-accuracy sweep (severed causal chain)
+- [ ] 3.1 `apps/web-platform/infra/soleur-host-bootstrap.sh:191-193` — annotate the 226/NAMESPACE clause as severed by the `-`-optional fix (keep GHCR rationale)
+- [ ] 3.2 `apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh:526` — same annotation
+
+## Phase 4 — Verify death-stage emit coverage (observability, no SSH)
+- [ ] 4.1 Confirm the `226/NAMESPACE` abort at the webhook enable step (`cloud-init.yml:578`) still surfaces a named baked-DSN emit (L581 `webhook_bound` beacon fires, or add a named emit at L578); no anonymous abort
+
+## Phase 5 — Full-suite + AC verification (pre-merge)
+- [ ] 5.1 `bash apps/web-platform/infra/inngest.test.sh` passes; `infra-config-apply.test.sh` + `infra-config-install.test.sh` still pass
+- [ ] 5.2 Walk AC1–AC8 (see plan); PR body `Closes #6090`
+
+## Phase 6 — Post-merge: fresh web-2-recreate + off-host green (automated)
+- [ ] 6.1 `gh workflow run apply-web-platform-infra.yml -f apply_target=web-2-recreate -f reason='#6090 verify webhook RWP inngest -optional'`
+- [ ] 6.2 Off-host acceptance step (`apply-web-platform-infra.yml:1209`): web-1 deploy-status `reason` flips `ok_peer_fanout_degraded` → `ok`; web-2 `:9000` bound (AC10)
+- [ ] 6.3 No `stage=webhook_bound` fatal in Sentry for the recreate boot (AC11)

--- a/knowledge-base/project/specs/feat-one-shot-6090-webhook-inngest-readwritepath/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6090-webhook-inngest-readwritepath/tasks.md
@@ -4,26 +4,26 @@ Plan: `knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-innges
 Lane: cross-domain (TR2 fail-closed default — no spec.md on branch; change is genuinely single-domain infra)
 
 ## Phase 1 — RED: regression test (lock the invariant before fixing)
-- [ ] 1.1 Add assertions to `apps/web-platform/infra/inngest.test.sh` (confirm exact host at /work):
-  - [ ] 1.1.1 `cloud-init.yml` webhook.service `ReadWritePaths` contains `-/var/lib/inngest` and NOT the bare ` /var/lib/inngest ` token
-  - [ ] 1.1.2 standalone `webhook.service` `ReadWritePaths` contains `-/var/lib/inngest`
-  - [ ] 1.1.3 lockstep parity: the two `ReadWritePaths=` token lists are byte-identical (modulo YAML indent)
-- [ ] 1.2 Run the test; confirm it FAILS on the current mandatory form (`cq-write-failing-tests-before`)
+- [x] 1.1 Add assertions to `apps/web-platform/infra/inngest.test.sh` (confirmed host; CI-registered infra-validation.yml:299):
+  - [x] 1.1.1 `cloud-init.yml` webhook.service `ReadWritePaths` contains `-/var/lib/inngest` and NOT the bare ` /var/lib/inngest ` token
+  - [x] 1.1.2 standalone `webhook.service` `ReadWritePaths` contains `-/var/lib/inngest`
+  - [x] 1.1.3 lockstep parity: the two `ReadWritePaths=` token lists are byte-identical (modulo YAML indent)
+- [x] 1.2 Ran the test; confirmed 4 FAILs on the current mandatory form (`cq-write-failing-tests-before`)
 
 ## Phase 2 — GREEN: apply the `-` prefix + comment alignment (both lockstep copies)
-- [ ] 2.1 `apps/web-platform/infra/cloud-init.yml:245` → `-/var/lib/inngest`; update comment L239-244 to the "optional; becomes real ReadWritePath once inngest-bootstrap creates it" rationale
-- [ ] 2.2 `apps/web-platform/infra/webhook.service:45` → `-/var/lib/inngest`; fold inngest into the existing vector `-`-optional rationale (L32-34 + L40-44), cite #4257 + #6090
-- [ ] 2.3 Re-run Phase 1 test → GREEN
+- [x] 2.1 `apps/web-platform/infra/cloud-init.yml` webhook.service RWP → `-/var/lib/inngest`; comment updated with the "optional; becomes real ReadWritePath once inngest-bootstrap creates it" rationale (#6090)
+- [x] 2.2 `apps/web-platform/infra/webhook.service` RWP → `-/var/lib/inngest`; folded inngest into the vector `-`-optional rationale, cited #4257 + #6090
+- [x] 2.3 Re-ran Phase 1 test → GREEN (86/86)
 
 ## Phase 3 — Comment-accuracy sweep (severed causal chain)
-- [ ] 3.1 `apps/web-platform/infra/soleur-host-bootstrap.sh:191-193` — annotate the 226/NAMESPACE clause as severed by the `-`-optional fix (keep GHCR rationale)
-- [ ] 3.2 `apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh:526` — same annotation
+- [x] 3.1 `apps/web-platform/infra/soleur-host-bootstrap.sh` — annotated the 226/NAMESPACE clause as severed by the `-`-optional fix (kept GHCR rationale)
+- [x] 3.2 `apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh` — same annotation (69/69 still green)
 
 ## Phase 4 — Verify death-stage emit coverage (observability, no SSH)
-- [ ] 4.1 Confirm the `226/NAMESPACE` abort at the webhook enable step (`cloud-init.yml:578`) still surfaces a named baked-DSN emit (L581 `webhook_bound` beacon fires, or add a named emit at L578); no anonymous abort
+- [x] 4.1 Confirmed: `cloud-init.yml:581` `soleur-wait-ready port 9000 webhook_bound || exit 1` fires immediately after the webhook enable (:578) — a named baked-DSN beacon already covers the abort; no anonymous abort, no new emit needed
 
 ## Phase 5 — Full-suite + AC verification (pre-merge)
-- [ ] 5.1 `bash apps/web-platform/infra/inngest.test.sh` passes; `infra-config-apply.test.sh` + `infra-config-install.test.sh` still pass
+- [x] 5.1 `inngest.test.sh` 86/86; `infra-config-apply.test.sh` 63; `infra-config-install.test.sh` 29; observability 69; firewall-9000 1; cron-egress-firewall 197 + 6 more sibling infra suites — all green (0 failures). cloud-init schema failure is pre-existing (Terraform template; origin/main fails identically)
 - [ ] 5.2 Walk AC1–AC8 (see plan); PR body `Closes #6090`
 
 ## Phase 6 — Post-merge: fresh web-2-recreate + off-host green (automated)


### PR DESCRIPTION
## Summary

Fresh web-2 hosts (weight-0 warm standby) hit a **deterministic systemd 226/NAMESPACE deadlock** on boot: `webhook.service` hard-required `/var/lib/inngest` in `ReadWritePaths=` (no `-` prefix), but the `web_colocate_inngest` gate (default `false` since 2026-07-11) gates off the only `runcmd` block that **creates** that dir. So systemd fails the unit → `:9000` never binds → every deploy fan-out reports `ok_peer_fanout_degraded` → the standby never deploys. This is the last blocker for the #6178 Inngest cutover (its runbook step-1a needs a clean web-2 recreate). The gate converted a previously-flaky `/var/lib/inngest` ordering race into a permanent deadlock.

**Fix:** prefix the token `-/var/lib/inngest` (systemd "ignore if absent") in BOTH lockstep copies — `cloud-init.yml` (baked at boot) + standalone `webhook.service` (base64-delivered to running web-1 via `terraform_data.deploy_pipeline_fix.triggers_replace`) — matching the adjacent `-/var/lib/vector` precedent (PR #4257). `inngest-server.service` (the dir's owner) keeps the mandatory form, so `colocate=on` is unaffected.

Plan: `knowledge-base/project/plans/2026-07-12-fix-webhook-readwritepaths-inngest-namespace-deadlock-plan.md`

Ref #6090

> **`Ref`, not `Closes` (Closes-after-apply):** #6090 stays open until the post-merge web-2 recreate proves `:9000` binds off-host (`tasks.md` Phase 6). This arc had stacked causes; auto-closing on merge before the recreate verifies would be premature.

## User-Brand Impact

- **Artifact:** the weight-0 warm-standby web host (fleet failover capacity) — **not** any per-user data or credential.
- **Vector:** a fresh web-2 recreate deadlocks at boot → the standby is undeployable → degraded fleet redundancy. web-1 remains the sole healthy primary; no user-facing impact while web-1 is up.
- **Brand-survival threshold:** `aggregate pattern` — the failure degrades fleet-wide availability/redundancy, not a single user's data or an individual account.

## Changelog

### Web Platform (infra)
- `webhook.service` + `cloud-init.yml`: `/var/lib/inngest` → `-/var/lib/inngest` (optional) in both lockstep `ReadWritePaths=` copies, so a `web_colocate_inngest=false` host no longer 226/NAMESPACEs on a dir it never creates.
- `inngest.test.sh`: +8 assertions (per-copy `-`-optional present, no bare mandatory token, byte-identical lockstep parity, exactly-one-`ReadWritePaths=`-line `head -1` safety); RED→GREEN.
- Comment-accuracy sweep in `soleur-host-bootstrap.sh` + its observability test (severed 226 causal chain; GHCR-auth rationale retained for `colocate=on`).

## Deploy note

`webhook.service` is a `deploy_pipeline_fix` trigger file → `apply-deploy-pipeline-fix.yml` auto-applies the standalone copy to running web-1 on merge (no operator action). `cloud-init.yml` applies to fresh hosts on the next `-replace`.

## Test plan

- [x] `inngest.test.sh` 88/88 (RED→GREEN); 13 sibling infra suites green locally (mirrors `infra-validation.yml`)
- [x] `shellcheck` clean; `cloud-init schema` failure confirmed pre-existing (Terraform templatefile — `origin/main` fails identically)
- [x] 5-agent review (security / architecture / pattern-recognition / observability / code-quality) — no P1/P2; one converged P3 (RWP-line-count hardening) fixed inline
- [ ] Post-merge: fresh web-2-recreate → off-host `:9000` acceptance reason flip `ok_peer_fanout_degraded → ok`; no `webhook_bound` fatal in Sentry (`tasks.md` Phase 6; agent-driven, ingress-safe/weight-0)

Generated with [Claude Code](https://claude.com/claude-code)
