### PR TITLE
fix(infra): relocate warm-standby web-2 hel1→fsn1 (cross-DC HA) — unwedge apply-on-merge

### DIFF
--- a/apps/web-platform/infra/server.tf
+++ b/apps/web-platform/infra/server.tf
@@ -109,7 +109,11 @@ resource "hcloud_server" "web" {
   # Spread across distinct physical hosts within the EU location (HA). Attaching to
   # the RUNNING web-1 forces a power-off → maintenance-window apply (an in-place
   # reboot, NOT a replace — verify `0 to destroy` in the plan before applying).
-  placement_group_id = hcloud_placement_group.web_spread.id
+  # A Hetzner placement group is LOCATION-scoped: a host in a different DC than web-1
+  # cannot join web_spread, so it gets null. That is not a downgrade — a cross-DC host
+  # is already spread from web-1 at the DC level (stronger HA than same-DC spread), and
+  # it stays placeable when web-1's DC is capacity-starved (2026-07-13: web-2 hel1→fsn1).
+  placement_group_id = each.value.location == var.web_hosts["web-1"].location ? hcloud_placement_group.web_spread.id : null
 
   # #5921 — the 22 bootstrap scripts + hooks.json were REMOVED from this map (they blew
   # the 32,768-byte Hetzner user_data cap). They are now baked into var.image_name and

--- a/apps/web-platform/infra/variables.tf
+++ b/apps/web-platform/infra/variables.tf
@@ -83,7 +83,13 @@ variable "web_hosts" {
   }))
   default = {
     "web-1" = { location = "hel1", private_ip = "10.0.1.10" }
-    "web-2" = { location = "hel1", private_ip = "10.0.1.11" }
+    # web-2 sits in a DIFFERENT DC from web-1's hel1 (DC-failure resilience). A same-DC
+    # warm standby gives no protection against a hel1 outage, and a `-replace` recreate
+    # DURING a hel1 capacity shortage destroyed web-2 then could not re-place it, wedging
+    # every apply-on-merge on `resource_unavailable` (2026-07-13, #6374 follow-on). fsn1 is
+    # eu-central (10.0.1.0/24 spans it, network.tf) + EU (CLO T-1). Cross-DC hosts cannot
+    # share the location-scoped web_spread placement group — server.tf gates that.
+    "web-2" = { location = "fsn1", private_ip = "10.0.1.11" }
   }
   validation {
     condition     = alltrue([for h in values(var.web_hosts) : contains(["nbg1", "fsn1", "hel1"], h.location)])

--- a/knowledge-base/project/learnings/bug-fixes/2026-07-13-warm-standby-cross-dc-and-replace-capacity-footgun.md
+++ b/knowledge-base/project/learnings/bug-fixes/2026-07-13-warm-standby-cross-dc-and-replace-capacity-footgun.md
@@ -1,0 +1,36 @@
+---
+title: HA hosts must span different DCs; `-replace` recreate during a capacity outage is a self-inflicted deploy-wide outage
+date: 2026-07-13
+category: bug-fixes
+tags: [infra, terraform, hetzner, high-availability, placement-group, warm-standby, capacity]
+severity: high
+related: [6374]
+---
+
+## What happened
+
+While investigating a false-positive inngest health alarm (#6374), the weight-0 warm-standby web host **web-2** was found wedged after a fresh-boot, so it was recreated via the sanctioned `apply-web-platform-infra` **`web-2-recreate`** path (terraform `-replace` of `hcloud_server.web["web-2"]`). web-2 was pinned to **hel1 — the SAME DC as prod web-1**. Hetzner hel1 was capacity-starved at the time, so terraform **destroyed web-2, then could not re-place it** (`error during placement (resource_unavailable)`), and it **retried destroy→create-fail four times**.
+
+Two compounding failures resulted:
+
+1. **web-2 gone** — no warm-standby / failover coverage.
+2. **Every `terraform apply` wedged** — web-2 was still in config (`var.web_hosts`) but no longer in state, so *each* apply-on-merge (routine `Apply web-platform infra` **and** the auto-firing `Apply deploy-pipeline-fix`) tried to recreate it and failed on the same capacity wall. A single failed recreate became a **repo-wide deploy blocker**: an unrelated PR's on-host scripts could not be delivered.
+
+Prod itself stayed healthy throughout (web-1 untouched), which is exactly why this was easy to miss — the damage was to the *deploy pipeline*, not the running app.
+
+## Root causes
+
+- **Same-DC standby.** A warm standby in the same DC as prod protects against a single-host failure but NOT a DC-level outage or a DC-level capacity shortage — and the capacity shortage is precisely when you most need to (re)provision.
+- **`-replace` is destroy-then-create.** For a singleton host, if the create cannot place, you are left strictly worse off than before (host gone + wedged state). There is no automatic rollback.
+- **A destroyed-but-in-config resource poisons all applies.** Terraform reconciles the whole config on every apply; a resource that can't be created blocks every future apply until it's resolved.
+
+## Fixes applied
+
+- **Relocate web-2 hel1 → fsn1** (a different EU DC, eu-central network zone so `10.0.1.11` still attaches; EU per CLO T-1). Cross-DC placement is *stronger* HA than same-DC spread and stays placeable when web-1's DC is capacity-starved. (`variables.tf`)
+- **Gate placement-group membership on co-location with web-1.** Hetzner placement groups are location-scoped, so a cross-DC host can't join `web_spread` — it now gets `null` instead of failing the apply. (`server.tf`)
+
+## Prevent next time
+
+- **Default HA/standby hosts to distinct DCs** (within the same EU network zone for private-net + GDPR). Same-DC redundancy is not redundancy against the failure modes that matter (DC outage, DC capacity).
+- **Treat a host `-replace` during a suspected capacity window as high-risk.** Prefer capacity-check-first or create-before-destroy for a singleton; at minimum, know that a failed create leaves the host gone AND wedges applies.
+- **Workflow improvement (follow-on):** the `apply-web-platform-infra` `web-2-recreate` path should surface the destroy-then-can't-recreate risk (and ideally pre-check target-DC capacity or offer a relocate-instead option) rather than silently destroying first. Tracked for the recreate-path hardening.


### PR DESCRIPTION
## Summary
- Relocates the weight-0 warm-standby web host **web-2** from **hel1 → fsn1** (a different EU DC) for DC-failure resilience.
- Unwedges terraform apply-on-merge: web-2 was `-replace`d during a hel1 capacity shortage, which destroyed it then failed to re-place it (`resource_unavailable`), and every subsequent apply reconciled the now-missing web-2 and failed on the same wall. fsn1 is in the eu-central network zone (so `10.0.1.11` still attaches) and is a distinct DC, so the recreate is placeable and the standby survives a hel1 outage.
- Gates placement-group membership on co-location with web-1 (Hetzner placement groups are location-scoped, so a cross-DC host gets `null` instead of failing the apply — cross-DC is already stronger HA-spread than same-DC).
- Adds a learning capturing the same-DC-standby + `-replace`-during-capacity-outage footgun.

## User-Brand Impact
- **Artifact/vector:** the web-host cluster terraform (`var.web_hosts`, `hcloud_server.web` placement) — infra reliability + the deploy pipeline.
- **Failure mode addressed:** a same-DC warm standby gives no protection against a hel1 DC/capacity failure, and a failed `-replace` recreate wedged all apply-on-merge (a repo-wide deploy blocker) with no prod impact but no way to ship infra changes.
- **Brand-survival threshold:** aggregate pattern

## Changelog
- Move web-2 to fsn1 (distinct EU DC) for cross-DC failover and placeable recreation.
- Make `placement_group_id` conditional on co-location with web-1 (location-scoped placement groups).
- Add a bug-fix learning on cross-DC HA + the `-replace`-during-capacity-shortage footgun.

## Test plan
- [x] `terraform fmt` clean on both files.
- [ ] ⏳ On merge, `Apply web-platform infra` creates web-2 in fsn1 (`resource_unavailable` gone) and `Apply deploy-pipeline-fix` succeeds, delivering the pending on-host inngest-liveness scripts.

Ref #6374

Generated with [Claude Code](https://claude.com/claude-code)
