### PR TITLE
fix(observability): betterstack-query.sh read only the hot window, silently truncating every soak

### DIFF
--- a/scripts/betterstack-query.sh
+++ b/scripts/betterstack-query.sh
@@ -80,6 +80,15 @@ export BS_TABLE="${BS_TABLE:-t520508_soleur_inngest_vector_prd_3_logs}"
 # the runbook (betterstack-log-query.md §Query mechanics). Verified disjoint on 2026-07-15:
 # 891 rows / 891 distinct / 0 dupes over 7d, archive ending 19:13:46 and hot starting
 # 19:15:02 — so UNION ALL does not double-count (load-bearing: soak gates COUNT events).
+#
+# An explicit BS_TABLE_S3 (env OR --table-s3) always wins; S3_EXPLICIT records that so the
+# post-flag re-derivation below cannot clobber it. Seeding the sentinel from the ENV here —
+# not only from the flag — is load-bearing: otherwise `BS_TABLE_S3=other_s3` is accepted,
+# silently ignored, and the caller gets rows from the DEFAULT archive with no error, because
+# the derived name exists and the query succeeds. That is this script's own headline bug
+# (asks for X, gets Y, exit 0) reintroduced one level down.
+S3_EXPLICIT=0
+[[ -n "${BS_TABLE_S3:-}" ]] && S3_EXPLICIT=1
 export BS_TABLE_S3="${BS_TABLE_S3:-${BS_TABLE%_logs}_s3}"
 
 run_sql() {
@@ -107,7 +116,6 @@ fi
 
 # --- Mode 2: convenience flags ---
 SINCE="1h"; UNTIL=""; LIMIT=100; RAW_ONLY=0; NO_ARCHIVE=0
-S3_EXPLICIT=0
 GREPS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -124,8 +132,32 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Re-derive the archive name AFTER flag parsing so `--table` and `--table-s3` are
-# order-independent: an explicit --table-s3 always wins, whichever side it was passed on.
-(( S3_EXPLICIT )) || BS_TABLE_S3="${BS_TABLE%_logs}_s3"
+# order-independent: an explicit --table-s3 (or BS_TABLE_S3 env) always wins, whichever
+# side it was passed on.
+if (( ! S3_EXPLICIT )); then
+  # Only the `_logs` suffix has a known `_s3` counterpart. The runbook documents `_metrics`
+  # and `_spans` tables too; guessing `<name>_metrics_s3` for those would invent a table the
+  # caller never named — silently querying the wrong source if it happens to exist. Demand
+  # an explicit archive name instead of guessing.
+  if [[ "$BS_TABLE" != *_logs ]]; then
+    if (( NO_ARCHIVE )); then
+      BS_TABLE_S3=""   # unused on this path; nothing to derive.
+    else
+      cat >&2 <<EOF
+betterstack-query.sh: cannot derive an archive table from BS_TABLE='${BS_TABLE}'.
+
+Only <name>_logs has a known <name>_s3 counterpart. For any other table, name the archive
+explicitly or opt out of it:
+
+  --table-s3 <archive_table>   (or BS_TABLE_S3=<archive_table>)
+  --no-archive                 (hot window only — returns ~40 minutes; see the header)
+EOF
+      exit 64
+    fi
+  else
+    BS_TABLE_S3="${BS_TABLE%_logs}_s3"
+  fi
+fi
 export BS_TABLE_S3
 
 # Build the WHERE clause. `dt` is the ClickHouse event-time column.
@@ -158,17 +190,31 @@ fi
 # LIMIT apply to the COMBINED set — pushing them inside either arm would truncate each
 # half independently and interleave wrongly.
 #
+# LIMIT takes the NEWEST rows (inner ORDER BY dt DESC), then the outer ORDER BY dt ASC
+# restores chronological output. Both halves are load-bearing:
+#   - DESC inner: before the archive arm existed the window was structurally <=40 min, so
+#     LIMIT effectively never bound and ASC+LIMIT was harmless. Against a real 24h window it
+#     bites — the runbook's own `--since 48h --grep SOLEUR_CLAUDE_COST --limit 20` would
+#     answer "show me recent costs" with the OLDEST 20 markers, i.e. ~48h stale. "Most
+#     recent N" is what every caller of a log tail means.
+#   - ASC outer: callers (and humans) read oldest->newest; flipping output order would be a
+#     silent behavior change for anything parsing the stream positionally.
+#
 # FAIL LOUD, never silently hot-only: returning a short answer to `--since 24h` is the
 # exact failure this fix exists to remove, and it is invisible at the call site (a caller
 # counting events sees "not yet filled", not "your window was truncated"). If the archive
 # arm errors, the whole query errors and the caller must opt out deliberately with
 # --no-archive rather than be handed partial data it will read as complete.
 if (( NO_ARCHIVE )); then
-  run_sql "SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE} ORDER BY dt ASC LIMIT ${LIMIT} FORMAT JSONEachRow"
+  run_sql "SELECT dt, raw FROM (
+  SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE} ORDER BY dt DESC LIMIT ${LIMIT}
+) ORDER BY dt ASC FORMAT JSONEachRow"
 else
   run_sql "SELECT dt, raw FROM (
