### PR TITLE
fix(infra): tunnel connect_timeout must be a duration STRING — the #6357 mitigation was never in effect

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -352,6 +352,14 @@ jobs:
       - name: Run fresh-boot observability probe guard (#6090 baked-DSN + readiness gates + H3)
         run: bash apps/web-platform/infra/soleur-host-bootstrap-observability.test.sh
 
+      # #6511: `connect_timeout = 5` was a bare number where the pinned v4 provider's schema says
+      # `string`. It coerced to "5", failed Cloudflare's duration parse, landed as "0s", and the
+      # #6357 fail-fast mitigation on the registry origin was inert for weeks while every apply
+      # re-planned it. This job lists its tests explicitly (no glob), so an unregistered test file
+      # ships as zero coverage — the trap tests/scripts/test-stock-preflight-gate.sh documents.
+      - name: Run tunnel origin_request schema-type guard (#6511 connect_timeout string vs int)
+        run: bash apps/web-platform/infra/tunnel-origin-request-types.test.sh
+
       - name: Run ci-deploy-wrapper.sh tests
         run: bash apps/web-platform/infra/ci-deploy-wrapper.test.sh
 

--- a/apps/web-platform/infra/tunnel-origin-request-types.test.sh
+++ b/apps/web-platform/infra/tunnel-origin-request-types.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Pins tunnel.tf's origin_request values to the PINNED cloudflare provider's schema types (#6511).
+#
+# WHY: `connect_timeout = 5` sat in tunnel.tf from #6357 until #6511 and NEVER took effect. The
+# v4 provider schema is `connect_timeout: string` (a Go duration). A bare `5` coerces to "5",
+# fails Cloudflare's duration parse, and lands as "0s" — so every apply planned
+# `connect_timeout = "0s" -> "5"`, applied it, reported success, and read back "0s" forever. The
+# mitigation for the 2026-07-11 502 (#6357) was inert the whole time, and the perpetual `1 to
+# change` trained everyone to read apply output as noise.
+#
+# The old comment asserted `INTEGER seconds (NOT "5s")` — exactly backwards. That IS the v5 shape;
+# this repo pins `~> 4.0`. Copying v5/REST-API docs onto a v4 pin is the trap; this test is the
+# tripwire for it.
+#
+# HERMETIC: pure text assertions over the HCL. No terraform, no network, no provider download —
+# it runs in the same ungated job as its siblings. It therefore pins the KNOWN-correct shape
+# rather than re-deriving the schema; see the provider-version guard below, which fails loudly if
+# the pin moves to a major where the correct shape differs.
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF="$DIR/tunnel.tf"
+MAIN="$DIR/main.tf"
+[[ -r "$TF" ]]   || { echo "FAIL: cannot read $TF" >&2; exit 1; }
+[[ -r "$MAIN" ]] || { echo "FAIL: cannot read $MAIN" >&2; exit 1; }
+
+pass=0; fail=0
+assert() { # <name> <cmd>
+  if eval "$2" >/dev/null 2>&1; then printf '  PASS: %s\n' "$1"; pass=$((pass+1))
+  else printf '  FAIL: %s\n' "$1" >&2; fail=$((fail+1)); fi
+}
+
+echo "--- #6511: origin_request values match the v4 provider's schema types ---"
+
+# The load-bearing one. v4 schema: connect_timeout is a STRING Go duration.
+assert "connect_timeout is a quoted duration string with a unit (not a bare integer)" \
+  "grep -qE '^[[:space:]]*connect_timeout[[:space:]]*=[[:space:]]*\"[0-9]+(ns|us|ms|s|m|h)\"' '$TF'"
+
+# The specific regression: a bare number silently becomes 0s on the origin.
+assert "connect_timeout is NOT assigned a bare number (coerces to \"5\" -> parses as 0s)" \
+  "! grep -qE '^[[:space:]]*connect_timeout[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*(#.*)?$' '$TF'"
+
+# The #6357 mitigation's actual value. If someone retunes it, this fails and they must confirm
+# the new bound is deliberate — the whole point is that it was silently 0s for weeks.
+assert "connect_timeout is 5s (the #6357 fail-fast bound on the registry origin)" \
+  "grep -qF 'connect_timeout   = \"5s\"' '$TF'"
+
+# Booleans stay booleans — no_happy_eyeballs is `bool` in the same schema block and was always
+# correct. Pinned so a future 'fix everything to strings' sweep doesn't over-correct it.
+assert "no_happy_eyeballs is a bare bool (schema: bool), not quoted" \
+  "grep -qE '^[[:space:]]*no_happy_eyeballs[[:space:]]*=[[:space:]]*(true|false)[[:space:]]*(#.*)?$' '$TF'"
+
+# The assertions above encode V4 semantics. In v5 connect_timeout became an INTEGER, so if the pin
+# ever moves to ~> 5.0 these tests would enforce a shape the provider rejects. Fail loudly here
+# rather than let the next person "fix" the tests to match a provider they didn't check.
+echo "--- provider pin guard (these assertions are v4-specific) ---"
+assert "cloudflare provider is still pinned to v4 (connect_timeout=string; v5 makes it an integer)" \
+  "grep -A2 'cloudflare = {' '$MAIN' | grep -qE 'version[[:space:]]*=[[:space:]]*\"~> 4\.[0-9]+\"'"
+
+printf '\n=== %s: %d passed, %d failed ===\n' "$(basename "$0")" "$pass" "$fail"
+[[ "$fail" -eq 0 ]]

--- a/apps/web-platform/infra/tunnel-origin-request-types.test.sh
+++ b/apps/web-platform/infra/tunnel-origin-request-types.test.sh
@@ -42,8 +42,10 @@ assert "connect_timeout is NOT assigned a bare number (coerces to \"5\" -> parse
 
 # The #6357 mitigation's actual value. If someone retunes it, this fails and they must confirm
 # the new bound is deliberate — the whole point is that it was silently 0s for weeks.
+# Whitespace-tolerant on purpose: a future `terraform fmt` may realign this block if a longer
+# sibling key joins origin_request, and the value would still be correct — don't red on alignment.
 assert "connect_timeout is 5s (the #6357 fail-fast bound on the registry origin)" \
-  "grep -qF 'connect_timeout   = \"5s\"' '$TF'"
+  "grep -qE '^[[:space:]]*connect_timeout[[:space:]]*=[[:space:]]*\"5s\"' '$TF'"
 
 # Booleans stay booleans — no_happy_eyeballs is `bool` in the same schema block and was always
 # correct. Pinned so a future 'fix everything to strings' sweep doesn't over-correct it.

--- a/apps/web-platform/infra/tunnel.tf
+++ b/apps/web-platform/infra/tunnel.tf
@@ -77,7 +77,14 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "web" {
         # saturate the shared tunnel daemon's HA-stream budget and degrade the sibling
         # deploy-webhook route (the 2026-07-11 502; #6357). Mitigation, not cure — root cause is
         # registry stability (#6288); full deploy-tunnel decoupling + metrics are #6178.
-        connect_timeout   = 5    # INTEGER seconds (NOT "5s") — bounds the TCP dial only
+        # Go duration STRING — provider v4's schema is literally `connect_timeout: string` (dump it:
+        # `terraform providers schema -json`). A bare `5` coerces to "5", fails Cloudflare's duration
+        # parse, and lands as "0s" — so from #6357 until #6511 this mitigation was NEVER in effect:
+        # every apply planned `connect_timeout = "0s" -> "5"`, applied it, and read back "0s" forever.
+        # The old comment here said `INTEGER seconds (NOT "5s")`, which is exactly backwards for this
+        # pin — that is the v5 shape (v5 takes an integer). We are on v4 (`~> 4.0`, main.tf:23-26).
+        # Do NOT copy v5/REST-API docs onto this resource without checking the pinned schema.
+        connect_timeout   = "5s"
         no_happy_eyeballs = true # origin is a v4 literal → drop the v4/v6 parallel-dial fan-out
       }
     }


### PR DESCRIPTION
## The bug

`connect_timeout = 5` on the **registry** ingress rule (`tunnel.tf:80`) has never applied. The live value is `0s`. Every apply plans the same change, applies it, reports success, and reads back `0s`. Forever.

## Proven

**The pinned provider types it as a STRING.** Dumped from `cloudflare/cloudflare 4.52.7` (`~> 4.0`, `main.tf:23-26`):

```
connect_timeout:        string     <--
keep_alive_timeout:     string
tcp_keep_alive:         string
tls_timeout:            string
keep_alive_connections: number
```

A bare `5` coerces to `"5"`, fails Cloudflare's duration parse, lands as `0s`.

**The comment asserted the exact opposite:**

```hcl
connect_timeout   = 5    # INTEGER seconds (NOT "5s") — bounds the TCP dial only
```

That is the **v5** shape — v5 genuinely takes an integer (`connect_timeout = 10` in current docs). This repo pins **v4**. v5/REST-API docs were applied to a v4 provider, with nothing tying the claim to the schema it described.

**It never converged — 4 of 4 merge-path applies**, each showing Terraform's own refresh (a live API read):

```
~ origin_request {
    ~ connect_timeout = "0s" -> "5"
```

The quoting independently confirms the string type; `"0s"` is Go's zero-duration rendering.

## Why it matters

This is the **#6357 mitigation**:

> *"Fail-fast so a DOWN registry origin (#6288) doesn't pile up ~30s-held dials that saturate the shared tunnel daemon's HA-stream budget and degrade the sibling deploy-webhook route (the 2026-07-11 502)."*

It guards the **registry origin that #6497's `registry-host-replace` dispatch takes down for 3-5 minutes**. The mitigation that exists to make that dispatch survivable was inert. Per the operator, #6511 lands **before** any dispatch.

## Why nothing caught it

`terraform validate` **passes on the buggy form** — HCL implicitly converts the number `5` to the string `"5"`, so it is type-valid and semantically wrong. The only symptom was a perpetual `1 to change` on every apply, which reads as noise. This session's own resume prompt described it as *"an unrelated Cloudflare tunnel config left over from #6425"* — it is neither unrelated nor a leftover. The drift trained everyone to stop reading apply output.

## Scope

Swept the sibling: `no_happy_eyeballs = true` matches its `bool` schema and **is** applied (it sits among the plan's unchanged attributes). Exactly one field was wrong.

## Tests

`tunnel-origin-request-types.test.sh` — 5 assertions, hermetic (text over HCL; no terraform, no network, runs in the same ungated job as its siblings):

- `connect_timeout` is a quoted duration string **with a unit**
- it is **not** a bare number (the exact regression)
- it is `5s` — so a retune is a deliberate edit, not another silent 0s
- `no_happy_eyeballs` stays a bare bool, so a future "quote everything" sweep can't over-correct it
- **provider-pin guard**: these assertions encode v4 semantics. If the pin moves to `~> 5.0`, the test fails loudly rather than enforcing a shape v5 rejects.

**Mutation-verified:** 3 of 5 fail against the pre-fix line.

Registered explicitly in `infra-validation.yml` — that job lists its tests rather than globbing, so an unregistered file ships as zero coverage (the trap `test-stock-preflight-gate.sh` documents at `:147-149`).

## Behavior change — read this

The registry route's dial bound becomes **5s for the first time**. That is what the code has intended since #6357; it has simply never run. 5s is generous for a LAN dial to `10.0.1.30:5000`. Expect the perpetual `1 to change` to disappear from apply output — if a future apply still shows it, the fix did not take.

Closes #6511

🤖 Generated with [Claude Code](https://claude.com/claude-code)