### PR TITLE
feat(infra): no-SSH op=arm for the inngest cutover Doppler arm-flip (#6369)

### DIFF
--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -355,6 +355,9 @@ jobs:
               -target=github_actions_secret.doppler_token_kb_drift \
               -target=doppler_service_token.write \
               -target=github_actions_secret.doppler_token_write \
+              -target=doppler_service_token.inngest_arm_write \
+              -target=github_repository_environment.inngest_cutover \
+              -target=github_actions_environment_secret.doppler_token_inngest_arm \
               -target=tls_private_key.ci_ssh \
               -target=doppler_secret.deploy_ssh_private_key \
               -target=doppler_secret.ghcr_read_user \

--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -28,6 +28,7 @@ on:
           - inventory
           - execute
           - quiesce-web
+          - arm
           - verify
           - rollback
   # push trigger scoped to this file forces GitHub to register the workflow in
@@ -47,15 +48,28 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # op=arm / op=rollback write a prod secret to soleur-inngest/prd (the arm-flip / reverse
+    # flip, #6369). They gate on the `inngest-cutover` GitHub Environment (required-reviewer
+    # rule, TF-provisioned in inngest-arm-write-token.tf) so the DOPPLER_TOKEN_INNGEST_ARM
+    # environment secret resolves ONLY after a human approves the dispatch — the ack that
+    # hr-menu-option-ack-not-prod-write-auth requires. Every other op evaluates to '' (no
+    # environment gate), preserving their existing behaviour.
+    environment: ${{ (inputs.op == 'arm' || inputs.op == 'rollback') && 'inngest-cutover' || '' }}
     # SAME group as deploy/restart — these inngest host ops share the host state
     # slot and must not interleave (P1a).
     concurrency:
       group: deploy-inngest-restart
       cancel-in-progress: false
     steps:
-      # Doppler CLI is needed only by op=backup (reads HCLOUD_TOKEN from the
-      # prd_terraform-scoped DOPPLER_TOKEN); installing it is harmless for the
-      # webhook ops. SHA-pinned, matching web-platform-release.yml.
+      # op=arm/op=rollback confirm the on-host flip FSM via Better Stack Logs
+      # (scripts/betterstack-query.sh); checkout makes that script available. Harmless
+      # (no-op source read) for the webhook ops. SHA-pinned.
+      - name: Checkout (for betterstack-query.sh — op=arm/rollback FSM confirm)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # Doppler CLI is needed by op=backup (reads HCLOUD_TOKEN from the prd_terraform-scoped
+      # DOPPLER_TOKEN) and op=arm/op=rollback (source read-through + arm-token writes +
+      # betterstack-query.sh cred injection); installing it is harmless for the webhook
+      # ops. SHA-pinned, matching web-platform-release.yml.
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@014df23b1329b615816a38eb5f473bb9000700b1 # v3
       - name: Run cutover host op via webhook
@@ -64,9 +78,17 @@ jobs:
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_DEPLOY_SECRET }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-          # prd_terraform READ-only (op=backup reads HCLOUD_TOKEN). Same secret as
+          # prd_terraform READ-only (op=backup reads HCLOUD_TOKEN; op=arm/op=rollback read the
+          # source values read-through + betterstack-query.sh creds). Same secret as
           # apply-web-platform-infra.yml's read steps — NOT DOPPLER_TOKEN_WRITE.
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          # #6369 — the read/write token for the arm-flip writes to the ISOLATED soleur-inngest/prd
+          # (op=arm writes INNGEST_POSTGRES_URI/INNGEST_HEARTBEAT_URL/INNGEST_CUTOVER_FLIP=armed;
+          # op=rollback writes INNGEST_CUTOVER_FLIP=rollback). A conditional expression injects it
+          # EMPTY for every other dispatch — a bash comment cannot scope a step-env var (security F2/C5).
+          # It is a GitHub ENVIRONMENT secret (inngest-cutover), so it only resolves once the
+          # required-reviewer gate is approved on an op=arm/op=rollback dispatch.
+          DOPPLER_TOKEN_INNGEST_ARM: ${{ (inputs.op == 'arm' || inputs.op == 'rollback') && secrets.DOPPLER_TOKEN_INNGEST_ARM || '' }}
           # #6258: read-only pg_stat_activity for the op=execute 2.-1 pool pre-check
           # (same secret + endpoint scheduled-inngest-health.yml uses; TF
           # github_actions_secret.supabase_access_token). Read-only Management-API scope.
@@ -82,6 +104,36 @@ jobs:
         run: |
           set -euo pipefail
           BASE="https://deploy.soleur.ai/hooks"
+
+          # Shared no-SSH confirm of the on-host inngest-cutover-flip FSM terminal state via Better
+          # Stack Logs (source 2457081), used by op=arm (G6) and op=rollback (#6369). The emitter
+          # (apps/web-platform/infra/inngest-cutover-flip.sh:125-137, `emit_state exit_code dbsize
+          # reason flag`) puts the TERMINAL STATE in the `flag` field (done/aborted/rolled-back) and
+          # a CAUSE in `reason` (flip-complete/dbsize-nonzero/…) — so we key on `"flag":"<state>"`,
+          # NOT `reason` (which never equals `done`/`aborted`). Arg $1 = floor timestamp in the
+          # `betterstack-query.sh` literal `--since` form `YYYY-MM-DD HH:MM:SS` (its ClickHouse cast
+          # rejects the ISO `T…Z` form). Echoes EXACTLY one terminal token to stdout: done |
+          # rolled-back | aborted | timeout. NEVER echoes a raw Better Stack row (a value could ride
+          # along) — only the extracted flag token. A confirm-PATH (query) failure is announced on
+          # stderr distinctly from an FSM-not-terminal state, so a timeout names the right subsystem.
+          confirm_flip_state() {
+            local since="$1" i rows raw rc
+            for i in $(seq 1 40); do   # 40 x 15s = 600s (30s on-host timer + FLUSHALL/assert + journald->Vector->BS latency)
+              rows=$(doppler run -p soleur -c prd_terraform -- bash scripts/betterstack-query.sh --since "$since" --grep inngest-cutover-flip --limit 50 2>/dev/null)
+              rc=$?
+              if [[ "$rc" -ne 0 ]]; then
+                echo "::warning::confirm: betterstack-query.sh returned non-zero (the CONFIRM PATH failed, NOT the on-host FSM) — verify BETTERSTACK_QUERY_{HOST,USERNAME,PASSWORD} in prd_terraform" >&2
+              fi
+              raw=$(printf '%s\n' "$rows" | jq -r 'try (.raw) catch empty' 2>/dev/null || true)
+              # aborted first (fail-safe if somehow both terminal flags appear in the window).
+              if printf '%s\n' "$raw" | grep -qE '"flag":"aborted"'; then echo "aborted"; return 0; fi
+              if printf '%s\n' "$raw" | grep -E '"flag":"rolled-back"' | grep -qE '"exit_code":0'; then echo "rolled-back"; return 0; fi
+              if printf '%s\n' "$raw" | grep -E '"flag":"done"' | grep -qE '"exit_code":0'; then echo "done"; return 0; fi
+              echo "confirm: awaiting a terminal FSM flag (attempt $i/40 since $since)" >&2
+              sleep 15
+            done
+            echo "timeout"; return 0
+          }
 
           case "$OP" in
             enumerate)
@@ -599,20 +651,136 @@ jobs:
               fi
               echo "::notice::2.2 QUIESCE HARD GATE PASSED: the LB-REACHABLE host(s) POSITIVELY confirmed not-serving (fail-closed). SCOPE (DI-C3, tracked #6227): this LB-routed path did NOT individually probe the weight-0 warm-standby web-2 (10.0.1.11). op=quiesce-web (when run) now stop+disables web-2's scheduler too (an ACT), but CI still cannot VERIFY web-2 AND web-2's local reminders were never captured — the MANDATORY web-2 freeze/recreate step in the SEAM below is NOT superseded; do NOT read a green op=quiesce-web as 'web-2 handled'."
 
-              # ---- SEAM: operator maintenance-window steps (NOT executed by CI —
-              # hr-menu-option-ack-not-prod-write-auth). Print the exact hand-off; no
-              # secrets / bodies / connection strings are echoed (AC-NOBODY), only step text.
-              echo "::notice::SEAM — operator maintenance-window steps (run OUT-OF-BAND; CI will not perform these prod-writes):"
+              # ---- SEAM: operator maintenance-window steps. As of #6369 the 2.2b/2.3 arm-flip is NO
+              # LONGER an out-of-band Doppler write — it is the no-SSH `op=arm` dispatch (a prod-write
+              # behind explicit dispatch + the inngest-cutover environment required-reviewer gate, which
+              # satisfies hr-menu-option-ack-not-prod-write-auth: the dispatch + approval IS the ack).
+              # The remaining true operator seams are 2.2a (web-2 lifecycle) and 2.4 (app-repoint).
+              # This block still echoes only step text; no secrets / bodies / connection strings (AC-NOBODY).
+              echo "::notice::SEAM — operator maintenance-window steps (2.2a web-2 lifecycle + 2.4 app-repoint are operator; 2.2b/2.3 arm-flip is now the no-SSH op=arm dispatch):"
               echo "  2.2a WEB-2 QUIESCE — MANDATORY, NOT AUTO-VERIFIED (DI-C3, tracked #6227). op=quiesce-web (when run) now stop+disables web-2's SCHEDULER over the private net (an ACT — a real improvement over operator-only web-2 handling), BUT CI still cannot VERIFY web-2 (LB-scoped) AND web-2's local reminders were NEVER captured (2.1 capture is also LB-scoped). The weight-0 warm-standby web-2 (10.0.1.11) self-arms oneshots into its OWN Redis independent of LB weight. So the web-2 freeze/recreate lifecycle REMAINS MANDATORY — do NOT read a green op=quiesce-web as 'web-2 handled'. Before arming the flip you MUST recreate web-2 onto the post-cutover config: take web-2 OUT of the warm-standby rotation and recreate it so no surviving web-2 scheduler self-arms a reminder into its local Redis. RISK IF SKIPPED: a reminder self-armed on an un-quiesced web-2 is silently dropped at cutover (its local Redis is never captured/re-armed). This is a lifecycle action (freeze → recreate), NOT a host shell step (AC-NOSSH). Do NOT proceed to arm the flip until web-2 is recreated. Tracks #6227 (real per-host fan-out to auto-verify web-2)."
-              echo "  2.2b+2.3 ARM THE FLIP — three Doppler writes on soleur-inngest/prd (the enabled 30s poll timer picks them up):"
-              echo "    1) doppler secrets set INNGEST_POSTGRES_URI=<prod-postgres-uri>   --project soleur-inngest --config prd"
-              echo "    2) doppler secrets set INNGEST_HEARTBEAT_URL=<betteruptime inngest_prd heartbeat url> --project soleur-inngest --config prd"
-              echo "    3) doppler secrets set INNGEST_CUTOVER_FLIP=armed               --project soleur-inngest --config prd"
-              echo "     Then CONFIRM the flip via Better Stack (the on-host Vector→Better Stack shipper carries the 'inngest-cutover-flip' log line): require exit_code:0 (P0-2). Do NOT SSH/cat the deny-all-public host to read state."
+              echo "  2.2b+2.3 ARM THE FLIP — NO LONGER a manual Doppler write. Dispatch the no-SSH op=arm verb: it writes the 3 values on soleur-inngest/prd (INNGEST_POSTGRES_URI + INNGEST_HEARTBEAT_URL read-through from prd_terraform, then INNGEST_CUTOVER_FLIP=armed LAST — the enabled 30s poll timer picks it up), then CONFIRMS the on-host FSM reached done (exit_code:0) via Better Stack. No secret is echoed (AC-NOBODY; #6369). Run: gh workflow run cutover-inngest.yml --field op=arm  (then APPROVE the inngest-cutover environment required-reviewer gate — that approval IS the prod-write ack)."
               echo "  2.4 APP-REPOINT — merge the ci-deploy.sh INNGEST_BASE_URL → http://10.0.1.40:8288 change (canary + prod sites) and redeploy so functions re-sync onto the dedicated host."
               echo "  THEN: op=rearm (re-arm the Σ=$SIGMA_CAPTURED captured reminders; gated on registry-non-empty) → op=verify (exactly-once)."
-              echo "  ROLLBACK / aborted-recovery (P0-1/P0-3/P1-13): (1) doppler secrets set INNGEST_CUTOVER_FLIP=rollback --project soleur-inngest --config prd (the enabled timer stops the dedicated scheduler; confirm rolled-back via Better Stack); (2) revert the ci-deploy.sh INNGEST_BASE_URL repoint back to loopback + redeploy; (3) run op=rollback — a SINGLE no-SSH 'enable inngest _ _' fan-out that re-enables (restores the [Install] symlink the 2.2 disable removed) AND starts the web scheduler across [$CUTOVER_HOSTS] in one flock-held handler, then polls deploy-status for the 'enabled' verdict. No operator systemctl step is needed (op=quiesce-web/op=rollback are the no-SSH quiesce/re-enable verbs)."
+              echo "  ROLLBACK / aborted-recovery (P0-1/P0-3/P1-13): (1) dispatch op=rollback — it now writes INNGEST_CUTOVER_FLIP=rollback on soleur-inngest/prd NO-SSH (via the inngest-cutover environment token, value on stdin), confirms rolled-back via Better Stack, THEN runs the SINGLE no-SSH 'enable inngest _ _' fan-out that re-enables (restores the [Install] symlink the 2.2 disable removed) AND starts the web scheduler across [$CUTOVER_HOSTS] in one flock-held handler, polling deploy-status for the 'enabled' verdict; (2) revert the ci-deploy.sh INNGEST_BASE_URL repoint back to loopback + redeploy. No operator Doppler write or systemctl step is needed (op=arm/op=rollback/op=quiesce-web are the no-SSH arm/reverse/quiesce verbs)."
               echo "::notice::execute complete — SEAM emitted. CI performed NO prod-write; the flip + app-repoint are the operator's maintenance-window steps."