-  SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE}
-  UNION ALL
-  SELECT dt, raw FROM s3Cluster(primary, ${BS_TABLE_S3}) WHERE _row_type = 1 AND (${WHERE})
-) ORDER BY dt ASC LIMIT ${LIMIT} FORMAT JSONEachRow"
+  SELECT dt, raw FROM (
+    SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE}
+    UNION ALL
+    SELECT dt, raw FROM s3Cluster(primary, ${BS_TABLE_S3}) WHERE _row_type = 1 AND (${WHERE})
+  ) ORDER BY dt DESC LIMIT ${LIMIT}
+) ORDER BY dt ASC FORMAT JSONEachRow"
 fi

--- a/scripts/betterstack-query.sh
+++ b/scripts/betterstack-query.sh
@@ -30,7 +30,16 @@
 #      "SELECT dt, raw FROM remote($BS_TABLE) WHERE … LIMIT 50 FORMAT JSONEachRow"
 #   2. Convenience flags (no SQL arg): --since <Nh|Nm|ISO>, --until <ISO>,
 #      --grep <substr> (repeatable, OR-combined), --limit <N>, --raw-only
-#      (exclude host metrics + journald noise).
+#      (exclude host metrics + journald noise), --no-archive (hot window only —
+#      see below), --table / --table-s3 (override either table).
+#
+# HOT WINDOW vs ARCHIVE: mode 2 queries remote(<..._logs>) UNION ALL
+# s3Cluster(primary, <..._s3>), because remote() alone is ONLY the hot window (~40
+# minutes on 2026-07-15). Anything asking for a real soak span MUST include the archive
+# arm or it gets a silently short answer. --no-archive opts out (hot-only, faster);
+# do not reach for it to work around an archive error — the short answer is the bug.
+# Raw SQL (mode 1) is verbatim: write the UNION yourself, using the $BS_TABLE and
+# $BS_TABLE_S3 tokens (both are substituted).
 #
 # Output: JSONEachRow (one JSON object per line) on stdout. Errors to stderr.
 set -uo pipefail
@@ -62,6 +71,17 @@ fi
 # Table identifier — overridable for other sources via BS_TABLE.
 export BS_TABLE="${BS_TABLE:-t520508_soleur_inngest_vector_prd_3_logs}"
 
