### PR TITLE
fix(followthrough): close two false-PASS anchors in the #6416 soak probe

### DIFF
--- a/knowledge-base/project/learnings/2026-07-15-guard-gate-and-probe-must-pin-the-thing-they-name.md
+++ b/knowledge-base/project/learnings/2026-07-15-guard-gate-and-probe-must-pin-the-thing-they-name.md
@@ -79,6 +79,21 @@ its T4/T5 were the only non-vacuous new tests in the first pass.
 
 ### 3. A probe that finds no failure has not found success.
 
+> **Post-merge addendum — the shipped probe had two more of these, found only against a REAL
+> log.** Ten agents reviewed it and missed them, because they are unobservable until a real
+> post-fix job log exists. (a) The degraded anchor required a literal `::warning::`, but GitHub
+> **renders** a `::warning::` workflow command as `##[warning]` in the job log — so the anchor
+> matched the emitter's echoed SOURCE and missed every real emit. (b) The liveness anchor
+> `copied .* to 127.0.0.1:5000/` matched **the PR's own commit message**, which the release job
+> log carries via the release-notes body and which quotes the anchor verbatim. Composed, they
+> counted a genuinely degraded run as clean. Fixed in PR #6451.
+>
+> **Two rules fall out.** An anchor over a CI job log must be validated against a **real emit**,
+> never the emitter's source — and must account for the platform **rendering** workflow commands
+> (`::warning::` → `##[warning]`). And because the job log contains the PR/commit body, **any
+> anchor a commit message could quote is unsafe by construction**; require an interpolated
+> runtime value (`copied v[0-9]`) that only the real `echo` can produce.
+
 The follow-through probe had **three false-verdict bugs found during work and two more at
 review** — every one a different way to certify silence:
 
@@ -201,12 +216,18 @@ one artifact and have every point-of-use *point* at it.
   hyphen. Would have auto-resolved issue #6416 at squash merge while the harm was live, defeating
   the `Ref`-not-`Closes` discipline the tasks file explicitly chose. — **Recovery:** rewrote the
   body and both commit messages (`auto-resolves issue #N`).
-  > **Then I did it a third time — in the commit that captures THIS learning.** The compound
-  > commit body said *"…that would have closed #6416 at merge"* while describing the trap. Caught
-  > only because I ran the scan again out of habit. Three violations in one session, by an author
-  > who had just written the rule down, is the strongest possible evidence that **the prose rule
-  > does not work and the scan is the control.** The scan is cheap (one `grep -oniE`) and the
-  > failure is silent and irreversible-at-merge.
+  > **It happened FIVE times in one session**, by an author who had just written the rule down:
+  > (1) the PR body, (2)+(3) two commit bodies, (4) the commit that captures THIS learning
+  > (*"…that would have closed #6416 at merge"* — while describing the trap), and (5) the body of
+  > the follow-up PR that fixes the probe (*"the probe is what auto-resolves #6416 on soak
+  > evidence"* — describing the correct behaviour, with auto-merge already queued, so that one
+  > would actually have fired).
+  >
+  > **Every single one was prose describing the correct behaviour.** That is the point: the
+  > natural way to *write about* an auto-close is to use the keyword next to the number. Intent
+  > cannot avoid this trap, vigilance cannot, and having authored the rule minutes earlier cannot.
+  > Only a mechanical scan catches it. The scan is one `grep -oniE`; the failure is silent and
+  > irreversible at merge.
   — **Prevention:** the rule exists (2026-06-29 learning) and `/ship`'s `auto-close-scan.sh`
   catches commit bodies — but it runs at **ship**, and both the PR body (authored at review) and
   the compound commit (authored after) precede it. **Run the scan at every authoring site, not

--- a/scripts/followthroughs/zot-mirror-connector-6416.sh
+++ b/scripts/followthroughs/zot-mirror-connector-6416.sh
@@ -162,9 +162,17 @@ while read -r run_id created_at; do
   # alternate covers degraded() firing before ZOT is assigned: its emitter reads
   # `${ZOT:-<image>}`, so a future call site above that assignment would emit the
   # literal `<image>` and slip an IP-only anchor — counting a degraded run as clean.
-  if grep -qE '::warning::zot mirror degraded for (127\.0\.0\.1:5000/[^ ]*|<image>) \(rc=' <<<"$logs"; then
+  #
+  # BOTH `::warning::` and `##[warning]` are accepted, and that is load-bearing:
+  # GitHub RENDERS a `::warning::` workflow command as `##[warning]` in the job log.
+  # The emitter's SOURCE echo carries the literal `::warning::`; the REAL emit carries
+  # `##[warning]`. An anchor matching only `::warning::` therefore matches the source
+  # and MISSES every real degraded run — verified against release run 29411418298,
+  # whose genuine emit reads:
+  #   ##[warning]zot mirror degraded for 127.0.0.1:5000/... (rc=bridge) — release UNAFFECTED
+  if grep -qE '(::warning::|##\[warning\])zot mirror degraded for (127\.0\.0\.1:5000/[^ ]*|<image>) \(rc=' <<<"$logs"; then
     echo "FAIL: run ${run_id} (${created_at}) reports a DEGRADED zot mirror."
