### PR TITLE
fix(infra): heartbeat needs PrivateTmp=true — root-owned /tmp/.doppler was the real #6536 cause

### DIFF
--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -248,6 +248,28 @@ Group=deploy
 # automatically, matching inngest-server.service's hardening pattern.
 # Surfaced 2026-05-20 once #4204's reconcile gate exposed the new unit shape.
 EnvironmentFile=/etc/default/inngest-server
+# #6536 ROUND 2 — this line is why the unit failed, and its absence is what 3,724 fires were.
+# MEASURED on the fresh host (the FIRST thing the SyslogIdentifier= channel below ever
+# shipped): `Doppler Error: open /tmp/.doppler/.doppler.yaml.XXXX: permission denied`.
+#
+# The env file above sets DOPPLER_CONFIG_DIR=/tmp/.doppler for EVERY doppler-wrapped unit.
+# That path is only safe under PrivateTmp: cloud-init-inngest.yml's boot isolation
+# self-check runs `doppler secrets` as ROOT (with HOME=/root and the same
+# DOPPLER_CONFIG_DIR, cloud-init-inngest.yml:212/226/289), so /tmp/.doppler exists
+# ROOT-OWNED from first boot. A unit with a PRIVATE /tmp never sees it and the CLI
+# recreates it as `deploy`; this unit shared the host /tmp and could not write there, so
+# `doppler run` died BEFORE exec -- the ping script never ran at all. Both siblings
+# (inngest-server, vector) already set this; the heartbeat was the lone omission, which is
+# exactly why they work and it did not.
+#
+# The #6536 plan REFUTED this hypothesis (H3) on reasoning: "they use different /tmps and
+# cannot collide" + "nothing mkdirs /tmp/.doppler; the CLI creates it lazily as deploy".
+# Both halves are false. The collision is not heartbeat-vs-sibling, it is
+# heartbeat-vs-ROOT's-boot-self-check; and the CLI creates it lazily as ROOT, before this
+# unit's first fire. It also explains the onset the plan could not attribute (13:00:38Z =
+# the host's boot, not a deploy): this unit has failed since its very first fire.
+# Do NOT remove without moving DOPPLER_CONFIG_DIR off the shared /tmp.
+PrivateTmp=true
 # #6536: WITHOUT this, systemd derives SYSLOG_IDENTIFIER from the ExecStart basename ->
 # "doppler", which matches ZERO vector.toml sources. The unit's own stderr (doppler's AND
 # curl's) then never leaves the host: the issue's _SYSTEMD_UNIT='inngest-heartbeat.service'
@@ -255,6 +277,8 @@ EnvironmentFile=/etc/default/inngest-server
 # Retagging onto the "inngest-heartbeat" channel (vector.toml Source 4, which carries NO
 # PRIORITY filter and so admits this unit's PRIORITY-6 output) is what makes the
 # "no row at all + unit failed" signature readable off-box, with no SSH.
+# This line is what made the PrivateTmp defect above diagnosable in 2 minutes, off-box,
+# after 3 days of a blind 60s storm. It earned its keep before the fix it shipped with did.
 SyslogIdentifier=inngest-heartbeat
 ExecStart=${DOPPLER_BIN} run --project ${DOPPLER_PROJECT} --config prd -- ${HEARTBEAT_SCRIPT}
 HEARTBEATEOF

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -151,6 +151,71 @@ assert "DOPPLER_BIN resolved via command -v before HEARTBEAT_UNIT write" \
 assert "heartbeat unit sets SyslogIdentifier=inngest-heartbeat (AC1, #6536)" \
   "printf '%s\n' \"\$HEARTBEAT_BLOCK\" | grep -qE '^SyslogIdentifier=inngest-heartbeat$'"
 