+# ARCHIVE table. `remote(..._logs)` is ONLY the hot window — on 2026-07-15 it held ~40
+# MINUTES. Rows older than that live in the s3 archive and are invisible to remote(), so a
+# hot-only query silently answers `--since 24h` with 40 minutes of rows: not an error, just
+# a short answer. That is what kept #6288 open since 2026-07-10 — its soak gate needs
+# ZOT_MIN_SOAK_SPAN_SEC=7200 (2h) of span and could never reach PASS through the keyhole,
+# reporting "TRANSIENT: soak not yet filled" forever. Both halves are UNION ALL-combined per
+# the runbook (betterstack-log-query.md §Query mechanics). Verified disjoint on 2026-07-15:
+# 891 rows / 891 distinct / 0 dupes over 7d, archive ending 19:13:46 and hot starting
+# 19:15:02 — so UNION ALL does not double-count (load-bearing: soak gates COUNT events).
+export BS_TABLE_S3="${BS_TABLE_S3:-${BS_TABLE%_logs}_s3}"
+
 run_sql() {
   # $1 = SQL. Credentials via Basic auth; never echoed.
   curl -sS --fail-with-body --max-time 60 \
@@ -76,12 +96,18 @@ run_sql() {
 # here so the table identifier survives `doppler run -- ... "$BS_TABLE"` quoting
 # (the env var would otherwise stay unexpanded inside the single-quoted arg).
 if [[ $# -ge 1 && "$1" =~ ^[[:space:]]*(SELECT|WITH|SHOW)[[:space:]] ]]; then
-  run_sql "${1//\$BS_TABLE/$BS_TABLE}"
+  # $BS_TABLE_S3 MUST be substituted before $BS_TABLE: the latter is a prefix of the
+  # former, so the reverse order would rewrite `$BS_TABLE_S3` into `<hot_table>_S3` —
+  # a table that does not exist — and the caller would see a confusing UNKNOWN_TABLE
+  # instead of their archive rows.
+  sql="${1//\$BS_TABLE_S3/$BS_TABLE_S3}"
+  run_sql "${sql//\$BS_TABLE/$BS_TABLE}"
   exit $?
 fi
 
 # --- Mode 2: convenience flags ---
-SINCE="1h"; UNTIL=""; LIMIT=100; RAW_ONLY=0
+SINCE="1h"; UNTIL=""; LIMIT=100; RAW_ONLY=0; NO_ARCHIVE=0
+S3_EXPLICIT=0
 GREPS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -90,10 +116,17 @@ while [[ $# -gt 0 ]]; do
     --grep)  GREPS+=("$2"); shift 2 ;;
     --limit) LIMIT="$2"; shift 2 ;;
     --raw-only) RAW_ONLY=1; shift ;;
+    --no-archive) NO_ARCHIVE=1; shift ;;
     --table) BS_TABLE="$2"; export BS_TABLE; shift 2 ;;
+    --table-s3) BS_TABLE_S3="$2"; S3_EXPLICIT=1; export BS_TABLE_S3; shift 2 ;;
     *) echo "unknown flag: $1" >&2; exit 64 ;;
   esac
 done
+
+# Re-derive the archive name AFTER flag parsing so `--table` and `--table-s3` are
+# order-independent: an explicit --table-s3 always wins, whichever side it was passed on.
+(( S3_EXPLICIT )) || BS_TABLE_S3="${BS_TABLE%_logs}_s3"
+export BS_TABLE_S3
 
 # Build the WHERE clause. `dt` is the ClickHouse event-time column.
 # --since accepts Nh / Nm / Nd (relative) or a literal 'YYYY-MM-DD HH:MM:SS'.
