### PR TITLE
feat(support): 'New conversation' affordance for the support chat

### DIFF
--- a/apps/web-platform/app/api/support/route.ts
+++ b/apps/web-platform/app/api/support/route.ts
@@ -64,8 +64,13 @@ export async function POST(request: Request): Promise<Response> {
     });
   }
 
-  const body = (await request.json().catch(() => null)) as { message?: unknown } | null;
+  const body = (await request.json().catch(() => null)) as
+    | { message?: unknown; newConversation?: unknown }
+    | null;
   const message = typeof body?.message === "string" ? body.message.trim() : "";
+  // "Start a new conversation" — the client sets this on the first send after
+  // the user taps the panel's new-thread button (or after a cost-cap error).
+  const forceNew = body?.newConversation === true;
   if (message.length === 0) {
     return new Response(JSON.stringify({ error: "Missing message" }), {
       status: 400,
@@ -79,7 +84,7 @@ export async function POST(request: Request): Promise<Response> {
   // persisted row (ownership probe / workspace_id / messages FK).
   let conversationId: string;
   try {
-    conversationId = await resolveOrCreateSupportConversation(userId);
+    conversationId = await resolveOrCreateSupportConversation(userId, { forceNew });
   } catch (err) {
     reportSilentFallback(err, { feature: "support", op: "support-route.resolveConversation", extra: { userId } });
     return new Response(JSON.stringify({ error: "Support is unavailable right now." }), {

--- a/apps/web-platform/components/support/support-launcher.tsx
+++ b/apps/web-platform/components/support/support-launcher.tsx
@@ -19,7 +19,7 @@ export function SupportLauncher() {
   // live (else the support agent could read the internal knowledge base).
   const live = useOptionalFeatureFlag("support-live");
   const [open, setOpen] = useState(false);
-  const { messages, send, abort } = useSupportChat(live);
+  const { messages, send, abort, reset } = useSupportChat(live);
   const tour = useTour();
   const bubbleRef = useRef<HTMLButtonElement>(null);
   const wasOpenRef = useRef(false);
@@ -68,6 +68,7 @@ export function SupportLauncher() {
         onClose={() => setOpen(false)}
         messages={messages}
         onSend={send}
+        onReset={reset}
         live={Boolean(live)}
         onStartTour={
           tour.available

--- a/apps/web-platform/components/support/support-panel.tsx
+++ b/apps/web-platform/components/support/support-panel.tsx
@@ -20,6 +20,7 @@ export function SupportPanel({
   onClose,
   messages,
   onSend,
+  onReset,
   onStartTour,
   live = false,
 }: {
@@ -27,6 +28,8 @@ export function SupportPanel({
   onClose: () => void;
   messages: SupportMessage[];
   onSend: (text: string, chipKey?: string) => void;
+  /** Start a fresh support thread (clears history; next send mints a new one). */
+  onReset?: () => void;
   /** feat-guided-tour: present only when the guided-tour flag is on. */
   onStartTour?: () => void;
   /** ADR-113 — true when the live Concierge backend is enabled (support-live). */
@@ -135,26 +138,53 @@ export function SupportPanel({
               {live ? SUPPORT_PANEL_SUBTITLE_LIVE : SUPPORT_PANEL_SUBTITLE}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close support"
-            className="flex h-8 w-8 items-center justify-center rounded-lg text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="h-4 w-4"
-              aria-hidden="true"
+          <div className="flex shrink-0 items-center gap-1">
+            {/* Start a fresh thread — only live (canned mode holds no server
+                conversation) and only once there's history to clear/escape. */}
+            {live && onReset && messages.length > 0 && (
+              <button
+                type="button"
+                onClick={onReset}
+                aria-label="New conversation"
+                title="New conversation"
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-4 w-4"
+                  aria-hidden="true"
+                >
+                  <path d="M12 20h9" />
+                  <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+                </svg>
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close support"
+              className="flex h-8 w-8 items-center justify-center rounded-lg text-soleur-text-secondary transition-colors hover:bg-soleur-bg-surface-2 hover:text-soleur-text-primary"
             >
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </button>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-4 w-4"
+                aria-hidden="true"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
         </header>
 
         {/* feat-guided-tour: "Take a tour" launch row — only when the flag is on

--- a/apps/web-platform/components/support/use-support-chat.ts
+++ b/apps/web-platform/components/support/use-support-chat.ts
@@ -37,6 +37,14 @@ export interface UseSupportChat {
   send: (text: string, chipKey?: string) => void;
   /** Abort any in-flight support turn (called on panel close — S1). */
   abort: () => void;
+  /**
+   * Start a fresh support thread: abort any in-flight turn, clear the on-screen
+   * history, and flag the NEXT `send()` to mint a new server-side conversation
+   * (POST body `newConversation:true`). Escapes a wedged thread (cost-capped or
+   * a stale pre-corpus session). No-op when not live (canned mode holds no
+   * server thread; it just clears the local preview).
+   */
+  reset: () => void;
 }
 
 // No support frame for this long → treat the stream as stalled (S5).
@@ -55,6 +63,9 @@ export function useSupportChat(live: boolean = false): UseSupportChat {
   const idRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Set by reset(); consumed (and cleared) by the NEXT live send() so exactly
+  // one turn carries `newConversation:true`.
+  const startFreshRef = useRef(false);
 
   const nextId = useCallback((prefix: string) => {
     idRef.current += 1;
@@ -83,6 +94,16 @@ export function useSupportChat(live: boolean = false): UseSupportChat {
     setMessages((prev) =>
       prev.map((m) => (m.streaming ? { ...m, streaming: false } : m)),
     );
+  }, [clearIdleTimer]);
+
+  const reset = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    clearIdleTimer();
+    // Mark the next live send() to mint a server-side thread. Harmless in canned
+    // mode (that path never reads it) — it just clears the local preview below.
+    startFreshRef.current = true;
+    setMessages([]);
   }, [clearIdleTimer]);
 
   const send = useCallback(
@@ -124,6 +145,11 @@ export function useSupportChat(live: boolean = false): UseSupportChat {
       };
       setMessages((prev) => [...prev, userMessage, supportMessage]);
 
+      // Consume the one-shot new-thread flag: this send mints a fresh server
+      // conversation, all following sends reuse it.
+      const startFresh = startFreshRef.current;
+      startFreshRef.current = false;
+
       const controller = new AbortController();
       abortRef.current = controller;
 
@@ -152,7 +178,11 @@ export function useSupportChat(live: boolean = false): UseSupportChat {
           const res = await fetch("/api/support", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ message: trimmed }),
+            body: JSON.stringify(
+              startFresh
+                ? { message: trimmed, newConversation: true }
+                : { message: trimmed },
+            ),
             signal: controller.signal,
           });
           if (!res.ok || !res.body) {
@@ -207,5 +237,5 @@ export function useSupportChat(live: boolean = false): UseSupportChat {
     [live, nextId, patch, clearIdleTimer],
   );
 
-  return { messages, hasConversation: messages.length > 0, send, abort };
+  return { messages, hasConversation: messages.length > 0, send, abort, reset };
 }

--- a/apps/web-platform/server/support-conversation.ts
+++ b/apps/web-platform/server/support-conversation.ts
@@ -20,9 +20,18 @@ import { reportSilentFallback } from "@/server/observability";
  * route can fall back to the honest canned reply (never proceed with a
  * non-existent conversation id — dispatchSoleurGo would throw "Conversation not
  * found" downstream).
+ *
+ * @param opts.forceNew When true, SKIP the reuse SELECT and always insert a
+ *   fresh thread. The "start a new conversation" affordance (support panel +
+ *   the per-workflow cost-cap error's own instruction) — without it a caller
+ *   whose most-recent thread is wedged (cost-capped, or a stale pre-corpus
+ *   session) can never escape it, since the resolve path always returns that
+ *   same newest row. The newly-inserted row becomes the newest, so subsequent
+ *   (forceNew=false) sends reuse IT.
  */
 export async function resolveOrCreateSupportConversation(
   userId: string,
+  opts?: { forceNew?: boolean },
 ): Promise<string> {
   // biome-ignore lint/suspicious/noExplicitAny: tenant client is an untyped supabase-js chain
   const tenant = (await getFreshTenantClient(userId)) as any;
@@ -30,17 +39,20 @@ export async function resolveOrCreateSupportConversation(
   // Reuse the caller's most-recent support thread so the conversation (and its
   // history) persists across panel close/reopen — the reconnect-replay cliff B2
   // resolves. RLS already scopes to the caller; the kind filter picks support.
-  const existing = await tenant
-    .from("conversations")
-    .select("id")
-    .eq("user_id", userId)
-    .eq("kind", "support")
-    .order("last_active", { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  // `forceNew` bypasses reuse to mint a deliberate fresh thread.
+  if (!opts?.forceNew) {
+    const existing = await tenant
+      .from("conversations")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("kind", "support")
+      .order("last_active", { ascending: false })
+      .limit(1)
+      .maybeSingle();
 
-  if (existing?.data?.id) {
-    return existing.data.id as string;
+    if (existing?.data?.id) {
+      return existing.data.id as string;
+    }
   }
 
   const id = randomUUID();

--- a/apps/web-platform/test/components/support/support-live-path.test.tsx
+++ b/apps/web-platform/test/components/support/support-live-path.test.tsx
@@ -73,6 +73,55 @@ describe("support live path (support-live ON)", () => {
     );
   });
 
+  it("New conversation button: appears after a turn, clears history, and the next send mints a fresh thread", async () => {
+    // Distinct reply per call so transcript assertions are unambiguous.
+    let turn = 0;
+    const fetchSpy = vi.fn().mockImplementation(async () => {
+      turn += 1;
+      return sseResponse([
+        { type: "stream", content: `reply-${turn}`, partial: true, leaderId: "cc_router" } as WSMessage,
+        { type: "session_ended" } as WSMessage,
+      ]);
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    render(<SupportLauncher />);
+    fireEvent.click(screen.getByLabelText("Open support"));
+    const dialog = screen.getByRole("dialog");
+
+    // No new-conversation button on an empty thread.
+    expect(within(dialog).queryByLabelText("New conversation")).toBeNull();
+
+    const textarea = within(dialog).getByPlaceholderText("Ask a question…");
+    fireEvent.change(textarea, { target: { value: "first question" } });
+    fireEvent.click(within(dialog).getByLabelText("Send message"));
+    await waitFor(() => expect(within(dialog).getByText("reply-1")).toBeTruthy());
+    // First send does NOT force a new conversation.
+    expect(JSON.parse(fetchSpy.mock.calls[0][1].body)).toEqual({ message: "first question" });
+
+    // Button now present; clicking it clears the transcript.
+    fireEvent.click(within(dialog).getByLabelText("New conversation"));
+    expect(within(dialog).queryByText("reply-1")).toBeNull();
+    expect(within(dialog).queryByText("first question")).toBeNull();
+    // And the button hides again on the now-empty thread.
+    expect(within(dialog).queryByLabelText("New conversation")).toBeNull();
+
+    // The NEXT send carries newConversation:true exactly once.
+    fireEvent.change(textarea, { target: { value: "second question" } });
+    fireEvent.click(within(dialog).getByLabelText("Send message"));
+    await waitFor(() => expect(within(dialog).getByText("reply-2")).toBeTruthy());
+    expect(JSON.parse(fetchSpy.mock.calls[1][1].body)).toEqual({
+      message: "second question",
+      newConversation: true,
+    });
+
+    // A THIRD send reuses (flag consumed — no newConversation).
+    fireEvent.change(textarea, { target: { value: "third question" } });
+    fireEvent.click(within(dialog).getByLabelText("Send message"));
+    await waitFor(() => expect(within(dialog).getByText("reply-3")).toBeTruthy());
+    expect(JSON.parse(fetchSpy.mock.calls[2][1].body)).toEqual({ message: "third question" });
+  });
+
   it("falls back to the canned reply when the transport fails", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
 

--- a/apps/web-platform/test/support-conversation.test.ts
+++ b/apps/web-platform/test/support-conversation.test.ts
@@ -21,6 +21,7 @@ import { resolveOrCreateSupportConversation } from "@/server/support-conversatio
 /** A chainable supabase mock. `existingRow` = what the resolve SELECT returns. */
 function makeTenant(existingRow: { id: string } | null) {
   const insert = vi.fn().mockResolvedValue({ error: null });
+  const maybeSingle = vi.fn().mockResolvedValue({ data: existingRow, error: null });
   const chain: Record<string, unknown> = {};
   const self = () => chain;
   Object.assign(chain, {
@@ -28,10 +29,10 @@ function makeTenant(existingRow: { id: string } | null) {
     eq: vi.fn(self),
     order: vi.fn(self),
     limit: vi.fn(self),
-    maybeSingle: vi.fn().mockResolvedValue({ data: existingRow, error: null }),
+    maybeSingle,
     insert,
   });
-  return { chain: { from: vi.fn(() => chain) }, insert };
+  return { chain: { from: vi.fn(() => chain) }, insert, maybeSingle };
 }
 
 describe("resolveOrCreateSupportConversation", () => {
@@ -59,6 +60,31 @@ describe("resolveOrCreateSupportConversation", () => {
     expect(row.workspace_id).toBe("ws-123");
     expect(row.user_id).toBe("user-1");
     expect(row.id).toBe(id);
+  });
+
+  it("forceNew skips the reuse SELECT and always inserts a fresh thread", async () => {
+    // A reusable row EXISTS, but forceNew must ignore it and mint a new one.
+    const { chain, insert, maybeSingle } = makeTenant({ id: "conv-wedged" });
+    mockGetFreshTenantClient.mockResolvedValue(chain);
+
+    const id = await resolveOrCreateSupportConversation("user-1", { forceNew: true });
+    expect(maybeSingle).not.toHaveBeenCalled(); // reuse SELECT bypassed
+    expect(insert).toHaveBeenCalledOnce();
+    const row = insert.mock.calls[0][0];
+    expect(row.id).toBe(id);
+    expect(row.kind).toBe("support");
+    expect(row.repo_url).toBeNull();
+    expect(id).not.toBe("conv-wedged");
+  });
+
+  it("default (no opts) still reuses the existing thread", async () => {
+    const { chain, insert, maybeSingle } = makeTenant({ id: "conv-existing" });
+    mockGetFreshTenantClient.mockResolvedValue(chain);
+
+    const id = await resolveOrCreateSupportConversation("user-1");
+    expect(maybeSingle).toHaveBeenCalledOnce();
+    expect(id).toBe("conv-existing");
+    expect(insert).not.toHaveBeenCalled();
   });
 
   it("throws if the insert fails (honest-degrade upstream)", async () => {

--- a/apps/web-platform/test/support-route.test.ts
+++ b/apps/web-platform/test/support-route.test.ts
@@ -113,6 +113,22 @@ describe("POST /api/support", () => {
     expect(sse).toContain(`"type":"stream_end"`);
   });
 
+  it("forwards newConversation:true as forceNew to the resolver", async () => {
+    h.dispatchSoleurGo.mockImplementation(async (args: { sendToClient: (u: string, m: WSMessage) => boolean }) => {
+      args.sendToClient("user-1", { type: "session_ended" } as WSMessage);
+    });
+    await POST(req({ message: "start over", newConversation: true }));
+    expect(h.resolveOrCreateSupportConversation).toHaveBeenCalledWith("user-1", { forceNew: true });
+  });
+
+  it("omitted/false newConversation resolves with forceNew:false (reuse)", async () => {
+    h.dispatchSoleurGo.mockImplementation(async (args: { sendToClient: (u: string, m: WSMessage) => boolean }) => {
+      args.sendToClient("user-1", { type: "session_ended" } as WSMessage);
+    });
+    await POST(req({ message: "hello" }));
+    expect(h.resolveOrCreateSupportConversation).toHaveBeenCalledWith("user-1", { forceNew: false });
+  });
+
   it("404 (dark) when support-live is OFF — never invokes the Concierge", async () => {
     h.getRuntimeFlag.mockResolvedValue(false);
     const res = await POST(req({ message: "read your internal roadmap" }));


### PR DESCRIPTION
## Why

The support route (`POST /api/support`) always reuses the caller's most-recent `kind='support'` thread. But the per-workflow **cost-cap error tells users to _"Start a new conversation to continue"_ — with no way to actually do so.** A user whose thread is wedged (cost-capped, or a session created before a corpus deploy — exactly what happened to the QA bot during #6303 go-live) can never escape it, because the resolve path always returns that same newest row.

## What

- **server** — `resolveOrCreateSupportConversation(userId, { forceNew })` bypasses the reuse SELECT and always inserts a fresh row. The new row becomes newest, so subsequent (non-forced) sends thread onto it.
- **route** — accepts `{ newConversation: true }` → `forceNew`.
- **client** — `useSupportChat` gains `reset()`: aborts any in-flight turn, clears the transcript, and one-shot-flags the **next** send to carry `newConversation:true`.
- **ui** — a **New conversation** header button (pencil icon), shown only when `live` AND the thread is non-empty (no dead button on a fresh panel, none in canned-preview mode).

## Tests

- resolver: `forceNew` bypasses reuse + still inserts; default path still reuses
- route: `newConversation:true`→`forceNew:true`, omitted→`forceNew:false`
- full launcher→panel→hook integration: button gating (hidden empty / shown after a turn / hidden again after reset), transcript clear, and `newConversation:true` sent **exactly once** then consumed (3rd send reuses)
- `tsc --noEmit` clean; 25 support tests green

## Rollout

Rides the existing `support-live` flag — no new flag, no migration. Inert for canned-preview users (button only renders live).

Part of #6303 go-live follow-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)