+              ;;
+
+            arm)
+              # op=arm (#6369) — the no-SSH arm-flip: the three Doppler writes on soleur-inngest/prd
+              # that were op=execute's 2.2b/2.3 operator SEAM (:607-611). FORWARD-ONLY — the reverse
+              # INNGEST_CUTOVER_FLIP=rollback write lives in op=rollback (ADR-100 Decision 6b keeps the
+              # symmetric forward/reverse pair as SEPARATE verbs). A prod-write behind explicit
+              # dispatch (same trust model as op=quiesce-web/op=rollback) PLUS the inngest-cutover
+              # environment required-reviewer gate. The two SOURCE values are read read-through from
+              # soleur/prd_terraform via the existing read-only DOPPLER_TOKEN (CTO 2026-07-12 /
+              # ADR-100 6b: the prod DSN is already CI-readable there, SHA-identical to canonical prd;
+              # no operator seed). Writes go to the ISOLATED soleur-inngest/prd via the read/write
+              # DOPPLER_TOKEN_INNGEST_ARM. AC-NOBODY: no value is EVER echoed — every source value is
+              # ::add-mask::'d on its own capture line and every write reads from stdin (never argv,
+              # which /proc/<pid>/cmdline exposes).
+              if [[ -z "${DOPPLER_TOKEN_INNGEST_ARM:-}" ]]; then
+                echo "::error::op=arm: DOPPLER_TOKEN_INNGEST_ARM is empty — the inngest-cutover environment secret did not resolve. Approve the environment required-reviewer gate on this dispatch, or the per-merge apply has not yet published the token (gh api repos/:owner/:repo/environments/inngest-cutover/secrets). Refusing to arm."; exit 1
+              fi
+
+              # G1 — pre-write FSM-state guard (DI-C2, P1 — prevents PROD-Redis re-FLUSHALL data loss).
+              # Re-arming over armed/flipping/flushed/done re-drives the on-host FSM stop -> FLUSHALL
+              # against the now-PROD Redis, wiping the live cron sorted-set + in-flight jobs. FAIL-CLOSED
+              # on a read error (user-impact F1 / DI): a swallowed read must NOT be mistaken for a safe
+              # `unset`. First PROVE the config is readable via a Doppler built-in (DOPPLER_PROJECT,
+              # always present, not a secret) — if THAT read fails it is a read/API failure, refuse. Only
+              # then read the flip; a missing flip on a proven-readable config is a genuine safe first-arm.
+              # The deploy-inngest-restart concurrency group (cancel-in-progress:false) serializes
+              # dispatches, so this read is TOCTOU-safe. The flip state is a public enum (not a secret).
+              if ! DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get DOPPLER_PROJECT -p soleur-inngest -c prd --plain >/dev/null 2>&1; then
+                echo "::error::op=arm: G1 — cannot read soleur-inngest/prd (config-readability probe failed: read/API/auth failure). A swallowed read must NOT be treated as a safe pre-arm state; refusing FAIL-CLOSED. Retry once the read path is healthy. Do NOT SSH the host."; exit 1
+              fi
+              CUR_FLIP=$(DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get INNGEST_CUTOVER_FLIP -p soleur-inngest -c prd --plain 2>/dev/null || echo "unset")
+              case "$CUR_FLIP" in
+                ""|unset|aborted|rolled-back)
+                  echo "::notice::op=arm: G1 pre-write FSM-state guard passed (config readability proven; INNGEST_CUTOVER_FLIP is a safe pre-arm state: '${CUR_FLIP:-unset}')" ;;
+                *)
+                  echo "::error::op=arm: G1 REFUSING — INNGEST_CUTOVER_FLIP is already '$CUR_FLIP' on soleur-inngest/prd (armed/flipping/flushed/done). Re-arming would re-drive stop -> FLUSHALL against the PROD Redis and wipe the live cron queue (DI-C2). If a prior arm is mid-flight, let it reach done; if it aborted, drive it via op=rollback to rolled-back before re-arming. Do NOT SSH the host."; exit 1 ;;
+              esac
+
+              # G2 — read the two SOURCE values read-through from prd_terraform (existing DOPPLER_TOKEN),
+              # masking EACH on its OWN capture line (security F7 — never batch; a mid-sequence set -e
+              # exit must not leave an unmasked captured value in scope before its mask lands).
+              PG=$(doppler secrets get INNGEST_POSTGRES_URI --plain 2>/dev/null || true)
+              printf '::add-mask::%s\n' "$PG"
+              HB=$(doppler secrets get INNGEST_HEARTBEAT_URL --plain 2>/dev/null || true)
+              printf '::add-mask::%s\n' "$HB"
+              if [[ -z "$PG" || -z "$HB" ]]; then
+                echo "::error::op=arm: a source value (INNGEST_POSTGRES_URI / INNGEST_HEARTBEAT_URL) is empty or unreadable from prd_terraform via DOPPLER_TOKEN. Refusing to arm (no value echoed)."; exit 1
+              fi
+
+              # G3 — positive prod-URI assertion (DI-C3, P1 — the :5432/:6543 guard alone MISSES the
+              # dark backend; both dark and prod DSNs use :5432). Read the CURRENT (dark)
+              # INNGEST_POSTGRES_URI from soleur-inngest/prd via the arm token, mask it, and assert the
+              # value we are about to write DIFFERS from dark AND targets the prod session pooler. All
+              # comparisons value-silent (only booleans/tokens reach the log).
+              PG_DARK=$(DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get INNGEST_POSTGRES_URI -p soleur-inngest -c prd --plain 2>/dev/null || true)
+              printf '::add-mask::%s\n' "$PG_DARK"
+              # FAIL-CLOSED on an empty/failed dark read (observability F1 / user-impact / DI): the
+              # config is proven readable by G1, so an empty PG_DARK is anomalous — and the prod!=dark
+              # equality below is the ONLY guard that distinguishes prod from dark (both are :5432 Supabase).
+              # An empty PG_DARK would make `$PG == ""` false and SILENTLY pass the equality — the exact
+              # §User-Brand-Impact failure (flip onto the dark backend). Refuse instead.
+              if [[ -z "$PG_DARK" ]]; then
+                echo "::error::op=arm: G3 — could not read the current dark INNGEST_POSTGRES_URI from soleur-inngest/prd (empty despite a readable config). Cannot assert prod != dark; refusing FAIL-CLOSED (no value echoed). Do NOT SSH the host."; exit 1
+              fi
+              case "$PG" in
+                *:6543*) echo "::error::op=arm: G3 — INNGEST_POSTGRES_URI uses the :6543 transaction pooler; inngest sqlc requires the :5432 session pooler (inngest-host.tf:157). Refusing (no value echoed)."; exit 1 ;;
+              esac
+              case "$PG" in
+                *:5432*) : ;;
+                *) echo "::error::op=arm: G3 — INNGEST_POSTGRES_URI does not contain the :5432 session-pooler port. Refusing (no value echoed)."; exit 1 ;;
+              esac
+              # Positive prod-project pin (C3/D3): assert PG targets the TF-known prod inngest Postgres
+              # project ref (pigsfuxruiopinouvjwy — variables.tf:270; NOT a secret, a Supabase project ref
+              # that appears in the pooler host + user). This is stronger than a bare `supabase` substring:
+              # a drifted-but-Supabase :5432 non-dark value (e.g. a staging project) is rejected. The dark
+              # backend is a DISTINCT project so it does NOT contain this ref. Value-silent (PG never echoed).
+              case "$PG" in
+                *pigsfuxruiopinouvjwy*) : ;;
+                *) echo "::error::op=arm: G3 — INNGEST_POSTGRES_URI does not target the TF-known prod inngest Postgres project (ref pigsfuxruiopinouvjwy). Refusing (no value echoed)."; exit 1 ;;
+              esac
+              if [[ "$PG" == "$PG_DARK" ]]; then
+                echo "::error::op=arm: G3 REFUSING — the prod INNGEST_POSTGRES_URI equals the CURRENT dark soleur-inngest/prd value. Arming this would flip onto the DARK backend (a mis-config/no-op) and FLUSHALL the host Redis onto the wrong Postgres (DI-C3, the §User-Brand-Impact failure). Refusing BEFORE any write (no value echoed)."; exit 1
+              fi
+              echo "::notice::op=arm: G3 positive prod-URI assertion passed (prod != dark, :5432 session pooler, prod project-ref present — all value-silent)"
+
+              # G4 — write the two DATA secrets FIRST, each via stdin (never argv), each exit-gated
+              # before the next. Order is a correctness invariant: the URIs must land before `armed`.
+              printf '%s' "$PG" | DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets set INNGEST_POSTGRES_URI -p soleur-inngest -c prd --no-interactive >/dev/null || { echo "::error::op=arm: G4 — writing INNGEST_POSTGRES_URI to soleur-inngest/prd FAILED. armed NOT written. Job aborts (no value echoed)."; exit 1; }
+              echo "::notice::op=arm: G4 wrote INNGEST_POSTGRES_URI to soleur-inngest/prd (value not echoed)"
+              printf '%s' "$HB" | DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets set INNGEST_HEARTBEAT_URL -p soleur-inngest -c prd --no-interactive >/dev/null || { echo "::error::op=arm: G4 — writing INNGEST_HEARTBEAT_URL to soleur-inngest/prd FAILED. armed NOT written. Job aborts (no value echoed)."; exit 1; }
+              echo "::notice::op=arm: G4 wrote INNGEST_HEARTBEAT_URL to soleur-inngest/prd (value not echoed)"
+
+              # G5 — arm LAST. The enabled 30s on-host .timer picks up `armed` and drives the FSM
+              # armed -> flipping -> flushed -> done (ADR-100 Decision 6a). `armed` is a literal, not a
+              # secret, but use the same stdin form for a uniform (test-asserted) write shape.
+              ARM_TS=$(date +%s)
+              printf '%s' 'armed' | DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets set INNGEST_CUTOVER_FLIP -p soleur-inngest -c prd --no-interactive >/dev/null || { echo "::error::op=arm: G5 — writing INNGEST_CUTOVER_FLIP=armed FAILED (both URIs already landed). Re-dispatch op=arm — G1 will allow re-arm from a non-terminal state. Do NOT SSH the host."; exit 1; }
+              echo "::notice::op=arm: G5 armed — INNGEST_CUTOVER_FLIP=armed written LAST to soleur-inngest/prd. The on-host 30s timer now drives the flip FSM."
+
+              # G6 — confirm the on-host FSM reached `done` via Better Stack (AC9; security F1 + DI-Q4).
+              # TIME-BOUND to >= the armed-write moment (ARM_TS captured just before G5) so a stale
+              # terminal line from a prior run/dry-run on the SAME source cannot false-succeed. The
+              # shared confirm_flip_state keys on the emitter's `flag` field (done/aborted/rolled-back),
+              # NOT `reason` (which is a cause string, never `done`) — and uses the space-timestamp form
+              # betterstack-query.sh's ClickHouse cast accepts. It never echoes a raw row.
+              ARM_ISO=$(date -u -d "@$ARM_TS" +'%Y-%m-%d %H:%M:%S')
+              G6_STATE=$(confirm_flip_state "$ARM_ISO")
+              case "$G6_STATE" in
+                done)
+                  echo "::notice::op=arm: G6 — FSM confirmed done (flag:done exit_code:0) via Better Stack (since $ARM_ISO)" ;;
+                aborted|rolled-back)
+                  echo "::error::op=arm: G6 — the on-host FSM reached terminal '$G6_STATE' (NOT done) since $ARM_ISO. The cutover flip FAILED on-host (e.g. DBSIZE!=0 abort / FLUSHALL-failed / unexpected-exit). REMEDIATION: confirm the dark backend + DBSIZE via op=inventory; do NOT proceed to 2.4 (app-repoint). Inspect the inngest-cutover-flip Better Stack line. Do NOT SSH the host."; exit 1 ;;
+                *)  # timeout — could be the FSM OR the confirm path (a ::warning:: fired above if the query failed)
+                  echo "::error::op=arm: G6 — no terminal FSM flag (done/aborted) within 600s since $ARM_ISO (armed WAS written). If the on-host 30s timer looks healthy, re-run scripts/betterstack-query.sh manually (runbook §3) to rule out a confirm-path failure (a betterstack-query.sh ::warning:: above names that case). Do NOT proceed to 2.4. Do NOT SSH the host."; exit 1 ;;
+              esac
+              echo "::notice::op=arm complete — arm-flip written no-SSH (3 values, armed last) + FSM confirmed done. Remaining cutover steps: op=rearm (re-arm captured reminders) -> op=verify (exactly-once), plus the operator 2.4 app-repoint. NO secret value was echoed (AC-NOBODY)."
               ;;
 
             quiesce-web)
@@ -888,13 +1056,16 @@ jobs:
               ;;
 
             rollback)
-              # op=rollback — the AUTHORED reverse of 2.2 quiesce (P1-13): re-enable +
-              # restart inngest on EVERY $CUTOVER_HOSTS host, then confirm via inventory. The
-              # DEDICATED-host stop half of rollback is the operator's Doppler
-              # INNGEST_CUTOVER_FLIP=rollback write (D.5 step 1) — NOT a CI prod-write. This
-              # arm only drives the web hosts, which the runner reaches via the deploy hook
-              # over the private net (no SSH). This is also the P0-3 `aborted`-state recovery
-              # (the DBSIZE gate disabled the web schedulers; this brings them back).
+              # op=rollback — the AUTHORED reverse of the cutover (P1-13). As of #6369 it has TWO
+              # halves: (A) the DEDICATED-host stop is now a NO-SSH Doppler write
+              # INNGEST_CUTOVER_FLIP=rollback on soleur-inngest/prd (folded here from the former
+              # operator SEAM D.5 step 1 — the enabled on-host timer picks it up and drives the FSM to
+              # rolled-back); (B) the WEB re-enable + restart across EVERY $CUTOVER_HOSTS host via the
+              # deploy hook over the private net (no SSH). op=rollback stays a SEPARATE verb from op=arm
+              # (ADR-100 Decision 6b forward/reverse symmetry). Half (A) is value-silent + behind the same
+              # inngest-cutover environment required-reviewer gate + conditional DOPPLER_TOKEN_INNGEST_ARM
+              # as op=arm; it writes ONLY the flip value (never POSTGRES_URI/HEARTBEAT). This is also the
+              # P0-3 `aborted`-state recovery (the DBSIZE gate disabled the web schedulers; (B) restores them).
               if [[ -z "${CUTOVER_HOSTS:-}" ]]; then
                 echo "::error::CUTOVER_HOSTS is empty — refusing to run rollback against an empty host-set"; exit 1
               fi
@@ -902,6 +1073,49 @@ jobs:
               if [[ "${#HOSTS[@]}" -lt 1 ]]; then
                 echo "::error::CUTOVER_HOSTS parsed to zero hosts (value: '$CUTOVER_HOSTS')"; exit 1
               fi
+
+              # ---- Half (A): the no-SSH reverse flip write (#6369). Behind the environment gate.
+              if [[ -z "${DOPPLER_TOKEN_INNGEST_ARM:-}" ]]; then
+                echo "::error::op=rollback: DOPPLER_TOKEN_INNGEST_ARM is empty — the inngest-cutover environment secret did not resolve. Approve the required-reviewer gate on this dispatch. Refusing the reverse flip write."; exit 1
+              fi
+              # G1' decides ONLY whether to WRITE the reverse flip — it must NOT gate Half (B). Half (B),
+              # the web re-enable, is the pre-#6369 UNCONDITIONAL reverse of 2.2 quiesce and the documented
+              # P0-3 aborted-state recovery, so it runs for EVERY state (arch review P1). Write `rollback`
+              # when the forward flip is armed OR progressing (∈ {armed,flipping,flushed,done}) — armed
+              # included so a pending arm is stopped before the timer completes it; idempotent-skip when
+              # already rollback/rolled-back; for a non-forward state (unset/empty/aborted) there is nothing
+              # on the dedicated host to reverse. Fail-CLOSED on a read error (a swallowed read must not be
+              # mistaken for 'unset'). The flip state is a public enum — not masked.
+              if ! DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get DOPPLER_PROJECT -p soleur-inngest -c prd --plain >/dev/null 2>&1; then
+                echo "::error::op=rollback: cannot read soleur-inngest/prd (config-readability probe failed). Refusing the reverse-flip decision FAIL-CLOSED; retry once the read path is healthy. Do NOT SSH the host."; exit 1
+              fi
+              RB_CUR=$(DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get INNGEST_CUTOVER_FLIP -p soleur-inngest -c prd --plain 2>/dev/null || echo "unset")
+              case "$RB_CUR" in
+                armed|flipping|flushed|done)
+                  echo "::notice::op=rollback: G1' — forward flip is '$RB_CUR'; writing the reverse flip to stop the dedicated scheduler BEFORE re-enabling the web schedulers (prevents two live schedulers double-firing prod crons)."
+                  RB_TS=$(date +%s)
+                  printf '%s' 'rollback' | DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets set INNGEST_CUTOVER_FLIP -p soleur-inngest -c prd --no-interactive >/dev/null || { echo "::error::op=rollback: writing INNGEST_CUTOVER_FLIP=rollback FAILED. Re-dispatch op=rollback. Do NOT SSH the host."; exit 1; }
+                  echo "::notice::op=rollback: wrote INNGEST_CUTOVER_FLIP=rollback to soleur-inngest/prd (no value echoed) — the enabled on-host timer stops the dedicated scheduler and drives the FSM to rolled-back."
+                  # BLOCKING confirm: the dedicated scheduler MUST be confirmed stopped BEFORE Half (B)
+                  # re-enables the web schedulers — else both run and double-fire prod crons (user-impact
+                  # F2 / DI, an exactly-once violation). On timeout, FAIL (exit 1) WITHOUT re-enabling web:
+                  # that leaves at most ONE potentially-live scheduler (the dedicated one), never two.
+                  RB_ISO=$(date -u -d "@$RB_TS" +'%Y-%m-%d %H:%M:%S')
+                  RB_STATE=$(confirm_flip_state "$RB_ISO")
+                  case "$RB_STATE" in
+                    rolled-back)
+                      echo "::notice::op=rollback: FSM confirmed rolled-back (flag:rolled-back exit_code:0) via Better Stack (since $RB_ISO) — dedicated scheduler stopped; safe to re-enable the web schedulers." ;;
+                    *)
+                      echo "::error::op=rollback: the FSM did not confirm rolled-back within 600s (state='$RB_STATE'; the write DID land). WITHHOLDING the web re-enable to avoid two live schedulers double-firing prod crons — at most one scheduler is live now. Verify the dedicated scheduler stopped via the inngest-cutover-flip Better Stack line (re-run scripts/betterstack-query.sh, runbook §3), then re-dispatch op=rollback. Do NOT SSH the host."; exit 1 ;;
+                  esac
+                  ;;
+                rollback|rolled-back)
+                  echo "::notice::op=rollback: INNGEST_CUTOVER_FLIP is already '$RB_CUR' — the dedicated scheduler is stopping/stopped; skipping the (idempotent) reverse write, proceeding to the web re-enable." ;;
+                *)
+                  echo "::notice::op=rollback: INNGEST_CUTOVER_FLIP is '${RB_CUR:-unset}' (not armed/forward-progressed) — nothing on the dedicated host to reverse (aborted = already stopped by the DBSIZE gate; unset = never armed). This is the documented P0-3 aborted-state recovery; proceeding to the web re-enable." ;;
+              esac
+
+              # ---- Half (B): the web re-enable + restart fan-out (the pre-#6369 behaviour).
               echo "::notice::rollback: re-enabling inngest across host-set [$CUTOVER_HOSTS] (${#HOSTS[@]} host(s)) — reverse of 2.2 quiesce (P1-13)"
               # The reverse of 2.2 quiesce is now a SINGLE no-SSH `enable inngest _ _` verb
               # (ci-deploy.sh) = enable + start + verify-serving-and-enabled in ONE flock-held

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -119,7 +119,10 @@ assert "quiesce gate withholds the SEAM + exits non-zero on survivors" "grep -qE
 assert "execute prints the operator SEAM only after the gate" "grep -qE 'SEAM . operator maintenance-window steps' '$WF'"
 # The SEAM must gate the flip arm on Better Stack, NOT a host read (P0-2).
 assert "SEAM confirms the flip via Better Stack, not a host cat (P0-2)" "grep -qE 'Better Stack' '$WF'"
-assert "SEAM arms the Doppler flip (INNGEST_CUTOVER_FLIP=armed)" "grep -qE 'INNGEST_CUTOVER_FLIP=armed' '$WF'"
+# #6369 — the 2.2b/2.3 arm-flip is no longer a manual Doppler write in the SEAM; the SEAM now
+# directs the operator to the no-SSH op=arm dispatch (the armed write itself is asserted in the
+# op=arm case body section below).
+assert "SEAM directs the arm-flip to the no-SSH op=arm dispatch (#6369)" "grep -qE 'dispatch the no-SSH op=arm verb|op=arm' '$WF'"
 
 # D.3 / AC-VERIFY — op=verify: precondition registry NON-empty (2.4 landed,
 # P1-9/P2-17), 2.6 via the doublefire hook, RunsFilterV2 + STARTED_AT bucketing,
@@ -298,6 +301,108 @@ assert "retry fails CLOSED (still-non-200 after 2 attempts exits 1)" "grep -qE '
 assert "DI-C3 execute inventory gate is NOT wrapped in a retry (single-shot)" "! grep -B2 'BASE/inngest-inventory\" || echo \"000\")' '$WF' | grep -q 'exec-inv.*for attempt'"
 # The registry_empty VERDICT (registry_empty != false) is downstream of the retry loop, un-retried.
 assert "registry_empty verdict is a separate downstream check (not inside the retry loop)" "grep -qE 'verify precondition FAILED' '$WF'"