@@ -121,4 +154,21 @@ if (( ${#GREPS[@]} > 0 )); then
   WHERE="${WHERE} AND (${ORS})"
 fi
 
-run_sql "SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE} ORDER BY dt ASC LIMIT ${LIMIT} FORMAT JSONEachRow"
+# Hot window + s3 archive, UNION ALL-combined (runbook §Query mechanics). ORDER BY and
+# LIMIT apply to the COMBINED set — pushing them inside either arm would truncate each
+# half independently and interleave wrongly.
+#
+# FAIL LOUD, never silently hot-only: returning a short answer to `--since 24h` is the
+# exact failure this fix exists to remove, and it is invisible at the call site (a caller
+# counting events sees "not yet filled", not "your window was truncated"). If the archive
+# arm errors, the whole query errors and the caller must opt out deliberately with
+# --no-archive rather than be handed partial data it will read as complete.
+if (( NO_ARCHIVE )); then
+  run_sql "SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE} ORDER BY dt ASC LIMIT ${LIMIT} FORMAT JSONEachRow"
+else
+  run_sql "SELECT dt, raw FROM (
+  SELECT dt, raw FROM remote(${BS_TABLE}) WHERE ${WHERE}
+  UNION ALL
+  SELECT dt, raw FROM s3Cluster(primary, ${BS_TABLE_S3}) WHERE _row_type = 1 AND (${WHERE})
+) ORDER BY dt ASC LIMIT ${LIMIT} FORMAT JSONEachRow"
+fi

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -153,6 +153,11 @@ if want_scripts; then
   # gate's own suite overrides the value to stay hermetic, so the shipped default was asserted
   # nowhere. Drift makes the gate advise a location terraform rejects.
   run_suite "tests/scripts/eu-location-allowset-parity" bash tests/scripts/test-eu-location-allowset-parity.sh
+  # betterstack-query.sh hot+archive UNION (#6288). remote() alone is the ~40-minute hot
+  # window, so a hot-only query answers `--since 24h` with 40 minutes — no error, just a
+  # short answer. That silently starved every soak gate built on it (#6288's needs 2h of
+  # span and could never PASS). Hermetic: stubs curl, asserts SQL shape, never live rows.
+  run_suite "tests/scripts/betterstack-query-archive" bash tests/scripts/test-betterstack-query-archive.sh
   run_suite "tests/scripts/classifier-regex-parity" bash tests/scripts/test_classifier_regex_parity.sh
   run_suite "tests/scripts/rule-id-regex-parity" python3 -m unittest tests.scripts.test_rule_id_regex_parity
   run_suite "tests/scripts/rule-metrics-aggregate" bash tests/scripts/test-rule-metrics-aggregate.sh

--- a/tests/scripts/test-betterstack-query-archive.sh
+++ b/tests/scripts/test-betterstack-query-archive.sh
@@ -44,6 +44,19 @@ capture_sql() {
   ' _ "$TARGET" "$@" 2>/dev/null
 }
 
+# Same, but the curl stub exits non-zero — used to prove the failure propagates to the
+# caller rather than being swallowed (the script runs under `set -uo pipefail`, NOT -e).
+run_with_failing_curl() {
+  BETTERSTACK_QUERY_HOST=stub \
+  BETTERSTACK_QUERY_USERNAME=stub \
+  BETTERSTACK_QUERY_PASSWORD=stub \
+  bash -c '
+    curl() { return 22; }
+    source "$1" "${@:2}"
+  ' _ "$TARGET" "$@" >/dev/null 2>&1
+  printf '%s' "$?"
+}
+
 # --- 1. default (mode 2) unions hot + archive ---
 sql="$(capture_sql --since 24h --grep MARKER)"
 case "$sql" in
@@ -66,13 +79,17 @@ case "$sql" in
   *) bad "archive arm filters _row_type = 1" "got: ${sql:0:180}" ;;
 esac
 
-# ORDER BY / LIMIT must apply to the COMBINED set, not inside either arm — otherwise each
-# half is truncated independently and the merge interleaves wrongly.
-outer="${sql##*)}"
-case "$outer" in
-  *"ORDER BY dt ASC"*"LIMIT"*) ok "ORDER BY + LIMIT apply to the combined set" ;;
-  *) bad "ORDER BY + LIMIT apply to the combined set" "outer tail: ${outer:0:120}" ;;
-esac
+# LIMIT must apply to the COMBINED set, never inside an arm: a per-arm LIMIT truncates each
+# half independently, so the merged result silently drops rows the caller matched. Pin it
+# structurally — exactly one LIMIT, and nothing before the UNION ALL carries one. (Ordering
+# itself is asserted precisely below, in the newest-N check.)
+lim_count="$(grep -o 'LIMIT' <<<"$sql" | wc -l | tr -d ' ')"
+arms_before_union="${sql%%UNION ALL*}"
+if [[ "$lim_count" == "1" && "$arms_before_union" != *LIMIT* ]]; then
+  ok "LIMIT applies once, to the combined set (not per-arm)"
+else
+  bad "LIMIT applies once, to the combined set (not per-arm)" "count=$lim_count hot_arm_has_limit=$([[ "$arms_before_union" == *LIMIT* ]] && echo yes || echo no)"
+fi
 
 # The time predicate must reach BOTH arms — a hot-only WHERE would drag the whole archive.
 hits="$(grep -o 'INTERVAL 24 HOUR' <<<"$sql" | wc -l | tr -d ' ')"
