### PR TITLE
fix(infra): pin both hosts to inngest-bootstrap v1.1.21 + guard the dedicated pin

### DIFF
--- a/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
+++ b/apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
@@ -238,6 +238,37 @@ else
     echo "        Fix: bump every 'soleur-inngest-bootstrap:<tag>' ref in"
     echo "        apps/web-platform/infra/cloud-init.yml to $LATEST_TAG."
   fi
+
+  # #6536: the DEDICATED host's pin was guarded by NOTHING. This guard read only
+  # cloud-init.yml (the web host), so cloud-init-inngest.yml silently sat on v1.1.19
+  # while the web host moved to v1.1.20 — and the two hosts extract inngest-bootstrap.sh
+  # + vector.toml from whatever image THEIR OWN file pins.
+  #
+  # That gap is not cosmetic; it is how a fix reaches main and never reaches the host.
+  # The dedicated host is delivered by `apply_target=inngest-host-replace`, whose
+  # `terraform plan -replace=` force-replaces REGARDLESS of any user_data diff — so the
+  # rebuild boots the pinned image whether or not the pin moved. #6539 measured v1.1.19
+  # and v1.1.20 to contain NONE of the #6536 fix: dispatching the replace against a
+  # stale pin would have rebuilt the dark host pre-fix, left the bug live, and spent the
+  # zero-downtime window (free only while the host is dark, a cron outage after #6178
+  # arms the flip). The guard above would have stayed green throughout — it was watching
+  # the other file.
+  #
+  # Same authoritative signal (semver-max published tag), same failure text shape.
+  # `|| true` mirrors the PIN extraction above: a rename must FAIL cleanly, not abort
+  # the run under pipefail before the results summary.
+  DED_CLOUD_INIT="$SCRIPT_DIR/cloud-init-inngest.yml"
+  DED_PIN=$(grep -oE 'soleur-inngest-bootstrap:v[0-9]+\.[0-9]+\.[0-9]+' "$DED_CLOUD_INIT" | head -1 | sed 's/.*://' || true)
+  assert "dedicated-host cloud-init pin ($DED_PIN) matches latest published vinngest-v* tag ($LATEST_TAG)" \
+    "[[ '$DED_PIN' == '$LATEST_TAG' ]]"
+  if [[ "$DED_PIN" != "$LATEST_TAG" ]]; then
+    echo "        DRIFT: cloud-init-inngest.yml pins $DED_PIN but the latest published tag is $LATEST_TAG."
+    echo "        Fix: bump every 'soleur-inngest-bootstrap:<tag>' ref in"
+    echo "        apps/web-platform/infra/cloud-init-inngest.yml to $LATEST_TAG."
+    echo "        This is the DEDICATED inngest host. Its replace is dispatch-only and"
+    echo "        force-replaces regardless of user_data, so a stale pin here means the"
+    echo "        rebuild boots a pre-fix image and the dispatch changes nothing (#6536)."
+  fi
 fi
 
 # --- AC6b: all pin refs present AND share one tag (catches a partial bump) ---

--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -334,7 +334,7 @@ runcmd:
   - |
     set -e
     test -f /run/soleur-inngest-doppler.ok || { echo "FATAL: doppler isolation self-check did not pass — refusing to bootstrap inngest" >&2; exit 1; }
-    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.19
+    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.21
     for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
     # #6178 boot observability: bracket the OCI pull so a pull hang/401 self-reports the STAGE
     # (pre-oci-pull with no oci-pull-rc-* = hung; oci-pull-rc-N!=0 = failed, with masked tail).

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -690,13 +690,13 @@ runcmd:
   # fresh hosts.
   - |
     set -e
-    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.20
+    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.21
     # #6122/ADR-096: prefer zot (dark; host already logged in by soleur-host-bootstrap.sh);
     # all 3 refs follow IREF, zot miss ⇒ GHCR fallback; soleur-boot-emit records the registry.
     ZURL=$(timeout 15 doppler secrets get ZOT_REGISTRY_URL --plain --project soleur --config prd 2>/dev/null || true)
     # ADR-096 5.3 tripwire (#6285): read ci-deploy.sh RETIREMENT TRIPWIRE before deleting this.
     if [ -n "$ZURL" ] && curl -s -o /dev/null --max-time 3 "http://$ZURL/v2/"; then
-      ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.20"
+      ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.21"
       if docker pull "$ZIREF"; then IREF="$ZIREF"; soleur-boot-emit inngest_zot info; else soleur-boot-emit inngest_ghcr_fallback warning; fi
     fi
     docker pull "$IREF"


### PR DESCRIPTION
Ref #6536 · follows #6539 (merged)

**This is the PR that actually delivers #6539's fix to the host.** #6539 landed the code; nothing on any host reads it until a pin moves.