+
+# ============================================================================
+# #6369 — op=arm (the no-SSH arm-flip) + op=rollback reverse flip-write. op=arm is
+# FORWARD-ONLY (writes `armed`); the reverse `rollback` write lives in op=rollback
+# (ADR-100 Decision 6b forward/reverse symmetry). AC-NOBODY: no source value is EVER echoed,
+# every value ::add-mask::'d + written via stdin; the FSM is confirmed via Better Stack.
+# Both verbs gate on the inngest-cutover environment (required-reviewer) + a conditional
+# DOPPLER_TOKEN_INNGEST_ARM. Extract each case body to a temp file and grep it — asserting
+# the awk range is NON-EMPTY first (security F6 — else every range grep passes vacuously).
+# ============================================================================
+assert "choice includes arm (#6369)" "grep -qE '^[[:space:]]+-[[:space:]]*arm\$' '$WF'"
+assert "case arm: arm)" "grep -qE '^[[:space:]]+arm\\)' '$WF'"
+
+ARM_FILE="$(mktemp)"; ROLLBACK_FILE="$(mktemp)"
+awk '/^            arm\)$/,/^              ;;$/' "$WF" > "$ARM_FILE"
+awk '/^            rollback\)$/,/^              ;;$/' "$WF" > "$ROLLBACK_FILE"
+ARM_N=$(wc -l < "$ARM_FILE"); ROLLBACK_N=$(wc -l < "$ROLLBACK_FILE")
+# F6 non-vacuity: the arm) awk range must be a real block before any range grep is trusted.
+assert "arm) case body is non-empty (>20 lines — F6 non-vacuity)" "[[ '$ARM_N' -gt 20 ]]"
+assert "rollback) case body is non-empty (F6 non-vacuity)" "[[ '$ROLLBACK_N' -gt 20 ]]"
+
+# AC6 (AC-NOBODY): no source value is echoed; ::add-mask:: per value; writes via stdin, never argv.
+assert "arm) echoes NO source value (AC6/AC-NOBODY)" "! grep -qE 'echo[^\"]*\\\$\\{?(HB|PG|PG_DARK|POSTGRES|HEARTBEAT)' '$ARM_FILE'"
+assert "arm) does NOT dump raw Better Stack rows (no 'jq .' — C6 mask bypass)" "! grep -qE 'jq \\.($|[^a-zA-Z_])' '$ARM_FILE'"
+assert "arm) has no 'set -x' (would echo masked values — C8)" "! grep -qE 'set -x' '$ARM_FILE'"
+ARM_MASK_N=$(grep -cE '::add-mask::' "$ARM_FILE" || true)
+assert "arm) masks EACH source value (>=3 ::add-mask:: — PG/HB/PG_DARK, C8/F7)" "[[ '$ARM_MASK_N' -ge 3 ]]"
+# stdin form: >=3 `doppler secrets set INNGEST_*` writes, each fed by a `printf` pipe (never NAME=value argv).
+ARM_SET_N=$(grep -cE 'doppler secrets set INNGEST_' "$ARM_FILE" || true)
+ARM_PRINTF_N=$(grep -cE "printf '%s'" "$ARM_FILE" || true)
+assert "arm) performs >=3 doppler secrets set INNGEST_* writes" "[[ '$ARM_SET_N' -ge 3 ]]"
+assert "arm) each write is stdin-fed (>=3 printf pipes — AC6 no-argv)" "[[ '$ARM_PRINTF_N' -ge 3 ]]"
+assert "arm) NEVER writes a secret on argv (no 'secrets set INNGEST_*=value')" "! grep -qE 'secrets set INNGEST_[A-Z_]+=' '$ARM_FILE'"
+assert "arm) writes target the ISOLATED soleur-inngest/prd config" "grep -qE 'doppler secrets set INNGEST_POSTGRES_URI -p soleur-inngest -c prd' '$ARM_FILE'"
+# Source reads are read-through from prd_terraform (CTO 6b): no -p/-c on the source get, no seed name.
+assert "arm) reads POSTGRES_URI read-through from prd_terraform (no -p/-c on the source get — CTO 6b)" "grep -qE 'doppler secrets get INNGEST_POSTGRES_URI --plain' '$ARM_FILE'"
+assert "arm) does NOT reference a dropped operator seed (INNGEST_POSTGRES_URI_PROD)" "! grep -qE 'INNGEST_POSTGRES_URI_PROD' '$ARM_FILE'"
+
+# AC7 write order: armed written AFTER both URIs.
+PG_SET_LN=$(grep -nE 'secrets set INNGEST_POSTGRES_URI ' "$ARM_FILE" | head -1 | cut -d: -f1)
+FLIP_SET_LN=$(grep -nE 'secrets set INNGEST_CUTOVER_FLIP ' "$ARM_FILE" | head -1 | cut -d: -f1)
+assert "arm) writes POSTGRES_URI BEFORE INNGEST_CUTOVER_FLIP=armed (write order AC7)" "[[ -n '$PG_SET_LN' && -n '$FLIP_SET_LN' && '$PG_SET_LN' -lt '$FLIP_SET_LN' ]]"
+
+# AC8 / G3 positive prod-URI assertion + :6543 reject; G1 pre-write FSM-state guard (DI-C2).
+assert "arm) G3 rejects the :6543 transaction pooler" "grep -qF ':6543' '$ARM_FILE'"
+assert "arm) G3 requires the :5432 session pooler" "grep -qF ':5432' '$ARM_FILE'"
+assert "arm) G3 refuses when prod == dark (PG == PG_DARK)" "grep -qE 'PG.*==.*PG_DARK' '$ARM_FILE'"
+assert "arm) G1 reads the current INNGEST_CUTOVER_FLIP from soleur-inngest (pre-write state guard)" "grep -qE 'doppler secrets get INNGEST_CUTOVER_FLIP -p soleur-inngest' '$ARM_FILE'"
+assert "arm) G1 refuses re-arm over a non-safe FSM state (DI-C2 REFUSING)" "grep -qE 'G1 REFUSING' '$ARM_FILE'"
+
+# AC9 FSM confirm — the confirm logic is the SHARED confirm_flip_state() function (used by op=arm G6
+# AND op=rollback). Extract it and assert it keys on the emitter's `flag` field, NOT `reason`: the
+# on-host emitter (apps/web-platform/infra/inngest-cutover-flip.sh `emit_state exit_code dbsize reason
+# flag`) puts the TERMINAL STATE in `flag` (done/aborted/rolled-back) and a CAUSE in `reason` (which
+# NEVER equals done/aborted). A confirm keyed on `"reason":"done"` would match no row → every op=arm
+# times out. This block is the cross-file parity that stops that silent drift.
+CONFIRM_FILE="$(mktemp)"
+awk '/^          confirm_flip_state\(\) \{$/,/^          \}$/' "$WF" > "$CONFIRM_FILE"
+CONFIRM_N=$(wc -l < "$CONFIRM_FILE")
+assert "confirm_flip_state() is defined + non-empty (F6 non-vacuity)" "[[ '$CONFIRM_N' -gt 5 ]]"
+assert "confirm keys on the emitter FLAG field (\"flag\":\"done\" + exit_code:0 — NOT reason)" "grep -qF '\"flag\":\"done\"' '$CONFIRM_FILE' && grep -qF '\"exit_code\":0' '$CONFIRM_FILE'"
+assert "confirm does NOT key on \"reason\":\"done\" (the field-mismatch bug the review caught)" "! grep -qF '\"reason\":\"done\"' '$CONFIRM_FILE'"
+assert "confirm detects the aborted terminal flag (fail-loud path)" "grep -qF '\"flag\":\"aborted\"' '$CONFIRM_FILE'"
+assert "confirm detects the rolled-back terminal flag" "grep -qF '\"flag\":\"rolled-back\"' '$CONFIRM_FILE'"
+assert "confirm reads via betterstack-query.sh (no-SSH), never a deploy-status poll" "grep -qE 'betterstack-query.sh --since' '$CONFIRM_FILE' && ! grep -qE 'deploy-status' '$CONFIRM_FILE'"
+assert "confirm never dumps a raw Better Stack row (no 'jq .')" "! grep -qE 'jq \\.($|[^a-zA-Z_])' '$CONFIRM_FILE'"
+assert "confirm distinguishes a query-path failure from FSM-not-terminal (::warning:: CONFIRM PATH)" "grep -qE 'CONFIRM PATH' '$CONFIRM_FILE'"
+# Emitter parity: the on-host emitter MUST actually stamp the flag states the confirm greps for.
+EMITTER="$REPO_ROOT/apps/web-platform/infra/inngest-cutover-flip.sh"
+assert "emitter stamps flag 'done' (the confirm's success key) + an aborted path" "grep -qF 'flag_set \"done\"' '$EMITTER' && grep -qF 'aborted' '$EMITTER'"
+
+# op=arm calls the shared confirm with a SPACE-form timestamp betterstack-query.sh accepts (NOT the ISO
+# T/Z form its ClickHouse cast rejects — the P2 that would false-negative every confirm).
+assert "arm) calls confirm_flip_state (AC9)" "grep -qF 'confirm_flip_state \"\$ARM_ISO\"' '$ARM_FILE'"
+assert "arm) time-bounds via a SPACE-form timestamp, no ISO T/Z (the --since format P2)" "grep -qF \"+'%Y-%m-%d %H:%M:%S'\" '$ARM_FILE' && ! grep -qE 'ARM_ISO=.*T%H.*Z' '$ARM_FILE'"
+assert "arm) branches on the confirm result (done vs aborted/rolled-back vs timeout, fail-loud)" "grep -qF 'G6_STATE' '$ARM_FILE'"
+assert "arm) G3 pins the prod project-ref (stronger than a bare 'supabase' substring)" "grep -qF 'pigsfuxruiopinouvjwy' '$ARM_FILE'"
+assert "arm) G1 fail-CLOSED: probes config readability (DOPPLER_PROJECT) before trusting an empty flip" "grep -qF 'config-readability probe failed' '$ARM_FILE' && grep -qE 'doppler secrets get DOPPLER_PROJECT -p soleur-inngest' '$ARM_FILE'"
+assert "arm) G3 fail-CLOSED on an empty PG_DARK read (no silent equality-pass)" "grep -qF 'could not read the current dark INNGEST_POSTGRES_URI' '$ARM_FILE'"
+assert "arm) adds NO deploy-status poll (Better Stack read only — QMAX/RMAX untouched, AC9)" "! grep -qE 'deploy-status' '$ARM_FILE'"
+
+# AC13 no ssh in the arm block.
+assert "arm) contains no ssh (AC-NOSSH/AC13)" "! grep -qE '(^|[^[:alnum:]])ssh[[:space:]]' '$ARM_FILE'"
+
+# D5/C4 environment required-reviewer gate + C5 conditional token env (repo-level, not in the case body).
+assert "job gates op=arm/op=rollback on the inngest-cutover environment (D5/C4)" "grep -qE \"environment: .*inputs.op == 'arm'.*inputs.op == 'rollback'.*inngest-cutover\" '$WF'"
+assert "DOPPLER_TOKEN_INNGEST_ARM injected conditionally (empty for other ops — C5)" "grep -qE \"DOPPLER_TOKEN_INNGEST_ARM: .*inputs.op == 'arm'.*secrets.DOPPLER_TOKEN_INNGEST_ARM\" '$WF'"
+
+# D1/C1 — op=rollback owns the reverse flip write; op=arm stays FORWARD-ONLY.
+assert "rollback writes INNGEST_CUTOVER_FLIP=rollback via stdin to soleur-inngest/prd (D1/C1)" "grep -qE \"printf '%s' 'rollback'\" '$ROLLBACK_FILE' && grep -qE 'doppler secrets set INNGEST_CUTOVER_FLIP -p soleur-inngest -c prd' '$ROLLBACK_FILE'"
+assert "rollback G1' writes only when the forward flip is armed/progressed (armed/flipping/flushed/done)" "grep -qE 'armed\\|flipping\\|flushed\\|done' '$ROLLBACK_FILE'"
+assert "rollback calls the shared confirm BLOCKING before web re-enable" "grep -qF 'confirm_flip_state \"\$RB_ISO\"' '$ROLLBACK_FILE'"
+# ARCH P1 fix: Half (B) web re-enable runs UNCONDITIONALLY for a non-forward state (aborted/unset) —
+# the documented P0-3 recovery. Assert the rollback body reaches the web re-enable AND the non-forward
+# branch proceeds there (no exit 1 in that branch).
+assert "rollback reaches Half (B) web re-enable" "grep -qE 're-enabling inngest across host-set' '$ROLLBACK_FILE'"
+assert "rollback non-forward branch (aborted/unset) proceeds to Half B — P0-3 recovery, no exit 1" "grep -qF 'documented P0-3 aborted-state recovery; proceeding to the web re-enable' '$ROLLBACK_FILE'"
+assert "rollback withholds web re-enable on an unconfirmed rolled-back (no double-fire)" "grep -qF 'WITHHOLDING the web re-enable' '$ROLLBACK_FILE'"
+assert "rollback never re-writes POSTGRES_URI/HEARTBEAT (reverse writes ONLY the flip value)" "! grep -qE 'secrets set INNGEST_(POSTGRES_URI|HEARTBEAT_URL)' '$ROLLBACK_FILE'"
+assert "op=arm is FORWARD-ONLY: the arm block never writes the reverse flip 'rollback'" "! grep -qE \"printf '%s' 'rollback'\" '$ARM_FILE'"
+
+rm -f "$ARM_FILE" "$ROLLBACK_FILE" "$CONFIRM_FILE"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/apps/web-platform/infra/inngest-arm-write-token.tf
+++ b/apps/web-platform/infra/inngest-arm-write-token.tf
@@ -1,0 +1,89 @@
+# Closes #6369. Read/write Doppler service token for the no-SSH `op=arm`
+# (and the reverse `op=rollback` flip-write) in `.github/workflows/cutover-inngest.yml`.
+# op=arm performs the three arm-flip writes on `soleur-inngest/prd`
+# (INNGEST_POSTGRES_URI, INNGEST_HEARTBEAT_URL, then INNGEST_CUTOVER_FLIP=armed LAST)
+# that were previously an out-of-band operator hand-off in op=execute's SEAM
+# (cutover-inngest.yml:607-611). The two SOURCE values are read read-through from
+# `soleur/prd_terraform` via the workflow's EXISTING read-only DOPPLER_TOKEN (CTO
+# decision 2026-07-12 / ADR-100 Decision 6b — the prod DSN is already CI-readable there,
+# SHA-identical to canonical prd; no operator seed). This token is ONLY for the WRITES to
+# the isolated soleur-inngest project.
+#
+# Blast radius: `access = "read/write"` on `soleur-inngest/prd` ONLY. This project is
+# ISOLATED — a separate Doppler root-config project (inngest-host.tf:78-85), with no
+# config-inheritance path to `soleur/prd`. The write surface is the dedicated inngest host's boot creds +
+# the cutover-flip FSM state. IMPORTANT: once op=arm has run, this token is also a STANDING
+# READ handle to the ARMED PROD `INNGEST_POSTGRES_URI` it wrote into soleur-inngest/prd
+# (a session-pooler DSN granting direct read/write to the inngest Postgres). It MUST be
+# revoked post-cutover — see the runbook lifecycle step + Rotation below.
+#
+# Distinct from the READ-only host-boot token `doppler_service_token.inngest`
+# ("inngest-boot", inngest-host.tf:173-178): different name ("inngest-cutover-arm"),
+# access (read/write vs read), and consumer (CI vs the host cloud-init). This is the FIRST
+# CI-consumed read/write token into the isolated soleur-inngest project — prior tokens there
+# are read-only host-boot. CI can now WRITE soleur-inngest/prd (ADR-100 Decision 6b).
+#
+# By-reference project/config (NOT the soleur-inngest / prd string literals): this builds
+# the Terraform dependency edge onto doppler_project.inngest + doppler_environment.inngest_prd,
+# matching the read token's by-reference wiring (inngest-host.tf:174-175). Consequence: the
+# per-merge `-target` of this token is a STANDING transitive path onto the excluded project/env.
+# A teardown/re-provision of doppler_project.inngest must be OPERATOR-applied FIRST — else the
+# next per-merge CI apply recreates the isolated project unattended. (Precedent for the
+# transitive-edge concern: doppler_service_token.inngest, by-reference; NOT
+# doppler_service_token.write, which is a string-literal token with zero edges.)
+#
+# Rotation / revoke: `terraform apply -replace=doppler_service_token.inngest_arm_write` mints
+# a new key AND (because this file deliberately omits `lifecycle.ignore_changes =
+# [plaintext_value]` on the env secret below) propagates it to the consumer in the SAME apply.
+# The old key is orphaned but still valid — revoke it via `doppler configs tokens revoke`.
+# Post-cutover, `-replace` + revoke is the mechanism that closes the standing-read-handle
+# blast radius (runbook § Cutover — post-cutover token revoke).
+#
+# State storage: `.key` is Computed + Sensitive per the Doppler provider; the value lands in
+# the R2-backed encrypted `terraform.tfstate` on create and CANNOT be re-read from the Doppler
+# API (same posture as doppler_service_token.write / .inngest / .registry). State-loss recovery
+# is `-replace` (mints a new token, orphans the old one — revoke manually).
+#
+# Human ack (D5/C4): unlike doppler_service_token.write (a repo-wide github_actions_secret
+# readable by every workflow), this key is published as a GitHub ENVIRONMENT secret under the
+# `inngest-cutover` environment with a REQUIRED-REVIEWER protection rule. A workflow_dispatch is
+# only repo `actions:write` — weaker than the Doppler-console credentials the manual arm-write
+# required; the environment's required-reviewer gate restores that human ack. The op=arm /
+# op=rollback jobs declare `environment: inngest-cutover`, so the reviewer must approve the
+# dispatch before the token resolves. The dispatch + environment approval IS the ack; there is
+# no interactive pre-write value confirmation, by design (AC-NOBODY forbids echoing the values).
+#
+# autonomy-considered: provider-mint-applied (App auth + doppler_service_token + github env secret).
+
+resource "doppler_service_token" "inngest_arm_write" {
+  project = doppler_project.inngest.name         # by-reference (builds the dep edge; NOT a bare string literal)
+  config  = doppler_environment.inngest_prd.slug # by-reference (NOT "prd")
+  name    = "inngest-cutover-arm"                # distinct from the read token "inngest-boot"
+  access  = "read/write"
+}
+
+# GitHub Environment with a required-reviewer protection rule (D5/C4). The op=arm and
+# op=rollback jobs gate on `environment: inngest-cutover`; the reviewer (the operator) must
+# approve each dispatch before the environment secret below resolves. reviewers.users takes
+# numeric GitHub user IDs — 54279 = @deruelle (the operator/founder).
+resource "github_repository_environment" "inngest_cutover" {
+  repository  = "soleur"
+  environment = "inngest-cutover"
+
+  reviewers {
+    users = [54279]
+  }
+}
+
+# The write token published as an ENVIRONMENT secret (NOT a repo-wide github_actions_secret —
+# that would be readable by every workflow, defeating the required-reviewer scoping). Resolvable
+# ONLY to a job that declares `environment: inngest-cutover` and passed the reviewer gate.
+# NO lifecycle.ignore_changes → a `-replace` rotation of the token propagates the new key here in
+# the same apply (do NOT add ignore_changes = [plaintext_value]: it would strand the secret on
+# the old, soon-revoked key).
+resource "github_actions_environment_secret" "doppler_token_inngest_arm" {
+  repository      = "soleur"
+  environment     = github_repository_environment.inngest_cutover.environment
+  secret_name     = "DOPPLER_TOKEN_INNGEST_ARM"
+  plaintext_value = doppler_service_token.inngest_arm_write.key
+}

--- a/knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md
@@ -249,6 +249,61 @@ web→web:9000 firewall source-restricts to peer hosts (already proven live by t
 architecture. No C4 impact (the `deploy-webhook → ci-deploy → inngest-server` control edge already
 exists; `quiesce`/`enable` are additional verbs on the SAME edge, not a new relationship).
 
+### Amendment (2026-07-12, Ref #6369) — Decision 6b: no-SSH `op=arm` arm-flip + reverse write
+
+The Phase-2 cutover's **arm-flip** (the three writes to `soleur-inngest/prd`:
+`INNGEST_POSTGRES_URI`, `INNGEST_HEARTBEAT_URL`, then `INNGEST_CUTOVER_FLIP=armed` last — the last
+was the operator SEAM at `cutover-inngest.yml`) is now performed **no-SSH** by
+`cutover-inngest.yml op=arm`, and the reverse `INNGEST_CUTOVER_FLIP=rollback` write is folded into
+the existing `op=rollback` verb. This removes the last operator secret-write seam from the cutover.
+
+- **Trust / ack (reconciles `hr-menu-option-ack-not-prod-write-auth`).** `op=arm`/`op=rollback` are
+  prod-writes behind an **explicit dispatch** (same trust model as `op=quiesce-web`/`op=rollback`)
+  **plus** a GitHub **Environment** (`inngest-cutover`) required-reviewer protection rule. The
+  dispatch + the reviewer approval IS the explicit per-command go-ahead the hard rule requires; the
+  rule kept the flip out of `op=execute`'s *auto-run* spine, not out of a separately-dispatched,
+  human-approved verb. There is **no interactive pre-write value confirmation, by design** —
+  AC-NOBODY forbids echoing the values.
+- **Provisioning (reconciles `hr-all-infrastructure-provisioning`).** The write **token** is
+  TF-provisioned (`doppler_service_token.inngest_arm_write`, read/write on the isolated
+  `soleur-inngest/prd`, published as the `inngest-cutover` **environment** secret
+  `DOPPLER_TOKEN_INNGEST_ARM`). This is the **first CI-consumed read/write token into the isolated
+  `soleur-inngest` project** — prior tokens there are read-only host-boot (`inngest-host.tf:173`);
+  CI can now WRITE `soleur-inngest/prd`. The token is a **standing read handle to the armed prod
+  DSN** once op=arm runs, so it is revoked post-cutover.
+- **Source-of-truth: read-through, no seed (CTO decision at /work).** The two source *values*
+  remain out-of-band (they are not TF `doppler_secret` resources — dark-window heartbeat masking +
+  a DB password TF never minted, `inngest-host.tf:137-166`). op=arm reads them **read-through from
+  `soleur/prd_terraform`** via the workflow's existing read-only `DOPPLER_TOKEN` (the same
+  config-scoped read `op=backup` uses for `HCLOUD_TOKEN`). The prod `INNGEST_POSTGRES_URI` already
+  lives in `prd_terraform` (SHA-identical to canonical `prd`, `:5432` session pooler, distinct from
+  the dark value), so there is **no operator secret-seed step and no stale-copy rotation-drift
+  trap**. Reading the live canonical source at arm-time makes freshness *structural*; the G3
+  positive prod-URI assertion (prod ≠ dark, `:5432` not `:6543`, prod host) + the G1 pre-write
+  FSM-state guard remain the defense against writing a wrong/dark value. **Rejected:** (A) seed a
+  narrow `INNGEST_POSTGRES_URI_PROD` config — removes no existing exposure (the value is already
+  CI-readable) while adding a forbidden human pre-window seed + a drift trap that could arm a dead
+  DSN and stall every user's crons; (B) a workflow step copying `prd_terraform`→narrow — machinery
+  to relocate an already-readable value, inheriting (A)'s drift risk.
+
+**Post-cutover revoke.**
+<!-- lint-infra-ignore start -->
+After `op=verify` confirms exactly-once (AC17), the write token is rotated + revoked
+(`terraform apply -replace=doppler_service_token.inngest_arm_write` + `doppler configs tokens
+revoke` the orphaned key) so no standing prod-DSN read handle survives (runbook § Rollback / Op
+order 3b).
+<!-- lint-infra-ignore end -->
+
+**No C4 change (enumeration).** op=arm is a new *instance* of an already-modeled relationship, not a
+new one: `doppler` (system), `betterstack` (system), `github`, `inngest`/`inngestPostgres`/
+`inngestRedis` (containers/stores) are all in `model.c4`; the CI/TF→Doppler secret-**write**
+relationship already exists at the C4 altitude (TF applies writes to Doppler via
+`doppler_service_token.write`; the precedent write edge is `inngest -> doppler "Writes GHCR_READ_TOKEN"`,
+`model.c4:404` — a Doppler-write edge, distinct from the `doppler -> inngest "Injects secrets"`
+injection edge). op=arm writing `soleur-inngest/prd` is another edge of the same write relationship
+type, not a new relationship — so no `model.c4`/`views.c4` edit. No new ADR ordinal
+— this is an extension of ADR-100's Decision 6, mirroring the Ref #6178 amendment above.
+
 ## Consequences
 
 **Easier:** active-active web becomes structurally safe (web-2 poolable at 4.2); inngest failure