@@ -119,6 +136,49 @@ case "$raw" in
     ok "raw SQL substitutes \$BS_TABLE_S3 before \$BS_TABLE" ;;
   *) bad "raw SQL substitutes \$BS_TABLE_S3 before \$BS_TABLE" "got: ${raw:0:160}" ;;
 esac
+
+# --- 5. BS_TABLE_S3 as an ENV VAR is honored in mode 2, not just as a flag ---
+# Regression pin: the sentinel was originally set only by --table-s3, so the post-flag
+# re-derivation clobbered an env-supplied BS_TABLE_S3. The caller then queried the DEFAULT
+# archive and got rows from the wrong source with NO error (the derived name exists, so the
+# query succeeds) — this script's own headline bug, one level down. BS_TABLE's env override
+# already survived both modes; BS_TABLE_S3's must too.
+sql_env="$(BS_TABLE_S3=my_custom_archive_s3 capture_sql --since 1h)"
+case "$sql_env" in
+  *"s3Cluster(primary, my_custom_archive_s3)"*) ok "BS_TABLE_S3 env override honored in mode 2" ;;
+  *) bad "BS_TABLE_S3 env override honored in mode 2" "override dropped: ${sql_env:0:180}" ;;
+esac
+
+# --- 6. LIMIT takes the NEWEST rows, output stays chronological ---
+# ASC+LIMIT was harmless while the window was structurally <=40min; against a real 24h it
+# returns the OLDEST N ("recent costs" -> 48h-stale markers).
+sql_lim="$(capture_sql --since 48h --limit 20)"
+inner_desc=0 outer_asc=0
+[[ "$sql_lim" == *"ORDER BY dt DESC LIMIT 20"* ]] && inner_desc=1
+[[ "${sql_lim##*LIMIT 20}" == *"ORDER BY dt ASC"* ]] && outer_asc=1
+if (( inner_desc && outer_asc )); then ok "LIMIT takes newest N (inner DESC), output re-sorted ASC"
+else bad "LIMIT takes newest N (inner DESC), output re-sorted ASC" "inner_desc=$inner_desc outer_asc=$outer_asc :: ${sql_lim:0:220}"; fi
+
+# --- 7. a non-_logs table refuses to guess an archive name ---
+out_rc="$(BETTERSTACK_QUERY_HOST=stub BETTERSTACK_QUERY_USERNAME=stub BETTERSTACK_QUERY_PASSWORD=stub \
+  bash "$TARGET" --since 1h --table t520508_foo_metrics >/dev/null 2>&1; printf '%s' "$?")"
+if [[ "$out_rc" == "64" ]]; then ok "non-_logs table errors rather than inventing <name>_s3"
+else bad "non-_logs table errors rather than inventing <name>_s3" "expected rc=64, got $out_rc"; fi
+
+# ...but --no-archive on a non-_logs table is fine (nothing to derive).
+sql_nl="$(capture_sql --since 1h --table t520508_foo_metrics --no-archive)"
+case "$sql_nl" in
+  *"remote(t520508_foo_metrics)"*) ok "--no-archive works on a non-_logs table" ;;
+  *) bad "--no-archive works on a non-_logs table" "got: ${sql_nl:0:140}" ;;
+esac
+
+# --- 8. failure propagates (fail-loud is the PR's headline claim; pin it) ---
+# Guards against a future run_sql refactor swallowing the status. No `set -e` here, so this
+# is not self-evident from reading the script.
+rc_u="$(run_with_failing_curl --since 1h)"
+rc_n="$(run_with_failing_curl --since 1h --no-archive)"
+if [[ "$rc_u" != "0" && "$rc_n" != "0" ]]; then ok "a failing query exits non-zero (both arms)"
+else bad "a failing query exits non-zero (both arms)" "union rc=$rc_u no-archive rc=$rc_n"; fi
 
 printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
 [[ "$fail" -eq 0 ]]