+# #6536 ROUND 2: EVERY doppler-wrapped unit MUST set PrivateTmp=true.
+#
+# Not a style rule — a correctness one. /etc/default/inngest-server sets
+# DOPPLER_CONFIG_DIR=/tmp/.doppler for all of them, and cloud-init-inngest.yml's boot
+# isolation self-check runs `doppler secrets` as ROOT against that same path
+# (cloud-init-inngest.yml:212/226/289), so /tmp/.doppler is ROOT-OWNED from first boot.
+# A unit with a private /tmp never sees it and the CLI recreates it as `deploy`; a unit on
+# the shared /tmp gets `permission denied`, and `doppler run` dies BEFORE exec — the child
+# never runs. That is measured, not theorised: it is verbatim what the heartbeat's channel
+# shipped on the fresh host, and it is why this unit failed every 60s for 3 days while its
+# two siblings (which already set PrivateTmp) were fine.
+#
+# ALL-MEMBERS, derived — not a spot-check of the one unit we just fixed. The heartbeat was
+# the lone omission out of three; the next doppler unit added here inherits the same trap,
+# and nothing else would catch it (the failure is invisible off-box by construction — that
+# is #6536's whole thesis). Enumerating from the source means a NEW unit is guarded the day
+# it lands, not the day it breaks.
+PRIVATE_TMP_VIOLATORS=$(python3 - "$BOOTSTRAP_SH" <<'PYEOF'
+import re, sys
+src = open(sys.argv[1]).read()
+bad = []
+# Each unit is written by `cat > "$VAR" <<'MARKER' ... MARKER`.
+for m in re.finditer(r'cat > "?\$\{?(\w+)\}?"? <<\'?(\w+EOF)\'?\n(.*?)\n\2', src, re.S):
+    var, body = m.group(1), m.group(3)
+    if '[Service]' not in body:
+        continue
+    execstart = re.search(r'^ExecStart=(.*)$', body, re.M)
+    if not execstart:
+        continue
+    # doppler-wrapped = the ExecStart runs the doppler CLI (literally or via ${DOPPLER_BIN}).
+    if 'doppler' not in execstart.group(1).lower() and 'DOPPLER_BIN' not in execstart.group(1):
+        continue
+    if not re.search(r'^PrivateTmp=true$', body, re.M):
+        bad.append(var)
+print(' '.join(bad))
+PYEOF
+)
+assert "every doppler-wrapped unit sets PrivateTmp=true (#6536 — root-owned /tmp/.doppler kills the child before exec)" \
+  "[[ -z '$PRIVATE_TMP_VIOLATORS' ]]"
+if [[ -n "$PRIVATE_TMP_VIOLATORS" ]]; then
+  echo "        VIOLATORS: $PRIVATE_TMP_VIOLATORS"
+  echo "        These units run doppler with DOPPLER_CONFIG_DIR=/tmp/.doppler on the SHARED"
+  echo "        /tmp, where cloud-init's root-run boot self-check already created that dir."
+  echo "        doppler run will exit 'permission denied' BEFORE exec and the child never runs."
+fi
+# Non-vacuity: the enumeration must actually FIND the units. A regex that matches nothing
+# reports zero violators and passes forever — the exact false-green this guard exists to
+# prevent. Three doppler units ship today (heartbeat, inngest-server, vector).
+DOPPLER_UNIT_COUNT=$(python3 - "$BOOTSTRAP_SH" <<'PYEOF'
+import re, sys
+src = open(sys.argv[1]).read()
+n = 0
+for m in re.finditer(r'cat > "?\$\{?(\w+)\}?"? <<\'?(\w+EOF)\'?\n(.*?)\n\2', src, re.S):
+    body = m.group(3)
+    if '[Service]' not in body:
+        continue
+    e = re.search(r'^ExecStart=(.*)$', body, re.M)
+    if e and ('doppler' in e.group(1).lower() or 'DOPPLER_BIN' in e.group(1)):
+        n += 1
+print(n)
+PYEOF
+)
+assert "PrivateTmp guard is non-vacuous: it found >=3 doppler-wrapped units (found $DOPPLER_UNIT_COUNT)" \
+  "[[ '$DOPPLER_UNIT_COUNT' -ge 3 ]]"
+
 # --- #6536 / FR3: heartbeat ping-script render split (@@DARK_ARM@@) ---
 echo ""
 echo "--- Heartbeat ping-script render split (@@DARK_ARM@@, #6536) ---"


### PR DESCRIPTION
Ref #6536 · follows #6539 + #6564 (both merged and delivered)

**#6539 shipped #6536's fix, the host was replaced with it, and the heartbeat still failed every 60s.** This is the real defect. It is one line.

## The observability half of #6539 is why this took two minutes instead of three days

