### PR TITLE
fix(adr): ADR-117 shipped an arming order the API cannot perform — corrected by executing it

### DIFF
--- a/apps/web-platform/infra/zot-registry.tf
+++ b/apps/web-platform/infra/zot-registry.tf
@@ -430,10 +430,16 @@ resource "hcloud_firewall_attachment" "registry" {
 #
 # `paused = true` here is correct and permanent: `ignore_changes = [paused]` below decouples source
 # from live state, and this resource is an OPERATOR_APPLIED_EXCLUSION (untargeted), so a source
-# unpause is a no-op either way. Live arming is a one-time API PATCH, done only AFTER a real beat is
-# measured — never before (an unfed monitor that gets unpaused pages forever; #6210). Until that
-# happens the monitor is inert, and no static check can see it (ADR-117 names this state; the
-# nightly live-reconcile that would bound it is #6549).
+# unpause is a no-op either way. LIVE state is armed (paused=false, up) as of 2026-07-16 — this
+# source value is not the live one, which is the whole point of ADR-117.
+#
+# Arming was a one-time API PATCH under a bounded arm-and-watch: the beat CANNOT be measured before
+# unpausing (Better Stack exposes no last_heartbeat_at and no /events; a paused monitor reads
+# status="paused" forever), so the rollback is held in-process and re-pauses inside period+grace if
+# no beat lands. It fired for real on the first attempt — the host booted NIC-less (#6400), the
+# feeder correctly withheld its ping, and the rollback re-paused at 86s with no alert. See ADR-117
+# §Ordering. Do NOT "simplify" this to a bare unpause: an unfed monitor left armed pages forever
+# (#6210).
 #
 # The consumer-perspective probe (can a CLIENT reach zot over the private net?) is a DIFFERENT
 # layer and remains open as #6438 §1; this on-host beat does not close it.

--- a/knowledge-base/engineering/architecture/decisions/ADR-117-executable-heartbeat-arming.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-117-executable-heartbeat-arming.md
@@ -121,10 +121,44 @@ is armed; it can only prove a feeder exists.** Arming is verified by measuring a
 
 ### Ordering is mandatory, not advisory
 
-**Build the feeder → measure a real beat → then unpause.** Never unpause first. This repo has already
-run that experiment: #6210 unpaused a monitor nothing fed and paged the founder until it was
-re-paused. An unfed monitor that gets unpaused converts a silent gap into a permanent false alarm,
-which trains the operator to ignore the alarm — strictly worse than the silence it replaced.
+**Build the feeder → verify the beat → then leave it armed.** Never arm an unfed monitor and walk
+away. This repo has already run that experiment: #6210 unpaused a monitor nothing fed and paged the
+founder until it was re-paused. An unfed monitor that gets unpaused converts a silent gap into a
+permanent false alarm, which trains the operator to ignore the alarm — strictly worse than the
+silence it replaced.
+
+> **Corrected 2026-07-16, by executing it.** This section originally read *"measure a real beat →
+> **then** unpause"*. **That is not implementable against Better Stack's API, and shipping it as
+> procedure was this ADR's own defect** — an arming instruction nothing could carry out, in the ADR
+> written because an arming instruction nothing carried out cost 9 days of blindness.
+>
+> Measured, not assumed (`GET /api/v2/heartbeats/<id>`): the resource exposes
+> `{status, paused, paused_at, period, grace, updated_at, url, …}` — there is **no
+> `last_heartbeat_at`**, and `/heartbeats/<id>/events` **404s**. A paused monitor reports
+> `status: "paused"` and its `updated_at` never moves when a beat arrives. Verified against a live
+> feeder mid-reprovision: `updated_at` stayed frozen at the provisioning timestamp throughout.
+> **A beat is not observable while the monitor is paused.** The order the issue asked for cannot be
+> performed.
+>
+> **What replaces it — bounded arm-and-watch with the rollback in the same process:**
+> 1. Ship the feeder and reprovision the host.
+> 2. `PATCH {"paused": false}`, then poll `status` every 10s.
+> 3. `status: "up"` ⇒ a real beat landed; done.
+> 4. No `up` by `period + grace − 10s` ⇒ **`PATCH {"paused": true}` immediately**, before the first
+>    alert can fire. Diagnose; do not retry blind.
+>
+> This is NOT #6210's shape, and the distinction is the whole point: #6210 armed an unfed monitor and
+> **left it armed**. Here the rollback is held for the entire window, so the worst case is bounded to
+> at most one email (free tier: `policy_id = null`) — not a permanent page.
+>
+> **It was exercised on the first attempt and it worked.** The registry's `registry-host-replace`
+> hit #6400's NIC race (`nic_ok=false` — the host booted with no `10.0.1.30`). The feeder correctly
+> withheld its ping, arm-and-watch saw `pending` for 86s, rolled back at 86s, and **no alert fired**.
+> After #6415's guard converged the NIC (`converged_by=reboot`), the re-arm went `up` in **11s**.
+>
+> The invariant survives the correction intact: **no static check can prove a monitor is armed; it
+> can only prove a feeder exists.** Arming is still verified by a beat — the beat is just measured
+> during a rolled-back-by-default arm, not before it.
 
 ## Consequences
 

--- a/knowledge-base/project/learnings/2026-07-16-the-fix-for-an-inert-monitor-shipped-a-probe-that-could-never-fire.md
+++ b/knowledge-base/project/learnings/2026-07-16-the-fix-for-an-inert-monitor-shipped-a-probe-that-could-never-fire.md
@@ -278,3 +278,49 @@ Fix: probe both routes — `$VAR`/`${VAR}` deref, **and** `<var>_url = betterupt
 - [[2026-07-15-silent-fallback-masked-a-dead-primary-for-14-days]] — #6400, the blindness the
   private-IP probe choice exists to avoid rebuilding.
 - ADR-117 (executable heartbeat arming) · ADR-096 · ADR-103 · #6548 · #6549
+
+## Postscript — what happened when it actually ran (same day, post-merge)
+
+Two things landed within an hour of merge that are worth more than the rest of this document.
+
+### 10. The load-bearing test reproduced itself in production, on the first boot
+
+The `registry-host-replace` that carried the feeder onto the host hit **#6400's NIC race**: the new
+host booted with **no private NIC** (`nic_ok=false`; interfaces were `lo, eth0, docker0` — no
+`enp7s0:10.0.1.30`). The feeder probed `10.0.1.30:5000`, got nothing, and **correctly withheld its
+ping**. The monitor stayed down because the registry genuinely *was* unreachable to its consumers.
+
+**A loopback probe would have reported green through all of it** — zot binds `0.0.0.0`, so
+`localhost:5000` answered fine the entire time. That is T3, the test this PR called the most
+important one, reproducing itself against real infrastructure minutes after shipping. The
+private-IP choice was not a theoretical nicety; it was the difference between a monitor that tells
+the truth and one that lies on its first boot.
+
+Then #6415's private-NIC guard (shipped one day earlier) healed it autonomously: it declined to act
+while `uptime_s` was under its 600s floor (`converged_by=none` — deliberately not rebooting a
+just-booted host), then fired `converged_by=reboot` at `uptime_s=663`. The re-rendered netplan
+brought `enp7s0:10.0.1.30` back, and the feeder's next probe went green. **Two guards, shipped a day
+apart, composed correctly without anyone wiring them together.**
+
+### 11. "Verify a ping BEFORE unpausing" is not implementable — the ADR shipped an unperformable step
+
+The issue's ask #1, this plan's Phase 4.3, ADR-117's "Ordering is mandatory", and the PR body all
+said: *measure a real beat, THEN unpause*. **None of us checked whether the API can do that.** It
+cannot:
+
+- `GET /api/v2/heartbeats/<id>` exposes `{status, paused, paused_at, period, grace, updated_at, url}`
+  — **no `last_heartbeat_at`**.
+- `/heartbeats/<id>/events` → **404**.
+- A paused monitor reports `status: "paused"`, and `updated_at` stays frozen at the provisioning
+  timestamp even while a live feeder beats at it (verified directly).
+
+So the ordering everyone agreed on, wrote down three times, and reviewed eight ways **could not be
+performed**. It is the same species as the comment that caused #6537 — an arming instruction nothing
+could carry out — reproduced inside the ADR written to end that species. Corrected in ADR-117 with
+the bounded arm-and-watch that actually works (rollback held in-process; blast radius one email).
+
+**The generalization is the sharpest thing in this file:** a procedure is a claim about a
+capability. "Verify X before Y" is only a rule if the system can observe X without doing Y — and
+nobody checked. Before writing an ordering constraint into an ADR, *execute it once*, or at minimum
+read the API's field list. The cheapest possible check (one `GET`, one `jq keys`) would have caught
+it at plan time, and it was never run because the sentence sounded obviously correct.


### PR DESCRIPTION
## Summary

ADR-117 (merged hours ago in #6540) mandates: *"Build the feeder → **measure a real beat** → then unpause. Never unpause first."*

**That ordering cannot be performed.** Nobody checked before writing it down — not the 7-agent plan panel, not the 8-agent review, not me.

Measured, with one `GET`:

| Probe | Result |
|---|---|
| `GET /api/v2/heartbeats/<id>` → field list | `{status, paused, paused_at, period, grace, updated_at, url, …}` — **no `last_heartbeat_at`** |
| `GET /heartbeats/<id>/events` | **404** |
| A paused monitor while a live feeder beats at it | `status: "paused"`, `updated_at` frozen at the provisioning timestamp |

**A beat is not observable while the monitor is paused.** So the order the issue asked for, the plan prescribed, the ADR mandated, and #6540's body claimed is not implementable.

This is the same species as the comment that caused #6537 — an arming instruction nothing could carry out — reproduced *inside the ADR written to end that species*. It sounded obviously correct, so nobody ran the one command that falsifies it.

## What replaces it

Bounded **arm-and-watch**, rollback held in the same process:

1. `PATCH {"paused": false}`, poll `status` every 10s.
2. `status: "up"` ⇒ a real beat landed.
3. No `up` by `period + grace − 10s` ⇒ **re-pause immediately**, before any alert fires.

Not #6210's shape, and the distinction is the point: **#6210 armed an unfed monitor and left it armed.** Here the rollback is held for the whole window, bounding the worst case to one email (free tier, `policy_id = null`) rather than a permanent page.

## It was exercised for real, on the first attempt

`registry-host-replace` hit **#6400's NIC race** — the host booted with no private NIC (`nic_ok=false`; no `enp7s0:10.0.1.30`):

- The feeder **correctly withheld its ping** (its probe targets the private IP).
- Arm-and-watch saw `pending` for 86s and **rolled back — no alert fired**.
- #6415's guard converged the NIC autonomously (`converged_by=none` while `uptime_s<600`, then `converged_by=reboot` at `uptime_s=663`).
- The re-arm went **`up` in 11 seconds**.

`soleur-registry-prd` is now live: **`status: up, paused: false`** — #6537 answered.

**And T3 reproduced itself in production.** A loopback probe would have reported green through the entire NIC outage (zot binds `0.0.0.0`; `localhost:5000` answered fine throughout). The private-IP choice was the difference between a monitor that tells the truth and one that lies on its first boot.

## Changelog

### Docs
- ADR-117 §Ordering: record that measure-before-arm is not implementable against the Better Stack API, and replace it with the bounded arm-and-watch (with the live evidence).
- Learning: add the two findings worth more than the rest of the file — T3 validating itself in production, and the generalization that **a procedure is a claim about a capability** ("verify X before Y" is only a rule if the system can observe X without doing Y).

### Infrastructure
- `zot-registry.tf`: the liveness comment carried the same unperformable instruction. It now describes what was actually done, and records that **live is armed while source stays paused** — the source≠live property ADR-117 exists to name.

## Test plan

- [x] `zot-liveness-heartbeat.test.sh` — 32/32
- [x] `heartbeat-reprovision-parity` — 19/19
- [x] `terraform fmt -check` clean · `check-adr-ordinals.sh` clean
- [x] Live: `registry_prd` `status=up, paused=false`, sustained across intervals

Docs + one comment; no behavior change — the feeder itself is untouched and beating.

Ref #6537
Ref #6540

Generated with [Claude Code](https://claude.com/claude-code)