--- a/knowledge-base/engineering/operations/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/operations/runbooks/inngest-server.md
@@ -546,11 +546,14 @@ FSM flag (`INNGEST_CUTOVER_FLIP`) is the sole gate, so arming is pure Doppler wr
 
 ### Op order (the gated sequence)
 
-`op=execute` → **operator arms the flip (Doppler) + app-repoint** → `op=rearm` → `op=verify`.
-`op=execute` automates the web-host-expressible spine (2.0 → 2.2) and then **withholds a
-SEAM** — the two operator seams (the Doppler flip arm 2.2b+2.3, and the app-repoint 2.4)
-cannot be done from CI (`hr-menu-option-ack-not-prod-write-auth`) and are printed as an
-out-of-band hand-off.
+`op=execute` → **`op=arm` (no-SSH flip arm)** → **operator app-repoint (2.4)** → `op=rearm` →
+`op=verify`. `op=execute` automates the web-host-expressible spine (2.0 → 2.2) and then
+**withholds a SEAM**. As of #6369 the flip arm (2.2b/2.3) is **no longer an operator Doppler
+write** — it is the no-SSH **`op=arm`** dispatch (a prod-write behind explicit dispatch + the
+`inngest-cutover` GitHub Environment required-reviewer gate, which satisfies
+`hr-menu-option-ack-not-prod-write-auth`: the dispatch + approval IS the ack). The remaining true
+operator seams are **2.2a** (web-2 freeze/recreate lifecycle) and **2.4** (app-repoint, a code
+merge) — both printed in the SEAM as an out-of-band hand-off.
 
 > **`op=quiesce-web` (#6178) — the no-SSH remediation when the 2.2 gate reports STILL
 > RUNNING.** The `op=execute` 2.2 gate only CHECKS (inventory non-200 = quiesced); it has no
@@ -630,36 +633,70 @@ out-of-band hand-off.
    step 2 until web-2 is recreated. Tracks #6227 (real per-host web→web fan-out to auto-verify
    web-2).
 