`SyslogIdentifier=inngest-heartbeat` made the unit's stderr leave the host for the first time. That query returned **zero rows for three days**. The **first thing** the new channel ever shipped was the answer:

```
Doppler Error: open /tmp/.doppler/.doppler.yaml.Pbc4Qm46: permission denied
```

#6539's plan called that line *"the highest-value line in the PR."* It earned that before the fix it shipped with did.

## Mechanism — measured, not inferred

`/etc/default/inngest-server` sets `DOPPLER_CONFIG_DIR=/tmp/.doppler` for **every** doppler-wrapped unit. `cloud-init-inngest.yml`'s boot isolation self-check runs `doppler secrets` **as root** against that same path (`:212` writes `HOME=/root` + the dir; `:226`/`:289` use it) — so **`/tmp/.doppler` exists root-owned from first boot.**

A unit with a **private** `/tmp` never sees that dir and the CLI recreates it as `deploy`. The heartbeat shared the host's `/tmp`, could not write, and `doppler run` **died before exec** — so the ping script never ran, and neither did the dark arm #6539 added.

| unit | `PrivateTmp` | `User` | doppler-wrapped | works? |
|---|---|---|---|---|
| `inngest-server` | ✅ | deploy | yes | yes |
| `vector` | ✅ | deploy | yes | yes |
| **`inngest-heartbeat`** | ❌ | deploy | yes | **no — 3,724 failures** |

The heartbeat was the lone omission of three. That asymmetry *is* the bug.

## The plan refuted this hypothesis (H3), and both halves of its reasoning were wrong

> *"`inngest-server.service` sets `PrivateTmp=true`; the heartbeat sets none — so they use different `/tmp`s and **cannot collide**."*

The collision is not heartbeat-vs-sibling. It is heartbeat-vs-**root's boot self-check**.

> *"Nothing `mkdir`s `/tmp/.doppler`; the CLI creates it **lazily as `deploy`**."*

The CLI creates it lazily as **root**, at cloud-init, before this unit's first fire.

Meanwhile **H5** (absent URL → `curl` rc=2) was confirmed from a **dev-box** probe plus the URL's absence in Doppler — the unit's own stderr was never read, because it was invisible. And #6536 never reported an exit code at all; it reported only `Failed with result 'exit-code'` and *inferred* a post-ping step. **H5 was likely never reached.**

This also resolves the one thing #6539's plan could not attribute — the **13:00:38Z onset**. It searched for a deploy or commit and found none. That is the **host's boot time**: the unit has failed since its very first fire, because root-owned `/tmp/.doppler` exists from cloud-init onward.

FR3's dark arm is still correct and still needed. It simply was never the blocker.

## The guard

All-members, **derived from source**: every doppler-wrapped unit must set `PrivateTmp=true`. Deliberately not a spot-check of the unit fixed here — the next doppler unit added inherits the same trap, and nothing else would catch it (the failure is invisible off-box by construction, which is #6536's whole thesis).

Plus a **non-vacuity** assert: the enumeration must find ≥3 doppler units. A regex that matches nothing would otherwise report zero violators and pass forever — the exact false-green this guard exists to prevent.

**Mutation-proven, both halves:**

| | Result |
|---|---|
| with the fix | **112/112** |
| `PrivateTmp` removed | **111/112** → `VIOLATORS: HEARTBEAT_UNIT` |
| non-vacuity | found **3** doppler units |

Mutated a backup copy and restored from it — never the tracked file.

## Delivery

Same chain as #6564, and the window is still free (host dark, AC15 green): merge → tag `vinngest-v1.1.22` → verify the published image contains `PrivateTmp` → bump `IREF` → dispatch `apply_target=inngest-host-replace` → **verify the storm actually stops via Better Stack** (the `url_present=no` dark-arm row that has never once appeared).

## Changelog

**Fixed**
- `inngest-heartbeat.service` now sets `PrivateTmp=true`, matching its two sibling doppler units. Without it, root-owned `/tmp/.doppler` (created by cloud-init's root-run boot self-check) made `doppler run` exit `permission denied` before exec — the actual cause of #6536's 60s failure storm, and why #6539's dark arm never executed.

**Added**
- All-members guard: every doppler-wrapped unit must set `PrivateTmp=true`, derived from source, with a non-vacuity floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