--- a/tests/scripts/test-betterstack-query-archive.sh
+++ b/tests/scripts/test-betterstack-query-archive.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Pins scripts/betterstack-query.sh's hot+archive query shape (#6288).
+#
+# WHY THIS EXISTS: the script queried ONLY remote(<..._logs>) — the hot window, ~40
+# MINUTES of rows on 2026-07-15. It never errored; it just answered `--since 24h` with 40
+# minutes. That silent truncation is invisible at the call site, and it kept #6288 open
+# from 2026-07-10: scripts/followthroughs/zot-restart-plateau-6288.sh needs
+# ZOT_MIN_SOAK_SPAN_SEC=7200 (2h) of span, so it reported "TRANSIENT: soak not yet filled"
+# forever against a window that could never contain 2h. A short answer that looks like a
+# complete one is the failure mode being pinned here.
+#
+# HERMETIC: run_sql is redefined to capture the generated SQL instead of issuing it — no
+# network, no BETTERSTACK_QUERY_* creds, no live rows (cq-test-fixtures-synthesized-only).
+# We assert the SQL SHAPE, never live data, because availability and row counts are
+# time-varying and must never be encoded in a test.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="${SCRIPT_DIR}/scripts/betterstack-query.sh"
+[[ -r "$TARGET" ]] || { echo "FAIL: cannot read $TARGET" >&2; exit 1; }
+
+pass=0 fail=0
+ok()   { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+bad()  { printf '  FAIL %s\n     %s\n' "$1" "${2:-}" >&2; fail=$((fail + 1)); }
+
+# Run the script with `curl` stubbed to print the SQL it would POST, instead of issuing it.
+# Intercepting at the curl layer (not run_sql) is deliberate: the script DEFINES run_sql, so
+# sourcing it would overwrite any run_sql stub. curl is the real egress boundary — stubbing
+# it also proves no request escapes. Creds are faked to clear the guard; they are never sent.
+capture_sql() {
+  BETTERSTACK_QUERY_HOST=stub \
+  BETTERSTACK_QUERY_USERNAME=stub \
+  BETTERSTACK_QUERY_PASSWORD=stub \
+  bash -c '
+    curl() {
+      # The SQL is the argument to -d. Print it and swallow the rest.
+      while [[ $# -gt 0 ]]; do
+        [[ "$1" == "-d" ]] && { printf "%s" "$2"; return 0; }
+        shift
+      done
+      return 0
+    }
+    source "$1" "${@:2}"
+  ' _ "$TARGET" "$@" 2>/dev/null
+}
+
+# --- 1. default (mode 2) unions hot + archive ---
+sql="$(capture_sql --since 24h --grep MARKER)"
+case "$sql" in
+  *"UNION ALL"*) ok "default query UNION ALLs hot + archive" ;;
+  *) bad "default query UNION ALLs hot + archive" "no UNION ALL in: ${sql:0:180}" ;;
+esac
+case "$sql" in
+  *"remote(t520508_soleur_inngest_vector_prd_3_logs)"*) ok "hot arm queries remote(<..._logs>)" ;;
+  *) bad "hot arm queries remote(<..._logs>)" "got: ${sql:0:180}" ;;
+esac
+case "$sql" in
+  *"s3Cluster(primary, t520508_soleur_inngest_vector_prd_3_s3)"*) ok "archive arm queries s3Cluster(primary, <..._s3>)" ;;
+  *) bad "archive arm queries s3Cluster(primary, <..._s3>)" "got: ${sql:0:180}" ;;
+esac
+
+# _row_type = 1 is REQUIRED on the s3 arm (runbook §Query mechanics). Without it the
+# archive returns internal non-log rows and the caller silently over-counts.
+case "$sql" in
+  *"_row_type = 1"*) ok "archive arm filters _row_type = 1" ;;
+  *) bad "archive arm filters _row_type = 1" "got: ${sql:0:180}" ;;
+esac
+
+# ORDER BY / LIMIT must apply to the COMBINED set, not inside either arm — otherwise each
+# half is truncated independently and the merge interleaves wrongly.
+outer="${sql##*)}"
+case "$outer" in
+  *"ORDER BY dt ASC"*"LIMIT"*) ok "ORDER BY + LIMIT apply to the combined set" ;;
+  *) bad "ORDER BY + LIMIT apply to the combined set" "outer tail: ${outer:0:120}" ;;
+esac
+
+# The time predicate must reach BOTH arms — a hot-only WHERE would drag the whole archive.
+hits="$(grep -o 'INTERVAL 24 HOUR' <<<"$sql" | wc -l | tr -d ' ')"
+if [[ "$hits" == "2" ]]; then ok "--since predicate applied to both arms"
+else bad "--since predicate applied to both arms" "expected 2 occurrences, got $hits"; fi
+
+# --grep must reach both arms too.
+ghits="$(grep -o "MARKER" <<<"$sql" | wc -l | tr -d ' ')"
+if [[ "$ghits" == "2" ]]; then ok "--grep predicate applied to both arms"
+else bad "--grep predicate applied to both arms" "expected 2 occurrences, got $ghits"; fi
+
+# --- 2. --no-archive opts out (hot only) ---
+sql_no="$(capture_sql --since 1h --no-archive)"
+case "$sql_no" in
+  *"s3Cluster"*) bad "--no-archive omits the archive arm" "s3Cluster present: ${sql_no:0:140}" ;;
+  *"remote("*)   ok "--no-archive omits the archive arm (hot only)" ;;
+  *) bad "--no-archive omits the archive arm" "unexpected: ${sql_no:0:140}" ;;
+esac
+
+# --- 3. --table derives the s3 name; --table-s3 wins in EITHER order ---
+sql_t="$(capture_sql --since 1h --table t1_foo_logs)"
+case "$sql_t" in
+  *"s3Cluster(primary, t1_foo_s3)"*) ok "--table derives <name>_logs -> <name>_s3" ;;
+  *) bad "--table derives <name>_logs -> <name>_s3" "got: ${sql_t:0:160}" ;;
+esac
+
+# Order-independence: --table AFTER --table-s3 must not clobber the explicit archive name.
+sql_o1="$(capture_sql --since 1h --table-s3 t9_explicit_s3 --table t1_foo_logs)"
+sql_o2="$(capture_sql --since 1h --table t1_foo_logs --table-s3 t9_explicit_s3)"
+if [[ "$sql_o1" == *"t9_explicit_s3"* && "$sql_o2" == *"t9_explicit_s3"* ]]; then
+  ok "--table-s3 wins regardless of flag order"
+else
+  bad "--table-s3 wins regardless of flag order" "before=${sql_o1:0:100} after=${sql_o2:0:100}"
+fi
+
+# --- 4. raw SQL (mode 1): $BS_TABLE_S3 substituted BEFORE $BS_TABLE ---
+# $BS_TABLE is a strict prefix of $BS_TABLE_S3. Substituting the short token first rewrites
+# `$BS_TABLE_S3` into `<hot_table>_S3` — a table that does not exist — surfacing as a
+# confusing UNKNOWN_TABLE instead of the caller's archive rows.
+raw="$(capture_sql 'SELECT dt FROM s3Cluster(primary, $BS_TABLE_S3) UNION ALL SELECT dt FROM remote($BS_TABLE)')"
+case "$raw" in
+  *"_logs_S3"*) bad "raw SQL substitutes \$BS_TABLE_S3 before \$BS_TABLE" "prefix collision produced _logs_S3: ${raw:0:160}" ;;
+  *"s3Cluster(primary, t520508_soleur_inngest_vector_prd_3_s3)"*"remote(t520508_soleur_inngest_vector_prd_3_logs)"*)
+    ok "raw SQL substitutes \$BS_TABLE_S3 before \$BS_TABLE" ;;
+  *) bad "raw SQL substitutes \$BS_TABLE_S3 before \$BS_TABLE" "got: ${raw:0:160}" ;;
+esac
+
+printf '\n%s: %d passed, %d failed\n' "$(basename "$0")" "$pass" "$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## The bug