## Why a pin bump is the delivery step

The dedicated Inngest host boots cloud-init, which pulls a **pinned** `soleur-inngest-bootstrap` OCI image and extracts `inngest-bootstrap.sh` + `vector.toml` from it. It pinned **v1.1.19**. Measured, by pulling each published image:

| Tag | `@@DARK_ARM@@` | `SyslogIdentifier=` | vector.toml tag |
|---|---|---|---|
| `v1.1.19` (dedicated host's pin) | 0 | 0 | 0 |
| `v1.1.20` (web host's pin) | 0 | 0 | 0 |
| **`v1.1.21`** (new, cut from #6539's squash) | **7** | **1** | **1** |

Verified against the **published artifact**, not the repo and not the green build — those are independent facts, which is the whole point of #6539's second finding.

In-image lockstep checked on the one axis that could break: `vector.toml` carries 4 `@@HOST_NAME@@` sentinels and the bootstrap renders them at `:690` → 5 × `soleur-inngest-prd`, **0 residual**. A mismatched pair would ship a literal `@@HOST_NAME@@` as the Better Stack discriminator.

## Changes

- **`cloud-init-inngest.yml` (DEDICATED): v1.1.19 → v1.1.21.** The delivery for #6536.
- **`cloud-init.yml` (WEB): v1.1.20 → v1.1.21**, `IREF` + `ZIREF` in lockstep (AC6b: count==2, distinct==1). Required by AC6 the moment `vinngest-v1.1.21` published — that guard exists because this bump was *"forgotten 10 consecutive times (v1.0.1…v1.1.10)"* before #4669.
- **New guard: the dedicated pin.** See below.

### Rides-along (named, not discovered later)

Moving the dedicated host v1.1.19 → v1.1.21 also ships every undeployed change to those two files since 2026-07-09: **#6315** (`"webhook"` tag), **#6396** (`@@HOST_NAME@@` sentinel), **#6311**, **#6456**, **#6540**. A dark-host replace is the cheapest possible moment to absorb this.

## The gap this closes — AC6 was watching the wrong file

`AC6` asserts the cloud-init pin equals the semver-max published `vinngest-v*` tag. It read **only `cloud-init.yml`** (the web host). So `cloud-init-inngest.yml` sat on **v1.1.19 while the web host moved to v1.1.20**, and nothing said a word.

That is not cosmetic. The dedicated host is delivered by `apply_target=inngest-host-replace`, whose `terraform plan -replace=` **force-replaces regardless of any `user_data` diff** — the rebuild boots whatever the pin says. Dispatching against the stale pin would have rebuilt the dark host **pre-fix**, left #6536 live, and **spent the zero-downtime window** — free only while the host is dark, and a real cron outage once #6178 arms the flip. AC6 would have stayed green throughout, because it was watching the other file.

This PR extends AC6 to the dedicated pin, keyed on the same authoritative signal (the semver-max published tag).

**Mutation-proven, both halves** — a guard whose deletion leaves the suite green pins nothing:

| | Result |
|---|---|
| correct pin (v1.1.21) | **71/71** |
| dedicated pin reverted to v1.1.19 | **70/71**, drift named with the file + fix |

Mutated a **backup copy** and restored from it — never the tracked file, never `git checkout --`.

## Delivery ordering after this merges

**AC15 gate (re-assert immediately before the dispatch):** both `INNGEST_HEARTBEAT_URL` and `INNGEST_CUTOVER_FLIP` must be **absent** from `soleur-inngest/prd`. URL is the primary trip-wire — `op=arm` writes it **first** and the flip **last**, so a failed arm leaves URL-present/flip-absent *durably*, a state a flip-only gate passes while the dark host is actively pushing the monitor. **URL present + flip absent ⇒ HALT.**

Probed at PR-open time: **both absent** — the host is dark, both premises hold, the replace is free.

Then: `gh workflow run apply-web-platform-infra.yml -f apply_target=inngest-host-replace`. The plan must show exactly one `hcloud_server.inngest` replace + its 2 id-referencing dependents, with `hcloud_volume.inngest_redis` **preserved** (AC14).

**Must land before #6178 arms the flip.**

## Tests

`cloud-init-inngest-bootstrap.test.sh` 71/71 (incl. both pin guards + AC6b lockstep) · `cloud-init-user-data-size` 26/0 (the tag swap is length-neutral)

## Changelog

**Fixed**
- Dedicated Inngest host pinned to `soleur-inngest-bootstrap:v1.1.21`, the first image containing #6536's heartbeat fix. Web host moved to the same tag (`IREF` + `ZIREF`).

**Added**
- `AC6` drift-guard extended to the **dedicated** host's cloud-init pin, which previously had no guard at all — the gap that let it lag two releases behind and would have made the `inngest-host-replace` dispatch a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