-    grep -oE '::warning::zot mirror degraded for [^ ]+ \(rc=[^)]*\)' <<<"$logs" | head -2 | sed 's/^/  /'
+    grep -oE '(::warning::|##\[warning\])zot mirror degraded for [^ ]+ \(rc=[^)]*\)' <<<"$logs" | head -2 | sed 's/^/  /'
     echo "  If rc=bridge: the CF tunnel connector serving registry.soleur.ai could not route to"
     echo "  10.0.1.30:5000. Verify EVERY web host is a 10.0.1.0/24 member (ADR-114 I1):"
     echo "    hcloud server describe soleur-web-2 -o json | jq .private_net    # must NOT be []"
@@ -174,11 +182,21 @@ while read -r run_id created_at; do
   # POSITIVE LIVENESS — the run must prove the mirror actually COMPLETED, not merely
   # that no failure was found. Without this, any change that stops the mirror from
   # emitting at all (step renamed, run block restructured, log-read silently broken)
-  # reads as "no degraded found" → clean → PASS → the sweeper closes #6416 on the
-  # ABSENCE of a signal. That is #6416's own defect class; a probe built to prove the
-  # fix must not reproduce it. Source-safe: the emitter echoes `to ${ZOT} and`, so
-  # only a real interpolated emit matches the literal IP.
-  if ! grep -qE 'zot mirror ok: copied .* to 127\.0\.0\.1:5000/' <<<"$logs"; then
+  # reads as "no degraded found" → clean → PASS → the sweeper auto-resolves #6416 on
+  # the ABSENCE of a signal. That is #6416's own defect class; a probe built to prove
+  # the fix must not reproduce it.
+  #
+  # `copied v[0-9][^ ]*,` — the INTERPOLATED version is load-bearing, not decoration.
+  # The release job log contains the PR/commit MESSAGE (via the release-notes body),
+  # and #6421's own commit prose quotes this very anchor:
+  #   marker ("zot mirror ok: copied ... to 127.0.0.1:5000/")
+  # A `copied .* to 127.0.0.1:5000/` anchor MATCHES that sentence. Combined with the
+  # `::warning::`-only degraded anchor above, the two composed into a FALSE PASS on a
+  # genuinely degraded run (verified against 29411418298: degraded missed, liveness
+  # satisfied by the echoed commit message → counted clean). Requiring `v<version>,`
+  # cannot be satisfied by prose — only `echo "zot mirror ok: copied v${VERSION}, ..."`
+  # produces it.
+  if ! grep -qE 'zot mirror ok: copied v[0-9][^ ]*, .* to 127\.0\.0\.1:5000/' <<<"$logs"; then
     echo "TRANSIENT: run ${run_id} ran the mirror (conclusion=${mirror}) but emitted neither a degraded warning nor the success marker." >&2
     echo "  The probe cannot certify a run whose producer left no trace — refusing to count it clean." >&2
     exit 2


### PR DESCRIPTION
## Two false-PASS anchors in the #6416 soak probe, caught by the first real post-fix release

**Ref #6416.** Follow-up to #6421, which shipped this probe. The probe is what auto-resolves issue #6416 on soak evidence — a false PASS would close the issue while zot is still empty. Both defects are proven against a real run, not reasoned about.

### The bugs

**1. The degraded anchor could never match a real emit.** It required a literal `::warning::`. GitHub **renders** a `::warning::` workflow command as `##[warning]` in the job log. So the anchor matched the emitter's *echoed source* and missed every genuine emit. The real line from run [29411418298](https://github.com/jikig-ai/soleur/actions/runs/29411418298):

```
##[warning]zot mirror degraded for 127.0.0.1:5000/jikig-ai/soleur-*** (rc=bridge) — release UNAFFECTED (GHCR primary/break-glass)
```

**2. The liveness anchor matched #6421's own commit message.** The release job log carries the PR/commit body via the release-notes payload — and #6421's prose quotes the anchor verbatim:

```
marker ("zot mirror ok: copied ... to 127.0.0.1:5000/")
```

`copied .* to 127\.0\.0\.1:5000/` matches that sentence.

### They compose into a false PASS

Simulated against the real log of 29411418298 — a **genuinely degraded** run:

| probe step | result |
|---|---|
| mirror != skipped | passes (it ran) |
| degraded anchor | **MISSES** (real emit is `##[warning]`) |
| liveness anchor | **MATCHES** — the echoed commit message |
| verdict | **counted CLEAN** |

Five such runs would have auto-resolved issue #6416 while zot was not backfilled at all.

### Fix

- Degraded: accept `(::warning::|##\[warning\])`.
- Liveness: require the interpolated `copied v[0-9][^ ]*,` — only `echo "zot mirror ok: copied v${VERSION}, ..."` can produce it; prose cannot.

Verified against the same real log: degraded now matches (probe FAILs 29411418298 correctly); liveness no longer matches the echoed prose but still matches a genuine success emit; the live end-to-end run exits 1 against today's still-broken state — the honest verdict.

### Why review missed it

Ten agents reviewed #6421 and this survived, because it is only observable against a **real post-fix job log** — which did not exist until the merge. The generalizable lesson (added to the #6416 learning): an anchor over a CI job log must be validated against a **real emit**, never the emitter's source, and must account for the platform **rendering** workflow commands. And because the job log contains the PR/commit body, **any anchor a commit message could quote is unsafe by construction** — here, the PR's own prose was the false positive.

## Changelog

- Fix two anchors in the #6416 zot-mirror soak probe that together counted a degraded release as clean.
