### PR TITLE
fix(skills): add support-live to flag-set-role's flag map (drift from #6303)

### DIFF
--- a/plugins/soleur/skills/flag-set-role/scripts/flip.sh
+++ b/plugins/soleur/skills/flag-set-role/scripts/flip.sh
@@ -60,6 +60,7 @@ declare -A FLAG_ENV_VARS=(
   ["c4-edit"]="FLAG_C4_EDIT"
   ["command-palette"]="FLAG_COMMAND_PALETTE"
   ["support"]="FLAG_SUPPORT"
+  ["support-live"]="FLAG_SUPPORT_LIVE"
   ["guided-tour"]="FLAG_GUIDED_TOUR"
 )
 


### PR DESCRIPTION
PR #6303 added `support-live` to `RUNTIME_FLAGS` but not to `flip.sh`'s `FLAG_ENV_VARS` map — the exact drift class fixed for `guided-tour` in #6182. Without this, the only approved flip path rejects the flag (`unknown flag: support-live`), blocking the #6303 go-live flip.

One-line map entry; no behavior change for other flags.

Part of #6303 go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)