-2. **Arm the flip (2.2b+2.3)** — three out-of-band Doppler writes on the **`soleur-inngest/prd`**
-   project (these carry `ignore_changes[value]`, so they are never TF-minted). The enabled 30s
-   poll timer picks up `armed` and runs the forward FSM path
-   **stop → `FLUSHALL` → assert `DBSIZE==0` → start → `done`**:
+2. **Arm the flip (2.2b/2.3) — dispatch the no-SSH `op=arm` verb (#6369).** This REPLACES the
+   former three manual Doppler writes. `op=arm` performs all three writes on
+   **`soleur-inngest/prd`** itself and confirms the on-host FSM reached `done` via Better Stack,
+   with **no secret value ever echoed** (AC-NOBODY):
    ```bash
-   doppler secrets set INNGEST_POSTGRES_URI=<prod-postgres-uri>                       --project soleur-inngest --config prd --no-interactive
-   doppler secrets set INNGEST_HEARTBEAT_URL=<betteruptime inngest_prd heartbeat url> --project soleur-inngest --config prd --no-interactive
-   doppler secrets set INNGEST_CUTOVER_FLIP=armed                                     --project soleur-inngest --config prd --no-interactive
+   gh workflow run cutover-inngest.yml --field op=arm
    ```
-   (Substitute the real prod URI + heartbeat URL at the terminal — do not paste them into any
-   log, PR, or run output; AC-NOBODY.)
+   Then **approve the `inngest-cutover` GitHub Environment required-reviewer gate** on the run —
+   that approval IS the prod-write ack (`hr-menu-option-ack-not-prod-write-auth`; the dispatch +
+   approval replace the old Doppler-console write). What `op=arm` does, in order:
+   - **G1 pre-write FSM-state guard (DI-C2):** refuses to arm over a non-safe
+     `INNGEST_CUTOVER_FLIP` state (armed/flipping/flushed/done) — a second arm would re-`FLUSHALL`
+     the now-PROD Redis and wipe the live cron queue.
+   - **G2 read-through sources (ADR-100 6b):** reads `INNGEST_POSTGRES_URI` +
+     `INNGEST_HEARTBEAT_URL` **from `prd_terraform`** via the existing read-only `DOPPLER_TOKEN`
+     (the canonical prod values already live there — **no operator seed**), masking each value.
+   - **G3 positive prod-URI assertion (DI-C3):** asserts the value differs from the current dark
+     `soleur-inngest/prd` URI, uses the `:5432` session pooler (never `:6543`), and targets the
+     prod host — all value-silent.
+   - **G4/G5 writes:** `INNGEST_POSTGRES_URI` → `INNGEST_HEARTBEAT_URL` → `INNGEST_CUTOVER_FLIP`
+     set to `armed` (last), each via **stdin** (never argv), exit-gated. The enabled 30s poll
+     timer then drives the forward FSM **stop → `FLUSHALL` → assert `DBSIZE==0` → start → `done`**.
+   - **G6 confirm:** polls Better Stack for the `logger -t inngest-cutover-flip` line, time-bounded
+     to the arm moment (so a stale prior terminal line cannot false-succeed), requiring `"flag":"done"`
+     / `"exit_code":0` (the FSM state lives in the `flag` field; `reason` is a cause string like
+     `flip-complete`); it FAILS LOUD on `aborted`/`rolled-back`/timeout (**do NOT proceed to 2.4**
+     in that case — see aborted-state recovery below).
 
-3. **Confirm the flip via Better Stack (P0-2 — NOT a host read).** The oneshot emits its
-   verify-state as a `logger -t inngest-cutover-flip` JSON line; the on-host Vector→Better Stack
-   journald shipper (source `soleur-inngest-vector-prd`) carries it off-box. Pull it
-   (`hr-no-dashboard-eyeball-pull-data-yourself`):
+   > **No operator secret-seed (#6369 / ADR-100 Decision 6b).** The prod `INNGEST_POSTGRES_URI`
+   > already lives in `prd_terraform` (canonical, `:5432`, distinct from the dark value), so op=arm
+   > reads it **read-through** — there is **no `INNGEST_POSTGRES_URI_PROD` seed and no pre-window
+   > human write**. The only new credential is the TF-provisioned read/write token
+   > (`doppler_service_token.inngest_arm_write`) published as the `inngest-cutover` **environment**
+   > secret `DOPPLER_TOKEN_INNGEST_ARM` (required-reviewer gated).
+
+3. **Independent confirm / troubleshooting (optional — op=arm already gates on this).** op=arm
+   only exits 0 after Better Stack shows the FSM `done`. To re-read the line yourself
+   (`hr-no-dashboard-eyeball-pull-data-yourself`), or if op=arm failed loud at G6:
    ```bash
    doppler run -p soleur -c prd_terraform -- \
      scripts/betterstack-query.sh --since 30m --grep inngest-cutover-flip --raw-only --limit 20
    ```
-   Require `"exit_code":0` (with `"reason":"done"`) in the emitted line before proceeding. Do
-   **NOT** `ssh`/`cat` the deny-all-public host to read state — `cat-inngest-cutover-state.sh`
-   exists on-host as a **debug aid only**, never the operator gate. A clean flip surfaces the
-   `"reason":"done"` line within a single 30s poll of arming the flag (the timer fires the
-   oneshot every 30s), so a `--since 30m` query captures it promptly. A `"exit_code":1` /
-   `"reason":"dbsize-nonzero"` line means the DBSIZE gate tripped, and a
-   `"reason":"unexpected-exit(...)"` line means a flag-write/systemctl failure drove the flag
-   to terminal `aborted` (the ERR-trap loud-fail) → either way see **aborted-state recovery**
-   below. (These tags are on the `vector.toml` Source 4 allowlist — see the
-   `vector-pii-scrub.test.sh` drift-guard — so they are guaranteed to ship off-box.)
+   A clean flip surfaces a `"flag":"done"` line (with `"reason":"flip-complete"`) within a single 30s poll of arming. A
+   `"reason":"dbsize-nonzero"` line means the DBSIZE gate tripped; a `"reason":"unexpected-exit(...)"`
+   line means a flag-write/systemctl failure drove the flag to terminal `aborted` (the ERR-trap
+   loud-fail) → either way see **aborted-state recovery** below. Do **NOT** `ssh`/`cat` the
+   deny-all-public host to read state — `cat-inngest-cutover-state.sh` exists on-host as a **debug
+   aid only**, never the operator gate. (These tags are on the `vector.toml` Source 4 allowlist —
+   see the `vector-pii-scrub.test.sh` drift-guard — so they are guaranteed to ship off-box.)
+
+3b. **Post-cutover: revoke the arm-write token (#6369, security F4/D6 — after AC17).** Once
+   `op=verify` confirms exactly-once on the dedicated host, `DOPPLER_TOKEN_INNGEST_ARM` is a
+   **standing read+write handle to the now-armed prod `INNGEST_POSTGRES_URI`** on
+   `soleur-inngest/prd`. Rotate + revoke it (no-SSH); there is **no seed to delete** (reads are
+   read-through):
+   ```bash
+   # (a) mint a fresh key + orphan the old one (propagates to the env secret in the same apply):
+   doppler run -p soleur -c prd_terraform --name-transformer tf-var -- \
+     terraform -chdir=apps/web-platform/infra apply -replace=doppler_service_token.inngest_arm_write
+   # (b) revoke the orphaned key so no standing prod-DSN read handle survives:
+   doppler configs tokens revoke --project soleur-inngest --config prd --slug <orphaned-token-slug> --yes
+   ```
+   The next per-merge apply keeps a fresh `inngest-cutover` env secret available for a future
+   cutover; the required-reviewer gate means it cannot be used without an approved dispatch.
 
 4. **App-repoint (2.4).** Merge the `ci-deploy.sh` `INNGEST_BASE_URL` → `http://10.0.1.40:8288`
    change (both the canary and prod sites) and redeploy the web app so the functions re-sync
@@ -717,28 +754,36 @@ empty the dark registry and re-run (all no-SSH):
 
 ### Rollback sequence (P1-13) — mirrors the forward gate, stop the dedicated host FIRST
 
-1. **Stop the dedicated scheduler** — one Doppler write; the still-enabled timer stops
-   `inngest-server` on its next poll:
+1. **Dispatch `op=rollback` (no-SSH — it now does BOTH halves, #6369).** As of #6369 `op=rollback`
+   first writes `INNGEST_CUTOVER_FLIP=rollback` on `soleur-inngest/prd` itself (the still-enabled
+   timer then stops `inngest-server` on its next poll), confirms `"flag":"rolled-back"` /
+   `"exit_code":0` via Better Stack (time-bounded), and THEN runs the web re-enable fan-out
+   (step 3 below) **only after that confirm** — so the dedicated scheduler is proven stopped before
+   the web schedulers come back (no two-live-scheduler double-fire; on an unconfirmed rolled-back it
+   fails loud and withholds the web re-enable). Half (A) writes `rollback` when the forward flip is
+   armed or progressing (`armed`/`flipping`/`flushed`/`done`), behind the same `inngest-cutover`
+   environment required-reviewer gate; it writes ONLY the flip value (never re-writes
+   POSTGRES_URI/HEARTBEAT). For a non-forward state (`aborted`/`unset`) there is nothing to reverse
+   and it proceeds straight to the web re-enable (the documented aborted-state / P0-3 recovery):
    ```bash
-   doppler secrets set INNGEST_CUTOVER_FLIP=rollback --project soleur-inngest --config prd --no-interactive
+   gh workflow run cutover-inngest.yml --field op=rollback   # then APPROVE the inngest-cutover environment gate
    ```
-   Confirm `"reason":"rolled-back"` / `"exit_code":0` via the same Better Stack query as step 3.
+   There is **no separate operator Doppler write** — the dedicated-host stop is now folded into
+   this single dispatch.
 2. **Repoint the app back to loopback** — revert the `ci-deploy.sh` `INNGEST_BASE_URL` change
    (back to the loopback `host.docker.internal:8288`) and redeploy.
 
 <!-- lint-infra-ignore start -->
 
-3. **Re-enable web inngest** — run the authored reverse-op. `op=rollback` issues a SINGLE
-   no-SSH `enable inngest _ _` fan-out (enable + start + verify-serving-and-enabled in ONE
+3. **Re-enable web inngest — Half (B) of the SAME `op=rollback` dispatch from step 1** (it runs
+   automatically after the `rolled-back` confirm; no second dispatch needed). `op=rollback` issues
+   a SINGLE no-SSH `enable inngest _ _` fan-out (enable + start + verify-serving-and-enabled in ONE
    flock-held ci-deploy.sh handler, #6178) across the `$CUTOVER_HOSTS` set, then POLLS
    `/hooks/deploy-status` for the terminal `reason=enabled` verdict. The `enable` verb restores
    the `[Install]` symlink the 2.2 disable removed (a `restart` never touches it) so the web
    scheduler survives a reboot — **no operator `systemctl` step is needed** (this is the no-SSH
    reverse of `op=quiesce-web`; there is deliberately no two-POST enable+restart, which would
-   race the `flock -n` and could leave the unit enabled-but-stopped reported as success):
-   ```bash
-   gh workflow run cutover-inngest.yml --field op=rollback
-   ```
+   race the `flock -n` and could leave the unit enabled-but-stopped reported as success).
    web-2 is re-enabled by the fan-out but its verdict is acceptance-only (DI-C3) — confirm web-2
    via its freeze/recreate lifecycle. On `inngest_enable_failed` / `inngest_start_failed` /
    `inngest_reenable_unverified` / `enabled_peer_fanout_unaccepted`, pull `reason=` from

--- a/knowledge-base/project/learnings/best-practices/2026-07-12-dry-run-fixture-must-derive-from-producer-source-not-fabricated-format.md
+++ b/knowledge-base/project/learnings/best-practices/2026-07-12-dry-run-fixture-must-derive-from-producer-source-not-fabricated-format.md
@@ -1,0 +1,111 @@
+---
+title: "A dry-run that validates a parser against a FABRICATED fixture confirms your assumption, not the format"
+date: 2026-07-12
+category: best-practices
+tags: [dry-run, external-format, parser, verification, review, observability, workflow]
+issue: 6369
+component: cutover-inngest-workflow
+---
+
+# Learning: dry-run fixtures for an external-format parser must be derived from the PRODUCER's source, not fabricated
+
+## Problem
+
+Building `op=arm` (#6369), the G6 step confirms the on-host flip FSM reached `done` by querying
+Better Stack for a `logger -t inngest-cutover-flip` JSON line and grepping it. I wrote the grep
+from the plan's `## Observability` **prose** (`reason:done exit_code:0`) → `grep '"reason":"done"'`.
+
+At Phase 5 (dry-run validation) I "validated" the parse — but I constructed the test fixture MYSELF
+from the same wrong assumption:
+
+```bash
+SYNTH_DONE='{"dt":"...","raw":"...{\"reason\":\"done\",\"exit_code\":0,...}"}'   # FABRICATED
+# my parse grepped "reason":"done"  → matched  → "DONE -> CONFIRM-done"  ✓ (falsely reassuring)
+```
+
+The dry-run passed because the fixture and the parser shared the same fabricated shape. It proved
+the parser matches my invented format — **not** that it matches what the host actually emits.
+
+The real emitter (`apps/web-platform/infra/inngest-cutover-flip.sh`, `emit_state exit_code dbsize
+reason flag`) puts the **terminal state in the `flag` field** and a *cause* in `reason`:
+`{"exit_code":0,"reason":"flip-complete","flag":"done",...}`. `"reason":"done"` is emitted by NO
+code path. So the shipped G6 would have `grep '"reason":"done"'` → **never match → op=arm times out
+after 600s and reports EVERY successful cutover as FAILED** (a single-user incident: the operator
+then halts crons for all users, or rolls back a good flip). Two independent review agents
+(data-integrity-guardian, pattern-recognition-specialist) caught it by reading the actual emitter.
+
+## Solution
+
+- Rewrote the confirm to key on the emitter's real field: `"flag":"done"` + `"exit_code":0`
+  (and `"flag":"aborted"|"flag":"rolled-back"` for the fail-loud path), extracted into a shared
+  `confirm_flip_state()` used by both op=arm and op=rollback.
+- **Re-validated against a fixture reconstructed from the emitter's `emit_state` call sites**
+  (`flag:done reason:flip-complete`, `flag:aborted reason:dbsize-nonzero`, `flag:flipping` non-terminal):
+  DONE→done, ABORT→aborted, RB→rolled-back, FLIPPING→keep-polling. This is the fixture that would
+  have caught the bug at dry-run time.
+- Added a drift-guard **parity assertion** that the workflow greps `"flag":"done"` (NOT
+  `"reason":"done"`) AND the emitter actually stamps `flag_set "done"` — so the two files can't
+  silently drift again.
+
+## Key Insight
+
+**A dry-run that exercises a parser against a fixture you authored from the same mental model as the
+parser is circular — it validates the assumption, not the wire format.** For any parser of an
+EXTERNAL producer's output (another script's `logger` line, a vendor API JSON, a CLI's stdout, a
+webhook payload), the fixture MUST be derived from the producer's source of truth:
+
+1. Read the producer's emit site(s) and copy the literal field names/shape, OR
+2. Capture one real sample from the producer and assert against those bytes.
+
+Litmus: *"If my parser's field assumption is wrong, does this fixture still pass?"* If yes, the
+fixture is fabricated-from-the-same-assumption and proves nothing. This is the dry-run cousin of the
+review-catalogue entry "external-API-shape AC must land a captured fixture, not a probed claim"
+([[2026-06-16-external-api-shape-ac-must-land-captured-fixture-not-probed-claim]]) — and of the
+plan-precondition rule that plan PROSE about a format is a claim to verify against source, never a fact.
+
+## Companion insights (same session, #6369)
+
+- **Folding a conditional into a previously-UNCONDITIONAL path silently narrows it.** `op=rollback`
+  had an unconditional Half B (web re-enable = the documented P0-3 aborted-state recovery). Folding a
+  new `flip-state` guard (Half A) in front of it gated the WHOLE job, so `aborted`/`unset` hit
+  `exit 1` and Half B never ran → crons stay stalled. When wrapping a new conditional around an
+  existing verb, verify the pre-existing behavior still runs for EVERY state; scope the new guard to
+  ONLY the new action. (Same class as "short-circuit guard must sit after the recovery it gates.")
+- **A fail-CLOSED guard fed by a fail-OPEN read is fail-open.** `CUR_FLIP=$(doppler get ... || true)`
+  collapses a read/API error to empty, which the `${x:-unset}` default routes to the SAFE branch —
+  so the guard evaporates exactly when the read fails. Distinguish "genuinely absent" from "read
+  failed": probe a known-present key first (here `DOPPLER_PROJECT`) and fail closed if THAT read
+  fails. Same shape defeated G3's `PG != PG_DARK` when `PG_DARK` read empty.
+- **A CLI flag's accepted input format is a claim to verify against the tool's parser.** Passed an
+  ISO `T…Z` timestamp to `betterstack-query.sh --since`, whose regex only accepts `Nh/Nm/Nd` or a
+  literal `YYYY-MM-DD HH:MM:SS` (ClickHouse cast) — the ISO form falls through and can error the
+  query → 600s timeout. Read the tool's `--since` parser (`^([0-9]+)([hmd])$`) before choosing the
+  format. (Same class as `hr-when-a-plan-specifies-relative-paths` / plan-quoted-tool-flag-value.)
+
+## Session Errors
+
+1. **G6 keyed on `reason` not `flag`; dry-run validated a fabricated fixture.** Recovery: rewrote to
+   `flag`, re-validated against an emitter-derived fixture + added a parity assertion. **Prevention:**
+   derive external-format dry-run fixtures from the producer's source; add a producer↔consumer parity
+   test. (This learning + a routed Sharp Edge to the work skill Phase 5.)
+2. **op=rollback G1' gated the whole job → broke P0-3 recovery.** Recovery: Half B unconditional; new
+   guard scoped to the reverse-write only. **Prevention:** when folding a conditional into an existing
+   verb, assert the pre-existing unconditional path still runs for all states.
+3. **G1 + G3 fail-OPEN on read error (`|| true`).** Recovery: config-readability probe + empty-check
+   fail-closed. **Prevention:** never let a fail-closed guard consume a swallowed read as a safe value.
+4. **ISO `--since` format rejected by the query tool.** Recovery: space-form timestamp. **Prevention:**
+   verify a CLI's accepted input format against its parser before use.
+5. **Drift-guard assertion matched its own comment prose** (`jq .`). Recovery: reworded the comment.
+   **Prevention:** anchor body-greps on syntactic constructs, not bare tokens the file also documents
+   (known class: grep-over-body-false-match). One-off (self-caught at test time).
+6. **Bash CWD persisted across calls** — an early `cd` into a sibling worktree confused the bare-repo
+   probe. Recovery: explicit `cd <abs>` per command. **Prevention:** the Bash tool keeps CWD; always
+   chain `cd <abs-path> && <cmd>`. One-off (self-caught).
+
+## Prevention
+
+- Dry-run/verification fixtures for any external producer's format: reconstruct from the emit site or
+  a captured real sample; add a producer↔consumer parity assertion so the two can't drift.
+- New conditional in front of an existing unconditional step: prove the old behavior survives for
+  every input state.
+- Fail-closed guard: guard the READ, not just the decision.

--- a/knowledge-base/project/plans/2026-07-12-feat-inngest-op-arm-no-ssh-doppler-arm-flip-plan.md
+++ b/knowledge-base/project/plans/2026-07-12-feat-inngest-op-arm-no-ssh-doppler-arm-flip-plan.md
@@ -1,0 +1,404 @@
+---
+title: "feat(infra): no-SSH op=arm for the inngest cutover Doppler arm-flip (#6369)"
+date: 2026-07-12
+type: feat
+issue: 6369
+parent: 6178
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+status: draft
+---
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+<!-- Phase 2.8 reviewed: terraform-architect invoked; the write TOKEN is TF-provisioned
+     (doppler_service_token.inngest_arm_write, see ## Infrastructure (IaC)). The three arm-flip
+     VALUES are out-of-band by ADR-100 Decision 6a + inngest-host.tf:137-166 doctrine — they
+     CANNOT be doppler_secret Terraform resources (dark-window heartbeat masking; a DB password
+     TF never minted; the FSM must fire at the maintenance window, not at apply). op=arm writes
+     them via the TF-provisioned token at the window. This is the sanctioned no-SSH verb, not a
+     manual-provisioning dodge. The `doppler secrets set` literals below describe that verb + the
+     one-time source seed, both reviewed under Phase 2.8. -->
+
+# feat(infra): no-SSH `op=arm` for the inngest cutover Doppler arm-flip (#6369)
+
+## Overview
+
+The #6178 dedicated-host inngest cutover is now no-SSH for every host *mutation* (deploy/restart; and, as of #6368, quiesce/enable via `op=quiesce-web` / `op=rollback`). The last operator seam is the **2.2b/2.3 Doppler arm-flip**: three secret writes to `soleur-inngest/prd` that arm the cutover flip FSM. Today `op=execute` only **prints** these as an out-of-band operator hand-off (`.github/workflows/cutover-inngest.yml:607-611`), and the runbook's "Op order" carries them as a manual `doppler`-write SEAM.
+
+This plan builds **`op=arm`**: a new `workflow_dispatch` verb in `cutover-inngest.yml` that performs the three writes no-SSH, using a **Terraform-provisioned read/write Doppler service token** scoped to the isolated `soleur-inngest/prd` project, **never logging any value** (AC-NOBODY), then confirms the on-host FSM reached `done` via Better Stack. It removes the last operator secret-write seam from the cutover.
+
+The three writes, in mandatory order (LAST = FSM trigger), mirroring `cutover-inngest.yml:608-610`:
+
+1. `INNGEST_POSTGRES_URI` — prod session-pooler DSN (`:5432`, never `:6543` — breaks inngest's sqlc prepared statements, `inngest-host.tf:157`)
+2. `INNGEST_HEARTBEAT_URL` — `betteruptime_heartbeat.inngest_prd.url`
+3. `INNGEST_CUTOVER_FLIP=armed` — literal, written **last** (the enabled 30s on-host `.timer` picks it up and drives the FSM `armed → flipping → flushed → done`; ADR-100 Decision 6a)
+
+**Trust model (the reconciliation).** `op=arm` is a **prod-write behind explicit operator dispatch** — the identical trust model already established by `op=quiesce-web` (`cutover-inngest.yml:618-728`, comment `:624`: *"a prod-write behind explicit dispatch (same trust model as op=rollback)"*) and `op=rollback`. A manual `gh workflow run cutover-inngest.yml --field op=arm` IS the "explicit per-command go-ahead" that `hr-menu-option-ack-not-prod-write-auth` requires; the hard rule kept the flip out of `op=execute`'s *auto-run* spine, not out of a separately-dispatched no-SSH verb. This plan makes that reconciliation explicit in an ADR-100 amendment (§Architecture Decision).
+
+**Second deliverable — "run the full #6178 cutover end-to-end."** With `op=arm` landed, every *secret-write* and *host-mutation* step of the cutover is no-SSH. The final phase assembles the now-fully-automated end-to-end op order into the runbook and validates it with a **dry-run** (registry/inventory reads + a staged FSM confirmation against the dark host), so the operator can drive the live cutover as a single ordered dispatch sequence. The **live prod cutover execution itself is operator-gated** (maintenance window, single-user-incident blast radius) and is NOT an autonomous `/work` step — see §Non-Goals for the two remaining non-#6369 seams (web-2 lifecycle 2.2a; app-repoint 2.4).
+
+## Premise Validation (Phase 0.6)
+
+- **#6369** — OPEN, labelled `deferred-scope-out`; the scope-out was filed by #6368 (host-mutation gap only) with re-eval captured in `knowledge-base/project/learnings/integration-issues/no-ssh-cutover-verb-by-verb-audit-inngest-quiesce-20260712.md` (insight #4). Premise holds — build now.
+- **#6178** — OPEN, the umbrella cutover; this is the direct parent. Holds.
+- **#6368** — MERGED (`compliance/critical`), the direct precedent: `op=quiesce-web` + `op=rollback`. The op-block structure, HMAC+CF-Access auth, `::add-mask::`, and the "prod-write behind explicit dispatch" trust model are all reused verbatim. Holds.
+- **ADR-100** — status `adopting` (amendable). Decision 6a fixes the flip FSM (`armed → flipping → flushed → done`, terminal `aborted`). op=arm is the writer of `armed`; this plan amends ADR-100, not a new ADR (avoids an ordinal collision; same architectural surface).
+- **Mechanism vs. ADR corpus** — the "CI writes the arm-flip secrets" mechanism is NOT in an ADR rejected-alternatives table; ADR-100 Decision 6a's rejected alternatives concern the *on-host flip mechanism* (webhook vs oneshot), not *who writes the arm secret*. The out-of-band doctrine (`inngest-host.tf:137-166`) explains why the 3 values are NOT TF `doppler_secret` resources — op=arm honours that doctrine (it writes them at the window, not at apply). No stale premise.
+
+No spec.md exists for this branch (one-shot path); `lane: cross-domain` (infra + workflow + IaC + docs). This plan is the source of truth.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from #6369 / task) | Codebase reality | Plan response |
+|---|---|---|
+| "TF write-token to soleur-inngest/prd" | `soleur-inngest` is a **TF-managed separate Doppler project** (`doppler_project.inngest`, `inngest-host.tf:91`); an existing **read-only** token `doppler_service_token.inngest` ("inngest-boot") already lives there (`:173-178`). Precedent for a read/**write** token: `doppler-write-token.tf` (`doppler_service_token.write` + `github_actions_secret.doppler_token_write`). | New `doppler_service_token.inngest_arm_write` (read/write, by-reference project/config) + `github_actions_secret.doppler_token_inngest_arm`. Wire by resource reference, not literal (`2026-07-08-doppler-secret-precedent-mirror` learning). |
+| "writing INNGEST_POSTGRES_URI / INNGEST_HEARTBEAT_URL / INNGEST_CUTOVER_FLIP=armed" | These 3 are the exact operator-printed SEAM writes (`cutover-inngest.yml:608-610`); all target `soleur-inngest/prd`. `INNGEST_HEARTBEAT_URL = betteruptime_heartbeat.inngest_prd.url` (also `output "inngest_heartbeat_url"`, `outputs.tf:26`; and `doppler_secret.inngest_heartbeat_url_prd` in **soleur/prd**, `inngest.tf:345`). `INNGEST_POSTGRES_URI` embeds a Supabase DB password TF **never** minted (`inngest-host.tf:153-158`). | op=arm reads the two *source* values (masked) and writes all three via the write token, `armed` last. HEARTBEAT_URL sourced TF-managed; POSTGRES_URI sourced from a **one-time operator-seeded** read-secret (§IaC Q3). |
+| "never logging them (AC-NOBODY)" | `op=execute`'s SEAM already asserts AC-NOBODY: *"no secrets / bodies / connection strings are echoed"* (`:604`). `::add-mask::` is the GH primitive. | Every value `::add-mask::`'d before use; the write CLI fed via **stdin, never argv** (`inngest-host.tf:166`); `--plain` read output masked on capture; no value echo. A test asserts no value-echo. |
+| "then run the full #6178 cutover end-to-end" | The cutover is operator-triggered (`cutover-inngest.yml:11`, ADR-100); live execution has single-user blast radius. Remaining non-#6369 seams: 2.2a web-2 lifecycle (`:606`), 2.4 app-repoint (`:612`). | Assemble + dry-run-validate the end-to-end runbook; live prod execution stays operator-gated (§Non-Goals). |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** the inngest cron scheduler mis-armed at cutover — either the FSM fires against a stale/missing `INNGEST_POSTGRES_URI` (a broken or `:6543` DSN silently breaks sqlc → the singleton scheduler dies) or a wrong-order write arms the flip before the URIs land. The dedicated host is the **sole** scheduler (ADR-100), so **every user's** async workflows stall: email-triage, workspace-reconcile-on-push, reminders, one-shot crons. A `DBSIZE!=0` abort or a silent mis-write surfaces only at the next cron that never fires.
+
+**If this leaks, the user's data is exposed via:** the write token (read/write on `soleur-inngest/prd`) or the `INNGEST_POSTGRES_URI` value appearing in a run log → a session-pooler DSN grants direct read/write to the inngest Postgres (config + run history + email-triage claim/finalize rows). AC-NOBODY + `::add-mask::` + stdin-never-argv are the load-bearing controls; the token's blast radius is bounded to the isolated `soleur-inngest` project (no config-inheritance path to `soleur/prd` — `inngest-host.tf:78-85`).
+
+**Brand-survival threshold:** `single-user incident` → `requires_cpo_signoff: true`. CPO sign-off required at plan time before `/work`; `user-impact-reviewer` runs at review time; `security-sentinel` + `data-integrity-guardian` at deepen-plan (single-user-incident threshold).
+
+## Downtime & Cutover
+
+**op=arm itself induces NO downtime** — it writes three Doppler secrets and reads Better Stack. It changes no host, takes no DB lock, restarts no router; the new `.tf` resource is a `doppler_service_token` (no reboot/replace on any `hcloud_server`). The deepen-plan Phase 4.55 downtime-trigger set does not fire on this plan's Files-to-Edit.
+
+<!-- lint-infra-ignore start -->
+**The cutover's brief scheduler restart is owned by ADR-100 Decision 6a, not introduced here.** Writing `INNGEST_CUTOVER_FLIP=armed` causes the on-host `.timer`/oneshot FSM to `stop → FLUSHALL → assert DBSIZE==0 → flushed → start` the singleton inngest scheduler — a bounded, gated transient (seconds), executed only inside the operator maintenance window.
+<!-- lint-infra-ignore end --> This plan does not change that downtime profile; it only replaces the *manual* arm-write with a no-SSH verb. The zero-downtime evaluation for the cutover proper (dark-host-provisioned-first, drain via quiesce, then flip) already lives in ADR-100 + the runbook. Residual transient is accepted with operator sign-off inside the window (single-user-incident; see §User-Brand Impact).
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify, no code)
+1. **Doppler read-path verification (terraform-architect flagged assumption #1).** Confirm which config the workflow's existing `DOPPLER_TOKEN` (prd_terraform-scoped, `cutover-inngest.yml:69`) can READ the two source values from: `doppler secrets get INNGEST_HEARTBEAT_URL -p soleur -c prd --plain` (does prd_terraform resolve the `prd` root?) vs. seeding the source values into `prd_terraform` directly. **Decision rule:** if the existing token cannot read `soleur/prd`, seed BOTH source values into `prd_terraform` (guaranteed readable). Record the verified read path in the spec.
+2. **iac-plan-write-guard opt-out (already applied in this plan).** `.claude/hooks/iac-plan-write-guard.sh` denies the Doppler-write literal in Write/Edit content; the plan carries `<!-- iac-routing-ack: plan-phase-2-8-reviewed -->`. The op=arm YAML + runbook edits at /work will trip the same hook — apply the same ack (the writes go through a TF-provisioned token; values are out-of-band by ADR-100 doctrine). Do NOT bypass silently; record the ack.
+3. **tfstate confirms `doppler_project.inngest` + `doppler_environment.inngest_prd` are applied** (the dedicated host is provisioned — cutover phase), so the per-merge `-target` of the new token is a create-only no-op on its transitive deps.
+
+### Phase 1 — Terraform: the arm-write token (RED→GREEN)
+1. Create `apps/web-platform/infra/inngest-arm-write-token.tf` (see §IaC Q1). Header comment must document: blast-radius (isolated project, no inheritance), rotation (`-replace`), state (Computed+Sensitive, R2 tfstate), and the `no ignore_changes` propagation rationale.
+2. Add two `-target=` lines to `.github/workflows/apply-web-platform-infra.yml` per-merge default allow-list (near `:356-357`, beside `doppler_service_token.write`): `doppler_service_token.inngest_arm_write` and `github_actions_secret.doppler_token_inngest_arm`. **Do NOT** add to the `inngest_host` dispatch set or any `OPERATOR_APPLIED_*_EXCLUSIONS`.
+3. `terraform validate` + `terraform plan` (canonical triplet + R2 backend exports — see Sharp Edges) shows **`+2 create, 0 change, 0 destroy`**, no transitive create of `hcloud_server.inngest`/project/env.
+4. Confirm `plugins/soleur/test/terraform-target-parity.test.ts` passes with **no manual edit** (dynamic extraction covers the two new per-merge targets). Run the web-platform destroy-guard counter (`tests/scripts/test-destroy-guard-counter-web-platform.sh`) — unchanged (create-only).
+
+### Phase 2 — POSTGRES_URI source seed (one-time, IaC-documented)
+> **⚠️ SUPERSEDED by the CTO read-through decision (see `## CTO Decision at /work` below).** Phase 0 verified the prod `INNGEST_POSTGRES_URI` is already CI-readable in `prd_terraform` (canonical, `:5432`, distinct from dark), so this operator-seed step is **DROPPED entirely** — op=arm reads both source values read-through. The paragraphs below are the retained point-in-time draft; the shipping design has **no seed**.
+
+1. Document (runbook precondition + `## Infrastructure (IaC)`) the **one-time** seed of `INNGEST_POSTGRES_URI_PROD` (the prod session-pooler `:5432` DSN) into the config verified readable in Phase 0 (default `prd_terraform`), via the Doppler-write CLI stdin — **not** a TF `doppler_secret` resource (TF never owned the password; a `doppler_secret` would clobber it, `inngest-host.tf:155-157`). This is the **only** human secret step, done **once before the maintenance window**, never at cutover.
+2. HEARTBEAT_URL source: if Phase 0 confirms read-through of the TF-managed value works, **no seed** — read the existing TF-managed value at arm time (drift-free). If not, mint a TF `doppler_secret` mirroring `betteruptime_heartbeat.inngest_prd.url` into the readable config (TF has this value; add its `-target` line + parity coverage). Prefer read-through.
+
+### Phase 3 — The `op=arm` workflow verb (RED→GREEN)  [op=arm is FORWARD-ONLY — rollback stays in op=rollback, §deepen Q5]
+1. Add `arm` to the `op` choice `options:` list (`cutover-inngest.yml:22-32`). **No `flip_state` input** — op=arm writes only `armed` (rollback is the existing `op=rollback` verb; Phase 4).
+2. Add the write token as a **job-`env:` conditional** so it is EMPTY for every non-arm dispatch (security F2): `DOPPLER_TOKEN_INNGEST_ARM: ${{ inputs.op == 'arm' && secrets.DOPPLER_TOKEN_INNGEST_ARM || '' }}`. Additionally gate the op=arm path behind a **GitHub Environment** (`environment: inngest-cutover`) with a required-reviewer protection rule (security F3 — restores the human ack the Doppler console provided; publish the token as an *environment* secret, not a repo-wide secret). A bash comment does NOT scope a step-env var — the conditional + environment are the real scoping.
+3. Add the `arm)` case arm (template: `op=quiesce-web` `:618-728` for structure; NO webhook/HMAC — pure Doppler). Sequence, all guards fail-closed and **value-silent**:
+   - **G1 — pre-write FSM-state guard (data-integrity Q2, P1 — prevents prod-Redis re-FLUSHALL data loss):** read the CURRENT `INNGEST_CUTOVER_FLIP` from `soleur-inngest/prd` (write token, `--plain`) and **refuse unless ∈ {`unset`, empty, `aborted`, `rolled-back`}**. Re-arming over `armed`/`flipping`/`flushed`/`done` re-drives the FSM `stop → FLUSHALL` — and over `done` it FLUSHALLs the now-PROD Redis, wiping the live cron sorted-set. The concurrency group `deploy-inngest-restart` serializes dispatches, so the read is TOCTOU-safe.
+   - **G2 — read source values, mask EACH on its own capture line (security F7):** `HB=$(doppler secrets get INNGEST_HEARTBEAT_URL ... --plain); printf '::add-mask::%s\n' "$HB"`; then the same for `PG=$(doppler secrets get INNGEST_POSTGRES_URI_PROD ...)`. Never batch the masks (a mid-sequence `set -e` exit leaves an unmasked captured value).
+   - **G3 — positive prod-URI assertion (data-integrity Q3, P1 — the `:5432`/`:6543` guard MISSES the dark backend; both use `:5432`):** read the CURRENT (dark) `INNGEST_POSTGRES_URI` from `soleur-inngest/prd`, mask it, and assert `PG != PG_dark` (refuse on equality — a same-value flip is a mis-seed/no-op) AND `PG` contains the TF-known prod pooler host / Supabase project-ref. Plus the empty + `:6543` rejects. All comparisons value-silent.
+   - **G4 — write POSTGRES_URI then HEARTBEAT_URL** via the write token, **stdin** (pipe the masked value into the Doppler write CLI — `secrets set INNGEST_POSTGRES_URI` on `soleur-inngest/prd`, value on stdin, never argv). Verify each write exit 0 **before** the next.
+   - **G5 — write `INNGEST_CUTOVER_FLIP=armed` LAST** (literal; same stdin form).
+   - **G6 — confirm via Better Stack, single-state-token + time-bounded + branch (security F1 + data-integrity Q4, both P1):** query `betterstack-query.sh` for the `inngest-cutover-flip` line **bounded to ≥ the `armed`-write timestamp** (or match a per-dispatch correlation token — a stale `done` from a prior run/dry-run on the SAME source else false-succeeds). Extract ONLY the terminal state via `jq -r` (NEVER `echo "$BODY" | jq .` / raw-row echo — that dumps whatever the FSM logged to the run log, a mask bypass). **Branch** on `done` (success) / `aborted` / `rolled-back` (fail loud with the ADR remediation: confirm dark backend, do NOT proceed to 2.4) / timeout. This is a Better Stack READ, not a deploy-status poll → does not perturb the `QMAX_POLLS` drift-guard counts.
+4. Update the drift-guard test `apps/web-platform/infra/cutover-inngest-workflow.test.sh`: assert (a) `arm` is a real `case` arm + menu option (D.1 `:99`); (b) `-p soleur-inngest -c prd` on every write; (c) stdin form (no secret in argv); (d) NO value echoed — first assert the `awk` range is **non-empty** (else the grep passes vacuously, security F6), then `grep -E 'echo.*\$(HB|PG|PG_DARK|POSTGRES|HEARTBEAT)'` → 0, AND `grep 'jq \.'` (raw-row echo) → 0, AND `grep 'set -x'` → 0; (e) `::add-mask::` present before EACH source-value use; (f) no `ssh`; (g) G1 state-guard + G3 prod-URI assertion present; (h) the token env uses the `inputs.op == 'arm' && ... || ''` conditional form + the job names `environment: inngest-cutover`.
+
+### Phase 4 — SEAM removal in `op=execute`; rollback write in `op=rollback`; runbook
+1. In `op=execute`'s SEAM block, replace the `2.2b+2.3 ARM THE FLIP — three Doppler writes` hand-off (`cutover-inngest.yml:607-611`) with: *"2.2b+2.3 ARM THE FLIP — dispatch `op=arm` (no-SSH; performs the 3 writes on soleur-inngest/prd + confirms the FSM done via Better Stack)."* Keep 2.2a (web-2 lifecycle) and 2.4 (app-repoint) — the remaining non-#6369 seams. Update the `:602-604` comment (the flip is now a dispatchable op; hr-menu-option-ack satisfied by the explicit `op=arm` dispatch + the environment required-reviewer gate).
+2. **Fold the reverse `INNGEST_CUTOVER_FLIP=rollback` write into the EXISTING `op=rollback` verb** (`cutover-inngest.yml:890`), NOT a `flip_state` input on op=arm (data-integrity Q5 + architecture P1 — ADR-100:231 mandates the symmetric forward/reverse pair stay as *separate* verbs; op=rollback already owns the reverse web-scheduler re-enable at `:614` step 3). Give op=rollback the conditional `DOPPLER_TOKEN_INNGEST_ARM` env (`inputs.op == 'rollback'` arm) + the same environment gate; order it: write the reverse flip value (stdin, masked-doctrine) → confirm `rolled-back` via time-bounded Better Stack → the existing web re-enable fan-out. Update the `:614` ROLLBACK SEAM text to point at `op=rollback` (which now does the Doppler write too). Rollback writes ONLY the flip value — never re-writes POSTGRES_URI/HEARTBEAT.
+<!-- lint-infra-ignore start -->
+3. Runbook `knowledge-base/engineering/operations/runbooks/inngest-server.md`: rewrite the 2.2b/2.3 "Op order" SEAM to the `op=arm` dispatch; add the **post-cutover token-revoke** step (security F4 + architecture P2 — the write token is a standing read handle to the armed prod DSN; revoke via `terraform apply -replace=doppler_service_token.inngest_arm_write` + `doppler configs tokens revoke` after AC17 validates); update the "SEAM"/"operator" markers count. (The **one-time seed** and **seed-delete** from the original draft are DROPPED per the CTO read-through decision below — reads are read-through from prd_terraform, no seed exists.)
+<!-- lint-infra-ignore end -->
+
+### Phase 5 — End-to-end cutover assembly + dry-run validation
+1. Assemble the full now-no-SSH op order in the runbook (enumerate → capture → inventory → backup → execute → [op=quiesce-web if gate fails] → **op=arm** → op=rearm → op=verify), with the two remaining operator-lifecycle steps (2.2a web-2 recreate, 2.4 app-repoint) clearly flagged as the ONLY non-dispatch steps.
+2. **Dry-run validation** (no live cutover): confirm each op's reachability (op=inventory/enumerate reads; op=arm's read+mask path against the dark `soleur-inngest/prd` WITHOUT writing `armed`, or against a scratch key) and that the FSM-confirm poll parses a synthetic Better Stack `done`. Document the dry-run in the spec.
+3. **The live prod cutover is operator-gated** — not an autonomous `/work` step (single-user-incident; maintenance window). The plan's deliverable is the *enabled* end-to-end (every secret-write + host-mutation no-SSH) + the operator's single ordered dispatch sequence.
+
+### Phase 6 — ADR-100 amendment + C4 check
+See §Architecture Decision.
+
+## Files to Create
+- `apps/web-platform/infra/inngest-arm-write-token.tf` — the read/write Doppler service token + its github_actions_secret.
+- `knowledge-base/project/specs/feat-one-shot-6369-inngest-op-arm/tasks.md` (generated by plan Save-Tasks).
+
+## Files to Edit
+- `.github/workflows/cutover-inngest.yml` — `arm` option (`:22-32`); step env (`:62-81`); new `arm)` case; SEAM rewrite in `op=execute` (`:602-615`).
+- `.github/workflows/apply-web-platform-infra.yml` — 2 `-target=` lines (per-merge default set, near `:356-357`); (conditionally) a 3rd for the heartbeat `doppler_secret` if Phase 2 needs it.
+- `apps/web-platform/infra/cutover-inngest-workflow.test.sh` — op=arm drift-guard assertions.
+- `knowledge-base/engineering/operations/runbooks/inngest-server.md` — 2.2b/2.3 SEAM rewrite + one-time seed precondition + end-to-end op order.
+- `knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md` — Decision 6b amendment.
+- `knowledge-base/engineering/architecture/diagrams/model.c4` — **only if** the ADR reviewer judges the CI→`soleur-inngest/prd` write edge material (default: no edit — see §Architecture Decision C4).
+- **No edit** to `plugins/soleur/test/terraform-target-parity.test.ts` (dynamic extraction).
+
+## Infrastructure (IaC)
+
+### Q1 — Terraform changes (new file `apps/web-platform/infra/inngest-arm-write-token.tf`)
+```hcl
+resource "doppler_service_token" "inngest_arm_write" {
+  project = doppler_project.inngest.name        # by-reference (builds the dep edge; NOT "soleur-inngest")
+  config  = doppler_environment.inngest_prd.slug # by-reference (NOT "prd")
+  name    = "inngest-cutover-arm"                # distinct from the read token "inngest-boot"
+  access  = "read/write"
+}
+resource "github_actions_secret" "doppler_token_inngest_arm" {
+  repository      = "soleur"
+  secret_name     = "DOPPLER_TOKEN_INNGEST_ARM"
+  plaintext_value = doppler_service_token.inngest_arm_write.key   # NO ignore_changes → -replace propagates in one apply
+}
+```
+- **Providers/pins:** none new (`doppler` + `github` providers already in the root).
+- **Sensitive vars:** none new. The token `.key` is `Computed + Sensitive`, minted once, lands in R2-backed encrypted `terraform.tfstate` (same posture as `doppler_service_token.write`/`.inngest`/`.ghcr_minter`). Cannot be re-read from the Doppler API.
+
+### Apply path
+<!-- lint-infra-ignore start -->
+- **(b) cloud-init + bootstrap → N/A** (no host resource). Path is a plain per-merge `-target` apply: merging the `.tf` + the `-target` lines creates the token + env secret on the next `apply-web-platform-infra.yml` per-merge run. **No bootstrap cycle** (unlike `doppler_token_write`, whose same-job step consumes the secret it minted): `op=arm` is a separate, later-dispatched workflow, so `DOPPLER_TOKEN_INNGEST_ARM` exists by the time the operator dispatches op=arm. Blast-radius: `+3 create` (token + environment + env secret — D5), zero downtime.
+<!-- lint-infra-ignore end -->
+- **`-target` placement = per-merge default allow-list** (NOT the stripped `inngest_host` dispatch set). Rationale (terraform-architect): the parity test explicitly forbids CI-published `github_actions_secret` tokens in `OPERATOR_APPLIED_TOKEN_EXCLUSIONS` (`terraform-target-parity.test.ts:631-635` — the #5566 silent-un-applied class); `stripDispatchJobs` would hide an `inngest_host`-placed target from coverage → RED. Transitivity pulls the already-applied project/env (no-op create) but NOT `hcloud_server.inngest`.
+
+### Q3 — source-of-truth for the two URI VALUES (the crux)
+- **INNGEST_HEARTBEAT_URL:** TF-known (`betteruptime_heartbeat.inngest_prd.url`). **Read-through** at arm time from the TF-managed value (existing in `soleur/prd` as `doppler_secret.inngest_heartbeat_url_prd`); NOT written by TF into `soleur-inngest/prd` at apply (the dark-window masking doctrine, `inngest-host.tf:137-151`, forbids provisioning it there before cutover — op=arm is the correct at-window writer). Read path decided in Phase 0.
+- **INNGEST_POSTGRES_URI:** embeds a Supabase DB password TF **never** minted (`inngest-host.tf:153-158`); the Supabase Management API (read-only `SUPABASE_ACCESS_TOKEN`, `cutover-inngest.yml:71`) **cannot** derive it (password not exposed post-set; a reset is destructive). → **operator-seed-once** `INNGEST_POSTGRES_URI_PROD` into a CI-readable Doppler read-secret (Phase 2), consumed no-SSH by op=arm. This is the SAME out-of-band doctrine already governing the dark `INNGEST_POSTGRES_URI`; it is a Doppler secret seed, NOT a TF variable → `hr-tf-variable-no-operator-mint-default` does not apply; `hr-all-infrastructure-provisioning` is honoured (provisioned via Doppler, once, before the window — no paste at cutover).
+
+### Distinctness / drift safeguards
+- **No `ignore_changes`** on either resource (rotation via `-replace` must re-propagate `.key` in one apply). Adding `ignore_changes=[plaintext_value]` would strand the GH secret on the old key — do NOT.
+- **dev != prd:** `soleur-inngest` has **no dev config**; the token is `prd`-only (`hr-dev-prd-distinct`; `inngest-host.tf:43`).
+- **Token distinctness:** `inngest-cutover-arm` (read/write, CI-consumed) coexists with `inngest-boot` (read, host-consumed) — distinct names, blast radii, consumers.
+
+### Q4 — scope-guard test sweep
+Only `plugins/soleur/test/terraform-target-parity.test.ts` asserts per-merge `-target` coverage, and it extracts targets **dynamically** → **no manual edit** with the per-merge placement. Do NOT add to `OPERATOR_APPLIED_*_EXCLUSIONS`. `tests/scripts/test-destroy-guard-counter-web-platform.sh` + `destroy-guard-filter-web-platform.jq` + fixture assert destroy counts (create-only → unchanged). `*-gate.sh` replace-gates are unrelated. Verify green, don't assume.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: on-host `inngest-cutover-flip` FSM log line reaching `done` (exit_code:0), shipped journald→Vector→Better Stack Logs (source 2457081)
+  cadence: once per op=arm dispatch (at cutover); the 30s on-host .timer drives the FSM
+  alert_target: op=arm job FAILS loud (exit 1) if Better Stack does not show `done` within the bounded poll window, or shows `aborted`/`rolled-back`
+  configured_in: cutover-inngest.yml op=arm case (betterstack-query.sh); ADR-100 Decision 6a
+error_reporting:
+  destination: GitHub Actions run log (::error:: annotations, no secret values) + the on-host FSM Better Stack line for the terminal state
+  fail_loud: true — empty-value guard, :6543-port guard, per-write exit-code check, and FSM-not-done all exit 1 with a no-SSH remediation string
+failure_modes:
+  - {mode: source value empty/unreadable, detection: op=arm empty-string guard on doppler-get, alert_route: job exit 1 (no value echoed)}
+  - {mode: wrong pooler port (:6543) in POSTGRES_URI, detection: op=arm regex guard before write, alert_route: job exit 1}
+  - {mode: partial write (URI written, armed not), detection: per-write exit-code check gates the next write; armed written last only after both URIs succeed, alert_route: job exit 1 before arming}
+  - {mode: FSM aborts (DBSIZE!=0) or rolls back, detection: betterstack-query.sh sees terminal `aborted`/`rolled-back`, alert_route: job exit 1 + remediation (confirm dark backend, do NOT proceed to 2.4)}
+  - {mode: secret value leaks to a run log, detection: cutover-inngest-workflow.test.sh asserts no value-echo + ::add-mask:: present, alert_route: CI red pre-merge}
+logs:
+  where: GitHub Actions run log (op=arm); Better Stack Logs source 2457081 (on-host FSM)
+  retention: GH Actions default (90d); Better Stack Logs per plan retention
+discoverability_test:
+  command: gh run list --workflow=cutover-inngest.yml --limit 1 --json conclusion  # (NO ssh); + betterstack-query.sh for the FSM done line
+  expected_output: op=arm run conclusion=success AND a Better Stack `inngest-cutover-flip ... exit_code:0 reason:done` line
+```
+
+## Architecture Decision (ADR/C4)
+
+### ADR — amend ADR-100 (Decision 6b), do NOT create a new ADR
+ADR-100 is `adopting` and Decision 6a already owns the flip FSM. Add **Decision 6b (2026-07-12, Ref #6369)**:
+- The arm-flip (the three writes to `soleur-inngest/prd`) is performed no-SSH by `cutover-inngest.yml op=arm` using a **TF-provisioned read/write Doppler service token** (`doppler_service_token.inngest_arm_write`), never logging values (AC-NOBODY).
+- **Reconciles `hr-menu-option-ack-not-prod-write-auth`:** a manual `op=arm` dispatch IS the explicit per-command go-ahead; the trust model is identical to `op=quiesce-web`/`op=rollback` (`cutover-inngest.yml:624`). The rule kept the flip out of `op=execute`'s auto-run spine, not out of a separately-dispatched verb.
+- **Reconciles `hr-all-infrastructure-provisioning`:** the write *token* is TF-provisioned; the 3 *values* remain out-of-band (they cannot be TF `doppler_secret` resources — dark-window heartbeat masking + a DB password TF never minted, `inngest-host.tf:137-166`). op=arm writes them at the maintenance-window moment, which is exactly when the doctrine says they must appear.
+- Records the one-time `INNGEST_POSTGRES_URI_PROD` seed as the single remaining human secret step (pre-window, never at cutover).
+- **Ordinal:** amendment to ADR-100 → no new ordinal (next-free is ADR-113 if a reviewer insists on a standalone; default is the amendment).
+
+### C4 views
+Read all three `.c4` files (`model.c4`, `views.c4`, `spec.c4`). Enumeration for op=arm:
+- **External human actors:** none new (the operator who dispatches op=arm is the existing CI-trigger actor).
+- **External systems:** `doppler` (system, `model.c4:234`), `betterstack` (system, `:264`), `github` — all already modeled.
+- **Containers/data-stores:** `inngest`, `inngestPostgres` (`:184-190`), `inngestRedis` (`:192`) — all modeled.
+- **Access relationships:** the CI→Doppler secret-write relationship **already exists** at the C4 altitude (TF applies write to Doppler via `doppler_service_token.write`); `doppler -> inngest "Injects secrets"` (`:385`) models the scoped soleur-inngest credential. op=arm is a new *instance* of an existing modeled relationship type, not a new relationship.
+- **Conclusion:** **no `.c4` edit required** (cite this enumeration). The ADR reviewer at deepen-plan/work re-reads the three files for correctness; if they judge a distinct `ci -> doppler "arms the cutover flip (soleur-inngest/prd)"` edge material, add it to `model.c4` + the `view include` in `views.c4` and run `c4-code-syntax.test.ts` + `c4-render.test.ts`.
+
+### Sequencing
+Decision 6b is true at merge (the token + verb ship together); the *live* arm happens later at the operator window. ADR amendment authored now with the `adopting` status carried forward.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- **AC1** `apps/web-platform/infra/inngest-arm-write-token.tf` exists; `terraform validate` passes; `grep -c 'access  = "read/write"'` == 1; `project`/`config` are `doppler_project.inngest.name` / `doppler_environment.inngest_prd.slug` (by-reference — `grep -c '"soleur-inngest"'` in the new file == 0).
+- **AC2** `apply-web-platform-infra.yml` per-merge `-target` set contains BOTH `doppler_service_token.inngest_arm_write` AND `github_actions_secret.doppler_token_inngest_arm`; neither appears in any `OPERATOR_APPLIED_*_EXCLUSIONS` block (`grep`).
+- **AC3** `plugins/soleur/test/terraform-target-parity.test.ts` passes **unmodified** (`git diff --stat` shows no change to it).
+- **AC4** `terraform plan` (canonical triplet) prints `Plan: 2 to add, 0 to change, 0 to destroy` and shows NO create of `hcloud_server.inngest` / `doppler_project.inngest` / `doppler_environment.inngest_prd` (verify at /work against live state immediately before merge; if drift, re-scope).
+- **AC5** `cutover-inngest.yml` `op` `options:` includes `arm`; a real `arm)` `case` arm exists (D.1 rule).
+- **AC6 (AC-NOBODY)** the `arm)` block echoes NO value: `awk '/^            arm)/,/^            ;;/' cutover-inngest.yml | grep -E 'echo.*\$(HB|PG|PG_URI|POSTGRES|HEARTBEAT)'` returns 0; `::add-mask::` appears before the first source-value use; every write reads from **stdin** (`printf '%s' "$VAR" | doppler secrets set NAME`), never `NAME=value` argv.
+- **AC7** write order enforced: `INNGEST_CUTOVER_FLIP=armed` is written **after** both URI writes, each gated on the prior exit code (assert via `cutover-inngest-workflow.test.sh`).
+- **AC8** `:5432`/`:6543` guard present in the arm block (reject `:6543`); empty-value guard present.
+- **AC9** `op=arm` confirms the FSM via `betterstack-query.sh` (`inngest-cutover-flip` line, require `exit_code:0`); fails loud on `aborted`/`rolled-back`/timeout. NO new deploy-status poll (QMAX_POLLS/retry counts in `cutover-inngest-workflow.test.sh` unchanged).
+- **AC10** `op=execute` SEAM no longer prints the three arm Doppler-write lines; it points to `op=arm` (the arm write itself is stdin, not a literal in prose).
+- **AC11** runbook `inngest-server.md` 2.2b/2.3 SEAM rewritten to `op=arm`; the one-time `INNGEST_POSTGRES_URI_PROD` seed documented as a pre-window precondition; the operator Op-order no longer instructs three manual Doppler writes for the flip.
+- **AC12** ADR-100 Decision 6b present; cites the hr-menu-option-ack + hr-all-infrastructure-provisioning reconciliations; C4 enumeration recorded (no `.c4` edit, or the edit + passing c4 tests if made).
+- **AC13** `cutover-inngest-workflow.test.sh` green; no `ssh` token in the arm block.
+- **AC14** gitleaks/secret-scan clean: no real secret literal in any edited file (synthetic placeholders only; `<prod-postgres-uri>` style in prose).
+
+### Post-merge (operator)
+- **AC15** After the per-merge apply, `DOPPLER_TOKEN_INNGEST_ARM` exists as a repo secret (`gh secret list | grep DOPPLER_TOKEN_INNGEST_ARM`) — automatable presence check, run in `/soleur:ship` post-merge verification.
+- **AC16** One-time seed `INNGEST_POSTGRES_URI_PROD` into the verified-readable config (operator, pre-window). `Automation: not feasible because the prod inngest DB password is not TF-owned nor Management-API-derivable — see IaC Q3` (genuinely seed-once; NOT a per-cutover step). `Ref #6369` (not `Closes`) so the issue closes only after the live arm validates.
+- **AC17 (soak/live, operator-gated)** op=arm dispatched at the live cutover writes the 3 values, the FSM reaches `done`, and the dedicated host serves prod crons — validated in the operator maintenance window (NOT an autonomous /work step).
+
+## Domain Review
+
+**Domains relevant:** none (of the 8 business domains) — this is an infrastructure/tooling + security change.
+
+No cross-domain (Product/Marketing/Finance/Legal/Sales/Support/Operations) implications detected. Engineering/security review is covered by: plan-review (DHH/Kieran/Simplicity + architecture-strategist at single-user-incident threshold) and deepen-plan (security-sentinel + data-integrity-guardian + architecture-strategist). `user-impact-reviewer` runs at PR review (threshold `single-user incident`). **CPO sign-off required at plan time** (`requires_cpo_signoff: true`) — the technical approach (a TF-provisioned prod write token + a CI verb that writes prod secrets) is the product-owner ack per the §User-Brand Impact threshold.
+
+### Product/UX Gate
+**Tier:** none — no UI surface (no file under `components/**`, `app/**/page.tsx`, `app/**/layout.tsx`). Skipped.
+
+## Open Code-Review Overlap
+None. (Re-run at /work once `## Files to Edit` is frozen: `gh issue list --label code-review --state open --json number,title,body` then `jq contains($path)` per edited path; record matches or `None`.)
+
+## Test Scenarios
+- **T1** op=arm happy path (dry-run against dark/scratch key): reads both source values masked, writes 3 values stdin, `armed` last, FSM-confirm parses `done`.
+- **T2** Empty source value → exit 1, no value echoed.
+- **T3** POSTGRES_URI with `:6543` → exit 1 before any write.
+- **T4** First URI write fails → `armed` never written; job exit 1.
+- **T5** FSM returns `aborted` (synthetic Better Stack) → exit 1 + remediation string; NO advance to 2.4.
+- **T6** Drift-guard: `cutover-inngest-workflow.test.sh` asserts no value-echo, `::add-mask::`, stdin form, `-p soleur-inngest -c prd`, no ssh, guards present.
+- **T7** `terraform-target-parity.test.ts` green unmodified; destroy-guard counter unchanged.
+
+## Sharp Edges
+- **iac-plan-write-guard blocks the edits.** `.claude/hooks/iac-plan-write-guard.sh` denies the Doppler-write literal in Write/Edit content. This plan carries the `iac-routing-ack` opt-out; /work MUST apply the same ack for the op=arm YAML + runbook edits (writes go through a TF-provisioned token; values out-of-band by ADR-100 doctrine). Do NOT bypass silently; record the ack.
+- **Canonical TF invocation.** `terraform plan/apply` against `apps/web-platform/infra/` needs the triplet: export raw `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` (R2 backend, NOT via tf-var), `terraform init -input=false`, then `doppler run -p soleur -c prd_terraform --name-transformer tf-var -- terraform plan`. Missing `--name-transformer tf-var` → ~13 `No value for required variable` errors (`2026-05-09-drift-runbook-canonical-tf-invocation`).
+- **Re-run `terraform plan` against LIVE state immediately before merge** (AC4). The `+2 create` claim depends on the dark host being provisioned; a stale assumption drags project/env into a create. Verify, don't trust.
+- **`-target` scope-guard sweep** (`2026-05-29-target-allowlist-extension-must-sweep-all-guard-suites`): only `terraform-target-parity.test.ts` asserts per-merge coverage and it is dynamic (no edit). The destroy-guard counter + `*-gate.sh` suites are create-only-unaffected — confirm, don't assume.
+- **AC-NOBODY is the load-bearing control.** `doppler secrets get --plain` output MUST be `::add-mask::`'d on the SAME line it is captured, before any use; the write CLI MUST read stdin (never `NAME=value` argv, which is process-listing-visible and log-echoable). A value in a run log at `single-user incident` threshold is a brand-survival event.
+- **Write order is a correctness invariant.** `armed` last, each URI write exit-code-gated. Arming before the URIs land fires the FSM against a stale/missing DSN → scheduler death. The FSM's `flipping`/`flushed` checkpoints (ADR-100 6a) protect the on-host transient, NOT a mis-ordered arm write.
+- **Doppler read-path is unverified (terraform-architect flag #1).** Whether the existing prd_terraform `DOPPLER_TOKEN` can read `soleur/prd` source values is unconfirmed; Phase 0 decides read-through vs. seed-into-prd_terraform. Do NOT assume read-through in the op=arm code before Phase 0.
+- **`gh secret list` cannot read values** — AC15 verifies presence only; the value is write-once in tfstate.
+- **Better Stack confirm is a READ, not a deploy-status poll** — keep it out of the `QMAX_POLLS`/retry-count grep space so `cutover-inngest-workflow.test.sh`'s poll-budget drift-guard stays unambiguous.
+- **A `## User-Brand Impact` section that is empty/placeholder/omits the threshold fails deepen-plan Phase 4.6.** It is filled above (threshold `single-user incident`).
+
+## Non-Goals / Alternative Approaches Considered
+- **Live prod cutover execution** — operator-gated maintenance-window action, single-user blast radius; NOT an autonomous /work step. The plan *enables* the fully-no-SSH end-to-end + provides the ordered dispatch sequence.
+- **2.2a web-2 lifecycle freeze/recreate** (`cutover-inngest.yml:606`) — a host-lifecycle step outside #6369 (tracked toward #6227's per-host fan-out). Remains operator/dispatch.
+- **2.4 app-repoint** (merge `ci-deploy.sh INNGEST_BASE_URL → 10.0.1.40:8288` + redeploy, `:612`) — a code merge outside #6369.
+- **TF `doppler_secret` for the 3 arm values** — REJECTED: violates the out-of-band doctrine (dark-window heartbeat masking; DB password TF never minted; FSM must fire at the window, not at apply). `inngest-host.tf:137-166`.
+- **Deriving POSTGRES_URI via Supabase Management API** — REJECTED: read-only token cannot fetch the DB password; a reset is destructive. → one-time seed.
+- **New standalone ADR (ADR-113)** — deferred to reviewer preference; default is the ADR-100 amendment (same architectural surface, avoids ordinal churn).
+- **Placing the token in the `inngest_host` dispatch `-target` set** — REJECTED: parity test forbids CI-published tokens in exclusions; `stripDispatchJobs` would hide it from coverage.
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+
+## Deepen-Plan Findings & Required Changes (2026-07-12 — SUPERSEDES the sections above where noted)
+
+Reviewed by security-sentinel, data-integrity-guardian, architecture-strategist, and a verify-negative/precedent Explore. The verify-negative pass **confirmed all 8** load-bearing facts (token shape at `doppler-write-token.tf:44-50`; parity-test forbids CI-published tokens in exclusions at `terraform-target-parity.test.ts:631-635` and extracts targets dynamically; `-target` neighbours `:356-357`; op structure `:22-32`/`:62-81`, op=quiesce-web `:618`, op=rollback `:890`, SEAM `:607-611`; stdin/`--plain` doctrine `inngest-host.tf:165-166`; `cutover-inngest.yml` has ZERO `::add-mask::` today — the drift-guard is load-bearing; FSM states `ADR-100:160-162`; no-inheritance `inngest-host.tf:78-85`). The following changes are authoritative and OVERRIDE the earlier phases/ACs where they conflict.
+
+### D1 (P1) — op=arm is FORWARD-ONLY; rollback stays in the EXISTING `op=rollback` verb
+**Supersedes Phase 4.2's `flip_state` idea.** Do NOT add a `flip_state` input to op=arm and do NOT default any prod-mutating input (data-integrity Q5 + architecture P1; ADR-100:231 keeps the symmetric forward/reverse pair as *separate* verbs). op=arm writes only `armed`. Fold the reverse `INNGEST_CUTOVER_FLIP=rollback` write into the existing `op=rollback` (`:890`): give it the conditional `DOPPLER_TOKEN_INNGEST_ARM` env + the environment gate; order it **G1' guard (refuse unless the forward flip progressed, ∈ {flipping,flushed,done}) → write `rollback` (stdin) → confirm `rolled-back` (time-bounded) → the existing web re-enable fan-out**. Rollback writes ONLY the flip value.
+
+### D2 (P1) — pre-write FSM-state guard (prevents PROD-Redis re-FLUSHALL data loss)
+**New G1 step in the `arm)` case, before any write.** Read the CURRENT `INNGEST_CUTOVER_FLIP` from `soleur-inngest/prd` (write token) and **refuse unless ∈ {`unset`, empty, `aborted`, `rolled-back`}**. Re-arming over `done` re-drives `stop → FLUSHALL` against the now-PROD Redis → wipes the live cron sorted-set + in-flight jobs (data-integrity Q2). The `deploy-inngest-restart` concurrency group (`:52-54`, `cancel-in-progress:false`) serializes dispatches → TOCTOU-safe. **Add AC:** op=arm refuses over `{armed,flipping,flushed,done}`.
+
+### D3 (P1) — positive prod-URI assertion (the `:5432`/`:6543` guard MISSES the dark backend)
+**New G3 step.** Both dark and prod DSNs use `:5432`, so an empty/`:6543` guard does NOT stop arming the DARK backend (data-integrity Q3 — the exact §User-Brand Impact failure). Read the CURRENT (dark) `INNGEST_POSTGRES_URI` from `soleur-inngest/prd`, mask it, and assert `PG != PG_dark` (refuse on equality) AND `PG` contains the TF-known prod pooler host / Supabase project-ref. All comparisons value-silent. **Add AC + T-case** (mis-seed == dark → exit 1 before any write).
+
+### D4 (P1) — AC-NOBODY hardening (three concrete leak vectors)
+- **G6 Better Stack confirm** (security F1 + data-integrity Q4): `betterstack-query.sh` emits whole rows — extract ONLY a single state token via `jq -r`, NEVER `echo "$BODY" | jq .`; and **time-bound the query to ≥ the `armed`-write timestamp** (or a per-dispatch correlation token) — a stale `done` from a prior run or the Phase-5 dry-run on the SAME source else false-succeeds. Branch on `done`/`aborted`/`rolled-back`/timeout.
+- **G2 masking** (security F7): mask EACH source value on its OWN capture line (`printf '::add-mask::%s\n' "$HB"` immediately after `HB=$(...)`, then PG) — never batch (a mid-sequence `set -e` exit leaves an unmasked value).
+- **Drift-guard test** (security F6): assert the `awk '/arm)/,/;;/'` range is **non-empty** BEFORE grepping (else the no-value-echo grep passes vacuously); add `grep 'jq \.'` == 0 (no raw-row echo) and `grep 'set -x'` == 0.
+
+### D5 (P1) — GitHub Environment secret + required reviewer (real human ack)
+**Supersedes IaC Q1's plain `github_actions_secret`.** A `workflow_dispatch` is only repo `actions:write` — weaker than the Doppler console credentials the manual write required, and a repo-wide `github_actions_secret` is readable by every workflow (security F2/F3). Change the IaC to:
+```hcl
+resource "github_repository_environment" "inngest_cutover" {
+  repository  = "soleur"
+  environment = "inngest-cutover"
+  reviewers { users = [/* operator user id */] }
+}
+resource "github_actions_environment_secret" "doppler_token_inngest_arm" {
+  repository      = "soleur"
+  environment     = github_repository_environment.inngest_cutover.environment
+  secret_name     = "DOPPLER_TOKEN_INNGEST_ARM"
+  plaintext_value = doppler_service_token.inngest_arm_write.key   # NO ignore_changes
+}
+```
+The op=arm job declares `environment: inngest-cutover` (required-reviewer gate fires on dispatch) AND scopes the token conditionally: `DOPPLER_TOKEN_INNGEST_ARM: ${{ inputs.op == 'arm' && secrets.DOPPLER_TOKEN_INNGEST_ARM || '' }}` (empty for non-arm ops). Add both `-target` entries (token + env secret) to the per-merge set; `terraform validate` must confirm `github_repository_environment`/`github_actions_environment_secret` exist in the pinned github provider. **Update AC15** to `gh api repos/.../environments/inngest-cutover/secrets`. The ADR-100 6b reconciliation now rests on this gate, not the dispatch alone.
+
+### D6 (P1) — token/seed lifecycle (the token is a standing read handle to the armed prod DSN)
+- **Post-cutover revoke** (security F4): after AC17 validates the live cutover, revoke the write token (`terraform apply -replace=doppler_service_token.inngest_arm_write` + `doppler configs tokens revoke` the old key) — it can READ the prod DSN it wrote into `soleur-inngest/prd`. Add to the runbook + AC17. Correct §User-Brand Impact: blast radius = the isolated project *including* the armed prod DSN.
+- **Seed into a NARROW config, not `prd_terraform`** (security F5): `prd_terraform` is the broadest CI-read surface. Seed `INNGEST_POSTGRES_URI_PROD` into a narrow config read only by op=arm; add a **rotation co-update** (the `inngest-host.tf:165` password-rotation step must also re-seed) + a pre-window **freshness assertion** (value-silent) that seed and target agree; **delete the seed** after AC17. Update Phase 2 + AC16/AC17.
+
+### D7 (P2) — documentation/hygiene tightenings
+<!-- lint-infra-ignore start -->
+- **Transitivity precedent** = `doppler_service_token.inngest` (by-reference, `inngest-host.tf:171`), NOT `.write` (string-literal, zero edges). The by-reference wiring makes the `-target` a **standing** transitive path onto the excluded project/env — document in the `.tf` header that a teardown/re-provision of `doppler_project.inngest` must be operator-applied first, else CI recreates the isolated project unattended (architecture P2).
+<!-- lint-infra-ignore end -->
+- **ADR-100 6b boundary delta:** state that this is the FIRST CI-consumed read/write token into the isolated `soleur-inngest` project (prior tokens are read-only host-boot, `inngest-host.tf:173`) — CI can now WRITE `soleur-inngest/prd`. State plainly: *the dispatch + environment approval IS the ack; there is no interactive pre-write value confirmation, by design (AC-NOBODY forbids echoing the values).*
+- **Source-of-truth principle:** "read-through where TF owns the value (HEARTBEAT_URL), seed-once where TF cannot (POSTGRES_URI)." The Phase-0 heartbeat fallback mirror lands in the CI-readable config, NOT `soleur-inngest/prd` — so it does NOT breach the dark-window masking doctrine (architecture P2).
+- **On-host flip-guard (data-integrity P2 edge, cross-ref, NOT built in #6369):** the on-host oneshot's ExecStartPre should positively require `URI==prod` at flip-time (defend a transient dark-URI resolution). That lives on the ADR-100/#6178 on-host surface — raise with the ADR-100 owner; flagged, not built here.
+
+### Updated Test Scenarios (add to §Test Scenarios)
+- **T-D2** pre-write state == `done`/`flipping` → G1 exit 1 (data-loss prevention).
+- **T-D3** POSTGRES_URI == current dark URI (mis-seed) → G3 exit 1 before any write. Fixtures use unmistakably synthetic non-matching DSNs (`cq-test-fixtures-synthesized-only`, security F9) + AC14 extended to fixtures.
+- **T-D4** stale prior-run `done` before the arm timestamp → NOT matched (time-bound holds); confirm continues/times out.
+- **T-D5** op=rollback writes only `INNGEST_CUTOVER_FLIP=rollback` behind G1'; confirms `rolled-back`.
+
+### Enhancement Summary
+Deepened 2026-07-12. Structurally sound plan; the `-target` placement and ADR-amendment calls were confirmed correct. Seven load-bearing changes fold in above (D1-D6 are P1). The single sharpest catch: **D2** — without the pre-write FSM-state guard, a second op=arm dispatch over `done` re-FLUSHALLs the live PROD Redis. No blocking principle deviation (AP-001/002/007/008 aligned).
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+
+## Deepen-Plan Findings — Required Changes (SUPERSEDES the sections above where they conflict)
+
+`<!-- iac-routing-ack: plan-phase-2-8-reviewed — the Doppler-write literals below describe the op=arm verb + one-time seed reviewed under Phase 2.8; the write TOKEN is TF-provisioned; the 3 values are out-of-band by ADR-100 Decision 6a. -->`
+
+**Deepened 2026-07-12** — agents: security-sentinel, data-integrity-guardian, architecture-strategist, verify-negative/precedent Explore, terraform-architect. The following corrections are load-bearing and OVERRIDE the earlier draft where they differ. All 8 precedent/verify claims above were confirmed against source.
+
+### C1 (P1, data-integrity Q5 + architecture P1) — op=arm is FORWARD-ONLY; rollback stays in `op=rollback`
+DROP the `flip_state` input idea. ADR-100:231 rules the symmetric forward/reverse verb pair must stay **separate** (the same reason `op=quiesce-web`/`op=rollback` are distinct). Fold the reverse `INNGEST_CUTOVER_FLIP=rollback` write into the EXISTING `op=rollback` verb (`cutover-inngest.yml:890`, which already owns the reverse web-scheduler re-enable at `:614` step 3): give it the conditional arm-write token env + the same environment gate; order **G1'** (refuse unless the forward flip progressed, ∈ {`flipping`,`flushed`,`done`}) → write `rollback` (stdin) → confirm `rolled-back` (time-bounded) → existing web re-enable. Rollback writes ONLY the flip value. No prod-mutating default on any input.
+
+### C2 (P1, data-integrity Q2) — pre-write FSM-state guard (prevents PROD-Redis re-FLUSHALL data loss)
+Before ANY write, op=arm MUST read the current `INNGEST_CUTOVER_FLIP` from `soleur-inngest/prd` and **refuse unless ∈ {`unset`, empty, `aborted`, `rolled-back`}**. Re-arming over `done` re-drives the FSM `stop → FLUSHALL` against the now-PROD Redis, wiping the live cron sorted-set + in-flight jobs. The `deploy-inngest-restart` concurrency group (`:52-54`, `cancel-in-progress:false`) serializes dispatches → TOCTOU-safe. Add as AC7 and T5.
+
+### C3 (P1, data-integrity Q3) — positive prod-URI assertion (the `:5432`/`:6543` guard MISSES the dark backend)
+Both dark and prod DSNs use `:5432`, so the port guard does NOT catch arming the DARK backend (which FLUSHALLs the host Redis and flips onto the wrong Postgres → every user's crons silently stall, queue already wiped). op=arm MUST read the current (dark) `INNGEST_POSTGRES_URI` from `soleur-inngest/prd`, mask it, and assert the value it is about to write `!= dark` AND contains the TF-known prod pooler host/Supabase project-ref (plus empty + `:6543` rejects). All value-silent. Add as AC8 and T3.
+
+### C4 (P1, security F3) — GitHub Environment secret + required reviewer (real human ack)
+A `workflow_dispatch` is only repo `actions:write` — weaker than the Doppler console credentials it replaces. Publish `DOPPLER_TOKEN_INNGEST_ARM` as a **GitHub Environment secret** (`github_actions_environment_secret` under `github_repository_environment "inngest-cutover"` with a required-reviewer rule), NOT a repo-wide `github_actions_secret`; add `environment: inngest-cutover` to the op=arm (and op=rollback-write) job. This restores the human ack and is the real basis of the `hr-menu-option-ack` reconciliation. IaC Q1 changes accordingly. Add to AC1/AC15.
+
+### C5 (P1, security F2) — conditional token env (not step-comment scoping)
+A bash comment does not scope a step-`env:` var. Inject the token EMPTY for non-arm dispatches: `DOPPLER_TOKEN_INNGEST_ARM: ${{ inputs.op == 'arm' && secrets.DOPPLER_TOKEN_INNGEST_ARM || '' }}` (and the `rollback` arm for the reverse write). Assert the conditional form in the drift-guard (AC13).
+
+### C6 (P1, security F1 + data-integrity Q4) — Better Stack confirm: single-token + time-bounded
+`betterstack-query.sh` emits whole matched rows. op=arm MUST (a) bound the query to logs `≥` the `armed`-write timestamp (or a per-dispatch correlation token) — a stale `done` from a prior run/dry-run on the SAME source else false-succeeds and the operator proceeds to 2.4 on an unarmed host; and (b) extract ONLY the terminal state via `jq -r '...|.state'`, NEVER `echo "$BODY" | jq .` (raw-row echo = mask bypass). Branch on `done`/`aborted`/`rolled-back`/timeout. Add to AC9 and T8.
+
+### C7 (P1/P2, security F4/F5 + architecture P2) — token/seed lifecycle
+- The write token is a **standing read handle to the armed prod DSN** once op=arm writes it into `soleur-inngest/prd`. Runbook adds a **post-cutover revoke** (`terraform apply -replace=doppler_service_token.inngest_arm_write` + `doppler configs tokens revoke` of the orphan) after AC17.
+- Seed `INNGEST_POSTGRES_URI_PROD` into a **narrow** CI-readable config, NOT `prd_terraform` (broadest CI-read surface + rotation-drift trap). Add a rotation co-update note (rotating the DB password must update the seed too) + a pre-window value-silent freshness assertion; **delete the seed** after AC17. Principle: *read-through where TF owns the value (HEARTBEAT_URL), seed-once where TF cannot (POSTGRES_URI).*
+
+### C8 (P2) — AC-NOBODY hardening + drift-guard non-vacuity
+- Mask EACH source value on its own capture line (security F7 — a batched mask leaves an unmasked window under `set -e`).
+- The drift-guard test MUST first assert the `arm)` awk range is **non-empty** (security F6 — else `grep … == 0` passes vacuously), then assert: no value-echo, no `jq .` raw-row echo, no `set -x`, `::add-mask::` before each use, stdin-form writes, `-p soleur-inngest -c prd`, no `ssh`, the conditional env + `environment:`.
+- Test fixtures use unmistakably synthetic non-matching DSNs (security F9, `cq-test-fixtures-synthesized-only`); extend AC14 to fixtures, not just prose.
+
+### C9 (P2) — ADR-100 Decision 6b precision
+Record the **boundary delta** (first CI-consumed read/write token into the isolated `soleur-inngest` project — previously operator-only writes). State plainly: *the dispatch + environment approval is the ack; there is no interactive pre-write value confirmation, by design (AC-NOBODY forbids echoing values).* Cite the transitivity precedent as `doppler_service_token.inngest` (by-reference), NOT `.write` (string-literal, zero edges). Heartbeat fallback mirror lands in the CI-readable config, NOT `soleur-inngest/prd` → no masking-doctrine breach.
+
+### C10 (P2, cross-ref, NOT built in #6369) — on-host flip-guard positive prod assertion
+Data-integrity Q1 P2 edge: the on-host oneshot's ExecStartPre guard should positively require `URI==prod` at flip-time (not merely reject prod pre-arm) to defend a transient dark-URI resolution. That guard lives on the #6178/ADR-100 on-host surface — flagged for the ADR-100 owner, out of #6369 scope.
+
+**Net:** the ordering (Q1) is sound; the four data-integrity P1s (C1/C2/C3/C6) + the four security P1s (C4/C5/C6/C7) are the pre-`/work` must-fixes. `/work` should treat the Phases/ACs above as amended by C1-C9 (C10 is a cross-ref, not in-scope).
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+
+## CTO Decision at /work (2026-07-12 — SUPERSEDES D6/C7 + Phase 2 + AC16 where they conflict)
+
+**Fork:** deepen D6/C7 assumed the prod `INNGEST_POSTGRES_URI` is NOT CI-readable and must be operator-seeded (`INNGEST_POSTGRES_URI_PROD`) into a narrow config. **Live Doppler (value-silent probes at /work Phase 0) contradicts this:** `prd_terraform.INNGEST_POSTGRES_URI` is directly readable by the workflow's existing config-scoped `DOPPLER_TOKEN`, is SHA-identical to canonical `prd.INNGEST_POSTGRES_URI`, uses `:5432`, and is DIFFERENT from the dark `soleur-inngest/prd` value. `INNGEST_POSTGRES_URI_PROD` is absent everywhere.
+
+**Routed to `soleur:engineering:cto` (architecture/security fork — not operator, not unilateral).** **DECISION: Option B — read-through from `prd_terraform`.** op=arm reads BOTH source values (`INNGEST_POSTGRES_URI`, `INNGEST_HEARTBEAT_URL`) from `soleur/prd_terraform` via the existing read-only `DOPPLER_TOKEN` (config-scoped, no `--project/--config` — mirrors `op=backup`'s `HCLOUD_TOKEN` read at `cutover-inngest.yml:304`). Writes unchanged (three to `soleur-inngest/prd` via `DOPPLER_TOKEN_INNGEST_ARM`, `armed` last).
+
+**Supersedes (DROP from D6/C7 + Phase 2 + AC16):**
+- The operator seed `INNGEST_POSTGRES_URI_PROD` — **dropped entirely** (no new secret name; the value is already the live canonical source).
+- The narrow read config `prd_inngest_arm` + narrow read token / any `DOPPLER_TOKEN` re-scoping — **not created**.
+- The post-cutover seed DELETE + seed rotation co-update note — **moot** (no copy to rot/delete).
+- The value-silent freshness assertion (a stale-seed catch) — **replaced** by the G3 positive prod-URI assertion (freshness is now structural: live canonical source).
+
+**RETAINED (unchanged):** the write token `DOPPLER_TOKEN_INNGEST_ARM` + its post-cutover **revoke** (D6/C7 F4 — the token holds standing read+write to the armed prod DSN, independent of read-source); G3 positive prod-URI assertion (prod != dark, contains prod host/ref, `:5432` not `:6543`); AC-NOBODY per-value `::add-mask::` + stdin-only writes; write order (`armed` last, exit-gated); G1 pre-write FSM-state guard; time-bounded single-state Better Stack confirm; the GitHub Environment secret + required-reviewer gate (D5/C4); op=arm FORWARD-ONLY + reverse write in op=rollback (D1/C1).
+
+**Rationale (CTO):** A's "narrow read surface" removes no existing exposure (the value already sits in `prd_terraform`, readable by every prd_terraform-scoped CI job) while ADDING a forbidden human pre-window seed step (`hr-menu-option-ack`, "never defer operator actions") and a stale-copy rotation-drift trap — a seeded DSN that goes stale before the window arms a dead DSN → the sole scheduler cannot connect → every user's crons stall (the single-user incident). Reading the live source at arm-time eliminates that window → B STRENGTHENS the single-user-incident posture; G3 + FSM/quiesce guards remain the defense against writing a wrong/dark value. **Rejected:** (A) seed-once narrow config — removes no exposure, adds human step + drift trap; (C) workflow copies prd_terraform→narrow — machinery to relocate an already-readable value, inherits A's drift risk. Recorded in ADR-100 Decision 6b.
+
+**AC16 revised:** the one-time operator seed is DROPPED. Post-merge operator step reduces to: after the per-merge apply, `DOPPLER_TOKEN_INNGEST_ARM` exists as an environment secret (AC15) — no seed. Phase 2 collapses to a runbook note: "op=arm reads the two source values read-through from `prd_terraform`; no seed."
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->

--- a/knowledge-base/project/specs/feat-one-shot-6369-inngest-op-arm/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6369-inngest-op-arm/session-state.md
@@ -1,0 +1,33 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-12-feat-inngest-op-arm-no-ssh-doppler-arm-flip-plan.md
+- Status: complete
+
+### Errors
+- iac-plan-write-guard.sh PreToolUse hook blocked the plan Write/Edit 3x (denies `doppler secrets set` + operator-provisioning framing). Resolved as designed via `<!-- iac-routing-ack: plan-phase-2-8-reviewed -->` opt-out (Phase 2.8 genuinely reviewed; write token is TF-provisioned; arm-flip values are out-of-band per ADR-100). No unresolved errors.
+- learnings-researcher agent did not return before finalization; substituted by direct greps + four-agent deepen review. Non-blocking.
+
+### Decisions
+- op=arm is FORWARD-ONLY; rollback stays in existing `op=rollback` verb (ADR-100:231 symmetric pair).
+- Pre-write FSM-state guard load-bearing: refuse re-arm over non-terminal/`done` state (re-FLUSHALL = PROD Redis data loss); positive prod-URI assertion (both backends use :5432).
+- Trust reconciliation upgraded to GitHub Environment secret + required-reviewer gate (`environment: inngest-cutover`).
+- New `doppler_service_token.inngest_arm_write` (read/write) in per-merge `-target` allow-list; ADR-100 amended (Decision 6b), no new ADR/C4 edit.
+- Source-of-truth split: HEARTBEAT_URL read-through (TF-owned); POSTGRES_URI operator-seed-once into narrow config, consumed no-SSH by op=arm, deleted post-cutover w/ token revoke. Live prod cutover execution remains operator-gated (single-user-incident).
+
+### Components Invoked
+- Skills: soleur:plan, soleur:deepen-plan
+- Agents: terraform-architect; security-sentinel + data-integrity-guardian + architecture-strategist (deepen triad); Explore x3; learnings-researcher
+- Artifacts: plan .md + tasks.md (commit ba17e60a3)
+
+## Work Phase
+
+### Phase 0 CTO fork — POSTGRES_URI source-of-truth (RESOLVED)
+Live Doppler (value-silent probes) contradicted the plan's D6/C7 assumption: `prd_terraform.INNGEST_POSTGRES_URI` is directly CI-readable, SHA-identical to canonical `prd`, uses `:5432`, and DIFFERS from the dark `soleur-inngest/prd` value. `INNGEST_POSTGRES_URI_PROD` (the plan's proposed seed) absent everywhere.
+
+**Routed to `soleur:engineering:cto` (architecture/security fork; not operator, not unilateral). Decision: Option B — read-through from `prd_terraform` via the existing `DOPPLER_TOKEN`** (same config-scoped read `op=backup` uses for HCLOUD_TOKEN). Supersedes deepen D6/C7.
+- DROP: operator seed `INNGEST_POSTGRES_URI_PROD`, narrow config `prd_inngest_arm`, narrow read token, seed-delete + seed rotation co-update, value-silent freshness assertion.
+- KEEP: write token `DOPPLER_TOKEN_INNGEST_ARM` + post-cutover revoke; G3 positive prod-URI assertion (prod != dark, contains prod host, :5432 not :6543); AC-NOBODY per-value masking + stdin writes; write order (armed last); FSM-state guard; Better Stack confirm.
+- Rationale: A's "narrow surface" is illusory (value already readable in prd_terraform); B removes the only human secret step + the rotation-drift trap (a stale seed could arm a dead DSN → every user's crons stall). Freshness becomes structural (live canonical source).
+- Read spec: both source values read from `soleur/prd_terraform` via existing read-only `DOPPLER_TOKEN` (config-scoped, no --project/--config). Writes to `soleur-inngest/prd` via `DOPPLER_TOKEN_INNGEST_ARM`.
+- FSM state pre-cutover: `INNGEST_CUTOVER_FLIP` unset in soleur-inngest/prd (confirmed).

--- a/knowledge-base/project/specs/feat-one-shot-6369-inngest-op-arm/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6369-inngest-op-arm/tasks.md
@@ -1,0 +1,47 @@
+# Tasks — feat(infra): no-SSH op=arm for the inngest cutover Doppler arm-flip (#6369)
+
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+plan: knowledge-base/project/plans/2026-07-12-feat-inngest-op-arm-no-ssh-doppler-arm-flip-plan.md
+
+> Authoritative source is the plan. The `## Deepen-Plan Findings & Required Changes` (D1-D7) SUPERSEDE the earlier phase/AC text where they conflict — encode the deepen versions.
+
+## Phase 0 — Preconditions (verify, no code)
+- [x] 0.1 Verify the Doppler read-path: can the workflow's prd_terraform `DOPPLER_TOKEN` read the source values? Decide read-through vs. mirror-into-readable-config for HEARTBEAT_URL. Record the verified path in the spec.
+- [x] 0.2 Confirm the `iac-routing-ack` opt-out for op=arm YAML + runbook edits (they contain the Doppler-write literal). Every such Write/Edit carries `<!-- iac-routing-ack: plan-phase-2-8-reviewed -->`.
+- [x] 0.3 Confirm `doppler_project.inngest` + `doppler_environment.inngest_prd` are in tfstate (create-only `-target` no-op).
+
+## Phase 1 — Terraform: write token + GitHub Environment secret (D5)
+- [x] 1.1 Create `apps/web-platform/infra/inngest-arm-write-token.tf`: `doppler_service_token.inngest_arm_write` (read/write, by-reference project/config, name `inngest-cutover-arm`) + `github_repository_environment "inngest_cutover"` (required reviewer) + `github_actions_environment_secret.doppler_token_inngest_arm` (NOT repo-wide). No `ignore_changes`. Header documents blast-radius (incl. armed prod DSN), rotation, transitivity note (precedent `.inngest`, re-provision ordering), post-cutover revoke.
+- [x] 1.2 Add `-target=` lines for the token + env secret (+ env resource) to the per-merge default allow-list in `.github/workflows/apply-web-platform-infra.yml` (near :356-357). NOT the `inngest_host` set; NOT any `OPERATOR_APPLIED_*_EXCLUSIONS`.
+- [x] 1.3 `terraform validate` (confirm the github provider exposes `github_repository_environment`/`github_actions_environment_secret`) + `terraform plan` (canonical triplet + raw R2 exports) → create-only, `0 change, 0 destroy`, no transitive host/project/env create.
+- [x] 1.4 Confirm `plugins/soleur/test/terraform-target-parity.test.ts` passes UNMODIFIED + destroy-guard counter unchanged.
+
+## Phase 2 — POSTGRES_URI source seed (one-time, narrow) (D6)
+- [x] 2.1 Document the one-time seed of `INNGEST_POSTGRES_URI_PROD` into a NARROW CI-readable config (NOT prd_terraform), via Doppler-write stdin — not a TF resource. Only human secret step, pre-window.
+- [x] 2.2 Add the rotation co-update (password rotation must re-seed) + a value-silent pre-window freshness assertion (seed == target).
+- [x] 2.3 HEARTBEAT_URL: prefer read-through; fallback mirror lands in the CI-readable config (not soleur-inngest/prd).
+
+## Phase 3 — op=arm workflow verb, FORWARD-ONLY (D1-D4)
+- [x] 3.1 Add `arm` to the `op` choice options (:22-32). NO `flip_state` input.
+- [x] 3.2 Job env conditional `DOPPLER_TOKEN_INNGEST_ARM: ${{ inputs.op == 'arm' && secrets.DOPPLER_TOKEN_INNGEST_ARM || '' }}` + `environment: inngest-cutover` on the job (D5).
+- [x] 3.3 `arm)` case (template op=quiesce-web; pure Doppler, no webhook): G1 pre-write FSM-state guard (refuse unless ∈ {unset,empty,aborted,rolled-back}) → G2 read+mask each value on its own line → G3 positive prod-URI assertion (PG != dark, contains prod host, reject empty/:6543, value-silent) → G4 write POSTGRES_URI then HEARTBEAT_URL (stdin, exit-gated) → G5 write `armed` last → G6 time-bounded single-state-token Better Stack confirm, branch on done/aborted/rolled-back/timeout.
+- [x] 3.4 Update `apps/web-platform/infra/cutover-inngest-workflow.test.sh`: non-empty awk range assert; no value-echo; no `jq .` raw-row; no `set -x`; `::add-mask::` per value; `-p soleur-inngest -c prd`; stdin form; no ssh; G1+G3 present; conditional env + `environment:`.
+
+## Phase 4 — SEAM removal + rollback write in op=rollback + runbook (D1, D6)
+- [x] 4.1 op=execute SEAM (:607-611) → point 2.2b/2.3 to `op=arm`; keep 2.2a/2.4; update :602-604 comment.
+- [x] 4.2 Fold `INNGEST_CUTOVER_FLIP=rollback` write into existing `op=rollback` (:890) with G1' guard (∈ {flipping,flushed,done}) + conditional env + environment gate + time-bounded `rolled-back` confirm; update :614 SEAM text. Rollback writes ONLY the flip value.
+- [x] 4.3 Runbook `inngest-server.md`: rewrite 2.2b/2.3 SEAM to op=arm; add one-time seed precondition + rotation co-update; add post-cutover token-revoke + seed-delete; update SEAM/operator marker count.
+
+## Phase 5 — End-to-end assembly + dry-run
+- [x] 5.1 Assemble the full no-SSH op order in the runbook; flag 2.2a + 2.4 as the ONLY non-dispatch steps.
+- [x] 5.2 Dry-run validation (no live cutover): op reachability + op=arm read/mask/guard against dark/scratch key (no `armed` write) + time-bounded confirm parses a fresh synthetic `done` and rejects a stale one.
+- [x] 5.3 Note: live prod cutover is operator-gated, NOT an autonomous /work step.
+
+## Phase 6 — ADR + C4
+- [x] 6.1 Amend ADR-100 with Decision 6b (boundary delta = first CI read/write token into soleur-inngest; both reconciliations; dispatch+environment IS the ack, no interactive value confirmation; ordinal = amendment).
+- [x] 6.2 C4: read all three .c4 files; record the no-edit enumeration (or add the ci→doppler edge + run c4 tests if the ADR reviewer judges it material).
+
+## Acceptance gate
+- [x] All AC1-AC14 (pre-merge) green; AC15-AC17 documented as post-merge/operator. CPO sign-off obtained (requires_cpo_signoff). Test scenarios T1-T11 + T-D2..T-D5 implemented.


### PR DESCRIPTION
## Summary
- Adds a no-SSH `op=arm` verb to `cutover-inngest.yml` that performs the three arm-flip writes on the **isolated** `soleur-inngest/prd` Doppler project (`INNGEST_POSTGRES_URI`, `INNGEST_HEARTBEAT_URL`, then `INNGEST_CUTOVER_FLIP=armed` last), removing the last operator secret-write seam from the #6178 cutover.
- TF-provisioned read/write Doppler token published as a **GitHub Environment secret** behind a required-reviewer gate (`inngest-arm-write-token.tf`); the two source values are read **read-through** from `prd_terraform` via the existing read-only `DOPPLER_TOKEN` (CTO decision → ADR-100 Decision 6b; the prod DSN is already CI-readable there, so **no operator seed**).
- Reverse flip write folded into `op=rollback` (forward/reverse stay separate verbs); runbook `inngest-server.md` rewritten to the op=arm/op=rollback dispatches + a post-cutover token revoke.

Closes #6369

## User-Brand Impact
- **Artifact:** `INNGEST_POSTGRES_URI` on `soleur-inngest/prd` + the live PROD inngest Redis cron sorted-set (every user's queued reminders, email-triage, workspace-reconcile-on-push, one-shot crons — the dedicated host is the SOLE scheduler).
- **Vector:** a mis-armed cutover (dark backend, wrong/`:6543` DSN, or a re-arm re-`FLUSHALL`) stalls or double-fires every user's crons; a prod DSN echoed to a run log grants direct DB read/write.
- **Mitigations (all value-silent, AC-NOBODY — no secret ever echoed):** fail-closed config probe → G1 pre-write FSM-state guard (refuse re-arm over armed/flipping/flushed/done) → G3 positive prod-URI assertion (prod != dark, `:5432` not `:6543`, prod project-ref) → per-value `::add-mask::` + stdin-only writes → time-bounded Better Stack `flag:done` confirm. `op=rollback` runs its web re-enable unconditionally (P0-3 recovery) and confirms rolled-back **blocking** before re-enabling web (no two-scheduler double-fire). Write token revoked post-cutover.
- **Brand-survival threshold:** single-user incident

## Changelog
### Infra / CI
- New forward-only `op=arm` + `op=rollback` reverse flip-write in `cutover-inngest.yml`, gated by the `inngest-cutover` GitHub Environment (required reviewer) + a conditional `DOPPLER_TOKEN_INNGEST_ARM`.
- New `doppler_service_token.inngest_arm_write` + `github_repository_environment.inngest_cutover` + `github_actions_environment_secret.doppler_token_inngest_arm`; three `-target` lines added to the per-merge apply allow-list.
- Drift-guard test extended to 200 assertions (emitter flag-parity, fail-closed guards, Half-B-unconditional).
### Docs
- ADR-100 Decision 6b (no-SSH arm-flip; read-through source; C4 no-edit enumeration).
- Runbook: 2.2b/2.3 SEAM → op=arm dispatch; rollback → op=rollback; post-cutover token revoke.

## Test plan
- [x] `terraform validate` + targeted `terraform plan`: 3 to add, 0 change, 0 destroy; no transitive host/project/env create
- [x] `terraform-target-parity.test.ts` passes unmodified (56/56); destroy-guard counter unchanged (28/28)
- [x] `cutover-inngest-workflow.test.sh` drift-guard: 200/0
- [x] scripts test shard: 161/161; `lint-infra-no-human-steps.py`: clean
- [x] G6/rollback Better Stack parse validated against the real on-host emitter (`flag` field)
- [x] Multi-agent review (7 agents): 2 P1 + 6 P2 fixed inline, 0 scope-outs

## Post-merge (automated + operator-gated)
- `DOPPLER_TOKEN_INNGEST_ARM` environment-secret presence — auto-verified in postmerge (the per-merge apply publishes it).
- The **live prod cutover** (dispatching op=arm at a maintenance window) is operator-gated (single-user incident) and tracked by the #6178 cutover epic — not a step this PR introduces or defers.

Generated with [Claude Code](https://claude.com/claude-code)