`scripts/betterstack-query.sh` queried `remote(<..._logs>)` alone. That is **only the hot window** — ~40 minutes of rows on 2026-07-15.

It never errored. It answered `--since 24h` with 40 minutes of data and exited 0. **A short answer that looks like a complete one.**

The runbook has documented the correct shape all along (`betterstack-log-query.md:116`): rows older than the hot window live in the s3 archive and must be `UNION ALL`-combined via `s3Cluster(primary, <..._s3>) WHERE _row_type = 1`. The script never did.

## What it broke

`scripts/followthroughs/zot-restart-plateau-6288.sh` gates on `ZOT_MIN_SOAK_EVENTS=20` **and** `ZOT_MIN_SOAK_SPAN_SEC=7200` (2h). Through a 40-minute keyhole it **could never reach PASS** — it reported `TRANSIENT: soak not yet filled` forever.

That is why **#6288 has stayed open since 2026-07-10**. The gate was correct all along; its input was silently truncated. This is the failure mode `hr-no-dashboard-eyeball-pull-data-yourself` exists to surface, one layer down: the data *was* pulled, it was just quietly incomplete.

## Verified against live prod

`--since 24h --grep SOLEUR_ZOT_DISK`:

| | rows | span | soak gate (needs ≥20 events, ≥7200s) |
|---|---|---|---|
| before | 13 | 3,000s | ❌ **impossible** |
| after | **312** | **86,100s** | ✅ |

The #6288 follow-through now reaches PASS for the first time:

```
PASS: zot restart-loop plateaued for boot_id=15ce29d1-... over 21300s / 72 events
(>=1 valid container sample) — restarts flat (delta<=3), no exit_code=137,
zot_oom_kills=0, oom_kills_5m=0, zot_anon_mb below the 7168m cap.
#6288 remediation holds.
```

## Design notes

**`UNION ALL` is safe — verified disjoint.** 891 rows / 891 distinct / **0 dupes** over 7d; the archive ends `19:13:46` and the hot window starts `19:15:02`. This is load-bearing: soak gates *count* events, so double-counting would inflate them.

**Fails loud, never silently hot-only.** If the archive arm errors, the whole query errors. Handing a caller partial data it will read as complete is the exact bug being fixed — so opting out is a deliberate `--no-archive`, not a fallback.

**`ORDER BY`/`LIMIT` apply to the combined set**, not inside either arm (which would truncate each half independently and interleave wrongly).

**Latent prefix collision fixed.** `$BS_TABLE` is a strict prefix of `$BS_TABLE_S3`, so raw-SQL token substitution must do the longer token first — otherwise `$BS_TABLE_S3` rewrites to `<hot_table>_S3`, a nonexistent table surfacing as a confusing `UNKNOWN_TABLE`. Pinned by test.

## Tests

Adds `tests/scripts/test-betterstack-query-archive.sh` — **11 assertions, hermetic**: stubs `curl` at the egress boundary (also proving no request escapes), asserts SQL *shape* only, never live rows or availability, per `cq-test-fixtures-synthesized-only`.

**Verified meaningful: 9 of 11 fail against the pre-fix script**, including the prefix collision reproducing exactly as `..._logs_S3`.

Registered in `scripts/test-all.sh` via explicit `run_suite` — `tests/scripts/` is not glob-discovered, so an unregistered test would ship as zero coverage (the same trap `test-stock-preflight-gate.sh` documents at `:147-149`).

## Why now

Unblocks two things beyond #6288: **AC11 of #6497** needs a real soak span to assert "≥1 `registry:zot` pull, zero new WEB-PLATFORM-5B", and the pending cx23 sizing trial needs the monotonic `zot_oom_kills` / `exit_code=137` signals observable over a real window rather than 40 minutes.

Refs #6288
Refs #6497

🤖 Generated with [Claude Code](https://claude.com/claude-code)