### PR TITLE
docs(adr): ADR-118 — resolve the #6538 B-GATE (proxy-tls cert rotation)

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-118-proxy-cert-sans-track-the-cluster-roster.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-118-proxy-cert-sans-track-the-cluster-roster.md
@@ -1,0 +1,239 @@
+---
+adr: 118
+title: A shared cert's SANs are the cluster roster — re-mint on membership change, never pin
+status: accepted
+date: 2026-07-17
+amends: ADR-068
+supersedes: none
+issue: 6538
+---
+
+# ADR-118: Proxy cert SANs track the cluster roster
+
+## Context
+
+`apps/web-platform/infra/proxy-tls.tf` mints the host↔host session-router proxy's TLS
+material. Both SAN inputs derive from the web-host cluster roster, and both are
+`RequiresReplace`:
+
+```hcl
+ip_addresses = [for h in values(var.web_hosts) : h.private_ip]
+dns_names    = concat(keys(var.web_hosts), ["localhost"])
+```
+
+PR B (#6538) removes the `"web-2"` key from `var.web_hosts` to retire an fsn1 orphan.
+That replaces the cert and rotates `PROXY_TLS_CERT` in Doppler `prd` — the value the
+proxying client pins as `ca:` with `rejectUnauthorized: true`.
+
+**The file contains no `web-2` literal.** PR B's reference sweep, AC-B4, and the
+push-apply-scope measurement are all token-based, so all three are structurally blind to
+it. The coupling is by *derivation*, not by mention. It fires at neither merge nor the
+targeted apply — it is latent, surfacing only on the next untargeted plan.
+
+### What was verified, and what turned out to be false
+
+The plan's §Open Decision framed this as a live-origin blast-radius problem. It is not.
+
+**The proxy path is dark — three independent locks, any one sufficient:**
+
+| Lock | Evidence |
+|---|---|
+| Feature flag | `ws-handler.ts` gates the only call site on `isGitDataStoreEnabled()`; `workspace-resolver.ts` = `process.env.GIT_DATA_STORE_ENABLED === "true"`, unset in prod |
+| Host roster | `session-router.ts` — `SOLEUR_HOST_ROSTER` unset → empty roster → routes resolve `owner-unresolved`, **never** `proxy` |
+| Listener bind | `index.ts` — `SOLEUR_PROXY_BIND` unset → `createProxyServer` fail-closes → returns `null`, no listener |
+
+No Terraform provisions any of those three vars. No load balancer resource exists in any
+root. `dns.tf` pins `app.soleur.ai` to `hcloud_server.web["web-1"]` as a singleton; the
+for_each round-robin is deferred prose, not code. `session-proxy.ts` states it directly:
+*"INERT until 3.D: at a single host every route resolves `local`, so proxyClientToOwner is
+never called and the owner's proxy listener has no peers."*
+
+**Three corrections to the plan's own text, recorded so they are not re-derived:**
+
+1. **The "TLS handshake failure across the proxy path" risk is vacuous.** The TLS server
+   cert and the pinned client CA are the *same PEM read from the same env var on the same
+   host*. A stale-but-consistent host verifies against itself. Vintage skew requires two
+   hosts with different container-start times — exactly what the destroy removes. The risk
+   as stated cannot occur, and §User-Brand Impact repeats it.
+2. **Only `PROXY_TLS_CERT` rotates — not `PROXY_TLS_KEY`.** `doppler_secret.proxy_tls_key`
+   reads `tls_private_key.proxy_server.private_key_pem`, and that resource has zero
+   dependency on `var.web_hosts`, so it is never replaced. Same key, new cert. This is not
+   a key-hygiene event in either direction.
+3. **The drift alarm is real.** `cron-terraform-drift.ts` fires `{ cron: "0 6,18 * * *" }`
+   and `scheduled-terraform-drift.yml` runs `terraform plan -detailed-exitcode` with no
+   `-target`. On exit 2 it files one issue, then comments "Drift still present" every 12h
+   forever, plus two emails/day to ops. No allow-list can silence a known-benign diff.
+
+**Empirically measured** against the pinned `hashicorp/tls 4.3.0`, reproducing the real
+state SANs (`ip_addresses ["10.0.1.10","10.0.1.11"]`, `dns_names ["web-1","web-2","localhost"]`):
+
+| Config | `terraform plan` |
+|---|---|
+| SANs hardcoded to current values, web-2 dropped | `No changes.` — a true no-op |
+| SANs derived (status quo), web-2 dropped | `must be replaced` → `1 to add, 0 to change, 1 to destroy` |
+| SANs hardcoded but **reordered** | `must be replaced` — the attributes are order-sensitive `ListAttribute`s |
+
+So both options work mechanically. The decision is not about risk; it is about which
+invariant survives.
+
+## Decision
+
+**Bring the cert and `doppler_secret.proxy_tls_cert` into PR B's scope. Rotate
+deliberately, now, inside the supervised operator-local apply.**
+
+`proxy-tls.tf` is **unchanged** — a zero-line diff. The for-expressions already compute the
+right answer; this decision just lets them.
+
+### Why
+
+**The repo already ruled on this, and a test enforces it.**
+`plugins/soleur/test/terraform-target-parity.test.ts` carries the written rationale for
+exempting these addresses from CI targeting:
+
+> the host↔host proxy TLS keypair/cert + their prd doppler_secrets belong to
+> the web-host cluster (SANs = web host private IPs) and ride the same
+> cluster apply
+
+That is not a comment — it is the justification for an exemption the test enforces. It
+asserts the cert's lifecycle **is** the cluster's lifecycle. PR B's operator-local apply
+*is* that cluster apply, and the first one since the cert was minted. Option 1 is not scope
+creep; it is the first discharge of a promise the repo already made.
+
+Pinning the SANs would **falsify that rationale in place**: `SANs = web host private IPs`
+becomes false, `belong to the web-host cluster` becomes false, and the exemption survives
+with a lying justification that nothing updates.
+
+**The shared-cert deviation is the whole reason this decision exists — and it cuts toward
+re-minting.** ADR-068 specified *"a long-lived self-signed server cert per host"*.
+`proxy-tls.tf` deliberately deviates to a **single shared** cert whose SANs cover every
+host, because web-1's frozen cloud-init (`ignore_changes = [user_data]`) cannot deliver
+per-host Doppler selection. Under the per-host design, retiring web-2 would simply drop
+web-2's cert — no churn, no decision. The shared design *deliberately couples cert identity
+to cluster membership*. Pinning freezes a shared cert so it stops tracking the cluster it is
+shared by, severing the one invariant the deviation was built around.
+
+**Cost is monotonically increasing in time.** Today the rotation is provably free: the path
+is dark, there is one host, the cert is unconsumed. After the 3.D cutover it is not (two
+hosts, live proxy, coordinated restarts). Accepting the drift *guarantees* the rotation
+happens anyway — someone eventually clears the 12h alarm with a full apply — but at an
+unknown later date, possibly past 3.D, at strictly higher cost. Rotate at the global
+minimum. That minimum is now.
+
+**This does not violate ADR-068's "no rotation cron."** That clause rejects *time-based,
+scheduled* rotation of a multi-year cert. It says nothing about re-minting when the SAN set
+legitimately changes — and `RequiresReplace` on `ip_addresses`/`dns_names` makes that
+re-mint the explicit design. Event-driven re-mint on cluster-membership change is the design
+working, not a deviation from it.
+
+### What this decision explicitly does NOT rest on
+
+**The dangling SAN is cosmetic, not a vulnerability.** Stated plainly so no reader mistakes
+this for a security fix. A SAN is a *name assertion*, not a credential. Presenting the cert
+requires `PROXY_TLS_KEY`, which lives in Doppler `prd` and reaches only our hosts. An
+attacker on `10.0.1.11` without the key cannot use a stale SAN for anything; an attacker
+*with* the key owns the trust domain regardless of SANs. The confused-deputy path is gated
+by `SOLEUR_HOST_ROSTER`, which won't list a destroyed host. Net security delta between
+rotating and not rotating is approximately zero. **The deciding axis is
+correctness-at-cutover, not security.**
+
+## Rejected alternatives
+
+**Option 2 — accept and document the drift. Rejected: dominated on every axis.** It pays a
+permanent 12h alarm plus two emails/day *and* still ends in the same rotation, later and
+unbounded. Alarm fatigue on the detector that guards prod is itself the harm: it trains the
+operator to ignore exit-2.
+
+**Option 3 — pin the SANs to a static list. Rejected: it converts a loud alarm into a silent
+break.** Its steelman is real — it is a proven no-op, it leaves the 5-address gate and the
+measured shape untouched, and it avoids touching prod TLS material during a prod-destroy PR.
+It fails anyway:
+
+- **It moves the failure to the worst possible moment.** At the 3.D cutover a new `web-3` in
+  `var.web_hosts` gets **no SAN**. The pinned cert doesn't change. The client pins the CA,
+  dials web-3's private IP, and TLS verification fails at SAN-mismatch — on the live path, at
+  the exact moment the feature goes live.
+- **It blinds the only sensor that would catch that.** A static pin doesn't drift when a host
+  is added: state == config, so the drift detector stays green. Option 1's derivation would
+  have added the SAN automatically.
+- **The gate objection is a category error.** `web2_retire_allow` membership is exact-equality
+  via `IN(.address; web2_retire_allow[])` — the same mechanism the existing `web2_allow`
+  recreate set uses, whose header warns against substring matching for precisely this reason.
+  Adding two cert addresses cannot admit
+  `hcloud_volume.workspaces["web-1"]`; they are exact strings in a disjoint resource-type
+  space. The allow-list is a set of exact addresses, not a risk budget.
+- **It has the larger source diff.** Option 1 changes zero lines of `proxy-tls.tf`; Option 3
+  requires hardcoding `10.0.1.10`/`10.0.1.11` into prod TLS material inside a destroy PR.
+- **The pin is reorder-fragile.** `ip_addresses` is a `RequiresReplace` ListAttribute
+  (measured above). `values(var.web_hosts)` is map-key-ordered and stable by construction; a
+  hand-maintained list forces a spurious replacement on a cosmetic edit.
+- **3.D is not speculative.** It is *why this PR exists*: a host born in fsn1 can never join
+  `web_spread`, so web-2 must be destroyed and re-born to reach active-active. Option 3 plants
+  a silent failure directly in the path of the work that motivates the PR.
+
+## Consequences
+
+### PR B must
+
+- **`-target` list 5 → 6** — add `-target=doppler_secret.proxy_tls_cert`. One target
+  suffices: `-target` is transitive **on dependencies**, so it pulls in
+  `tls_self_signed_cert.proxy_server` → `tls_private_key.proxy_server`. Do **not** add
+  `-target=doppler_secret.proxy_tls_key`; it is not in the plan, and adding it invites the
+  false belief that the key rotates.
+- **`web2_retire_allow` 5 → 7** — the `-target` list and the allow-list are different lists;
+  the allow-list must name everything that *appears* in the plan:
+  `tls_self_signed_cert.proxy_server` (replace: delete+create) and
+  `doppler_secret.proxy_tls_cert` (update-in-place).
+- **Two new counters**, mirroring the existing `firewall_attachment_ok` pattern:
+  `cert_replaced` (`<= 1`, delete+create only — the plan's idempotent-retry shape) and
+  `doppler_cert_ok` (exactly one `update`, **never `delete`** — a delete strips
+  `PROXY_TLS_CERT` from Doppler `prd`; harmless while dark, but it must fail closed).
+- **Assert a deliberate omission:** `tls_private_key.proxy_server` must **NOT** be in
+  `web2_retire_allow`. It should never plan a change; if it ever does, that is a key rotation
+  and `web2_out_of_scope_changes` must halt. Add a synthesized fixture (key change present →
+  FAIL), per `cq-test-fixtures-synthesized-only`.
+- **Re-measure, do not encode.** The push-apply-scope measurement
+  (`0 to add, 1 to change, 1 to destroy`) is **unchanged** — the cert is unreachable from that
+  scope, since `-target` is transitive on dependencies, not dependents, and nothing in the
+  push-apply list depends on the cert. The **B3 local-apply shape does change**, and a cert
+  replace is `1 to add, 0 to change, 1 to destroy`, so the destroy count increments. AC-B1
+  already mandates empirical re-measurement at B0; that mandate governs. Encoding a predicted
+  number here would repeat the v1 P0 miss that the 5th address already cost once.
+- **Add a derivation sweep to B0.** `proxy-tls.tf` has zero `web-2` literals, so the token
+  grep cannot see it. Add `git grep -n 'var\.web_hosts' apps/web-platform/infra` as a second
+  sweep and diff AC-B4 against that hit-set too.
+
+`host_creates` is **not** tripped: the tripwire is type-scoped to `hcloud_server`/
+`hcloud_volume`, so the cert's create does not fire the mirrored wedge.
+
+### The transferable lesson
+
+**A token grep is structurally blind to derived coupling.** The sweep enumerated *mentions*
+and missed *dependents*. This is `hr-write-boundary-sentinel-sweep-all-write-sites` in its
+read-side form: when a variable is a fleet-wide coupling, the reference sweep must enumerate
+what *derives from* it, not what *names* it.
+
+### Relationship to #6574
+
+The same defect class, mirrored:
+
+- **#6574:** `hcloud_firewall_attachment.web` is **in** the push-apply graph while the header
+  claims it is excluded. *In the graph, claimed out.*
+- **proxy-tls:** the cert is **out** of every apply path while the parity test's rationale
+  claims it *"ride[s] the same cluster apply"* — but there is no cluster-apply job. The
+  "cluster apply" is an operator ritual, not automation. *Out of the graph, claimed in.*
+
+Both reduce to: **`var.web_hosts` is a fleet-wide coupling that the `-target` boundary does
+not model.** #6574's own framing — *"real as a target, and a fiction as a boundary"* —
+applies verbatim. No blocking dependency (#6574's candidate fix doesn't touch the cert, and
+it is out of scope for PR B). This decision makes the parity test's claim true for the first
+time; a sibling issue tracks the fact that its exclusion rationale names an apply path that
+exists only as a human habit.
+
+### 3.D
+
+Option 1 is the precondition that makes 3.D safe by default. With the derivation intact, the
+cutover PR adds its host to `var.web_hosts` and the SANs follow automatically — the cert
+replacement appears in that PR's own plan, under its own review, with the proxy still gated
+by `isGitDataStoreEnabled()`. Under a pin, 3.D's author must *remember* to hand-edit a
+hardcoded IP list in a file whose name doesn't mention hosts, with no gate, no drift signal,
+and no test to catch the omission.

--- a/knowledge-base/project/plans/2026-07-16-chore-retire-web-2-fsn1-orphan-plan.md
+++ b/knowledge-base/project/plans/2026-07-16-chore-retire-web-2-fsn1-orphan-plan.md
@@ -145,6 +145,23 @@ section mid-implementation.
    ```
    Capture the hit-set to a file at B0 — **AC-B4 diffs against it** rather than grading
    prose. (Measured today: **311 hits / 45 files** — v1's AC4 was unsatisfiable.)
+2b. **Derivation sweep (ADR-118 — the sweep above cannot find what created the B-GATE).**
+   The token grep enumerates *mentions*; `proxy-tls.tf` couples to web-2 purely by
+   *derivation* (`for h in values(var.web_hosts)`) and contains **zero** `web-2` literals,
+   so step 2, AC-B4 and the measurement missed it simultaneously. Capture a second hit-set:
+   ```
+   git grep -ln 'var\.web_hosts' apps/web-platform/infra    # 9 files, measured 2026-07-17
+   ```
+   Audit **every dependent** (not every mention) for ForceNew-on-membership-change *and for
+   host-count assumptions*, and diff AC-B4 against this set too. The **nine**:
+   `server.tf`, `network.tf`, `dns.tf`, `placement-group.tf`, `proxy-tls.tf`, `variables.tf`,
+   **`web-hosts-fanout-parity.test.sh`**, **`tests/web-hosts-eu-pin.tftest.hcl`**,
+   **`scripts/deploy-status-fanout-verify.sh`**.
+
+   ⚠️ **The last three were themselves missed by the first draft of this very step** (it
+   listed six from memory instead of running the command). That is the ADR-118 lesson
+   recurring inside its own remediation: **run the sweep, do not recall it.** Derive this list
+   fresh at B0 — if it returns more than nine, audit the extras rather than assuming noise.
 3. **Do NOT** join the `web-1-swap` concurrency group (v1 would have red-CI'd:
    `web-1-swap-concurrency-parity.test.sh` asserts a named member allow-list **and**
    exactly 4 `group: web-1-swap` occurrences). Moot under the local-apply mechanism —
@@ -157,7 +174,7 @@ section mid-implementation.
 `tests/scripts/lib/destroy-guard-filter-web-platform.jq` already implements
 exact-equality via `IN(.address; web2_allow[])`. Its `web2_allow` is a **recreate**
 set — 3 addresses, deliberately excluding the volume (that is AC15). Add a sibling
-`web2_retire_allow` with **five**:
+`web2_retire_allow` with **seven** *(5 + the 2 added by ADR-118)*:
 
 ```
 hcloud_server.web["web-2"]
@@ -165,7 +182,27 @@ hcloud_server_network.web["web-2"]
 hcloud_volume_attachment.workspaces["web-2"]
 hcloud_volume.workspaces["web-2"]        # retire DESTROYS it (inverts AC15)
 hcloud_firewall_attachment.web           # the measured "1 to change" — update-only
+tls_self_signed_cert.proxy_server        # ADR-118 — replace (delete+create); cert_replaced <= 1
+doppler_secret.proxy_tls_cert            # ADR-118 — update-only; doppler_cert_ok, NEVER delete
 ```
+
+`tls_private_key.proxy_server` is **deliberately absent** — it has no `var.web_hosts`
+dependency, so it must never plan a change; if it does, that is a key rotation and
+`web2_out_of_scope_changes` must halt. Assert this with a synthesized fixture, don't assume it.
+
+Adding the two cert addresses **cannot weaken the gate**: membership is exact-equality via
+`IN(.address; web2_retire_allow[])` (the filter's own header warns against substring matching
+for precisely this reason), and they are exact strings in a resource-type space disjoint from
+`hcloud_volume.workspaces["web-1"]`. The allow-list is a set of exact addresses, not a risk budget.
+⚠️ **Name the RETIRE array, not the recreate one** — the existing `web2_allow` is the 3-address
+*recreate* set above; the new predicate must read `web2_retire_allow[]`. Copy-pasting
+`web2_allow[]` into B1.4 silently grades the retire plan against the recreate allow-set.
+
+**The corresponding `-target` list gains only ONE entry (5 → 6)** — the two lists are not the
+same list. `-target=doppler_secret.proxy_tls_cert` transitively pulls in
+`tls_self_signed_cert.proxy_server` → `tls_private_key.proxy_server`, because `-target` is
+transitive on *dependencies*. The allow-list must name everything that **appears in the plan**;
+the `-target` list names only what must be **reached**.
 
 **The 5th address is a v1 P0 miss.** The precedent targets its firewall attachment
 deliberately (`registry_region_migrate` comments *"the registry server + its 3
@@ -210,9 +247,30 @@ Make the destroy-HALT name `[skip-web-platform-apply]` and warn that `[ack-destr
 here may be a *partial* destroy. **In PR B, not #6575** — we create this hazard, so we
 carry its mitigation; and it is a one-string safety fix, not machinery deletion.
 
-### B3 — var removal + `proxy-tls` decision (SEE §Open Decision)
+### B3 — var removal + the `proxy-tls` decision (SEE §Resolved Decision / ADR-118)
 
-Remove the `"web-2"` key + its rationale comment. `terraform fmt` + `validate` clean.
+1. Remove the `"web-2"` key + its rationale comment from `var.web_hosts`.
+2. **`proxy-tls` — ADR-118, Option 1.** `proxy-tls.tf` must end **byte-identical to `main`**
+   (a zero-line diff — the existing for-expressions already compute the right answer; if that
+   file changed, the wrong option was implemented). The work lives entirely in the gate
+   (B1.4/B1.4b) and the `-target` list (B6). **Do NOT hardcode/pin the SAN list** — rejected
+   Option 3.
+3. `terraform fmt` + `validate` clean.
+4. **Fix `web-hosts-fanout-parity.test.sh` — PR B red-CIs it otherwise** (CI-registered at
+   `.github/workflows/infra-validation.yml:434`; measured against a simulated B3.1, not
+   predicted). Two distinct edits, both required:
+   - **Three workflow literals must move in lockstep** with the roster —
+     `web-platform-release.yml:563`, `apply-web-platform-infra.yml:710` and `:974` each
+     hardcode `WEB_HOST_PRIVATE_IPS: "10.0.1.10,10.0.1.11"` → `"10.0.1.10"`.
+   - **The test's own hardcoded 2-host floor** (`if [ "$tf_n" -lt 2 ]; then fail "… — parser
+     drift"`) must drop to `-lt 1`. Correcting only the literals still leaves `3 passed, 1
+     failed`, and it fails with a message blaming *parser drift* rather than the roster — fix
+     the message too, or the next reader debugs the wrong thing.
+
+   ⚠️ **Ordering trap for #6575:** apply-workflow copies #1/#2 live in the
+   `warm_standby`/`web_2_recreate` jobs that **#6575 deletes after B6** — and
+   `check_all_copies "$APPLY_WORKFLOW" … 2` pins `min_copies=2`, so #6575's deletion trips
+   `expected >=2 copies, found 0`. #6575 must lower `min_copies` in the same PR.
 
 ### B4 — ADR-068 amendment + C4
 
@@ -239,13 +297,18 @@ practice, and the token must survive for the audit trail). Add an amendment note
 ### B6 — Merge, apply, verify, close
 
 1. Merge PR B with `[skip-web-platform-apply]` **on its own line** of the squash commit.
-2. Produce the saved plan locally (`-target` the 5 addresses, `-out=tfplan`), run
+2. Produce the saved plan locally (`-target` the **6** addresses — the 5 plus
+   `doppler_secret.proxy_tls_cert` per ADR-118; the gate's `web2_retire_allow` is a
+   **different list** and carries **7** — `-out=tfplan`), run
    `terraform show -json tfplan | jq -f destroy-guard-filter-web-platform.jq`, and show
    the operator the gate verdict **and** the exact apply command.
 3. **Wait for explicit per-command go-ahead** (`hr-menu-option-ack-not-prod-write-auth`
    — per-command confirmation; menu acks and prior approvals do NOT extend). Then apply
    in-session. This is a confirm-then-run, **never** a checklist handed over
-   (`hr-never-defer-operator-actions`).
+   (`hr-ship-message-no-operator-checklist`). *(Corrected 2026-07-17: this cited
+   `hr-never-defer-operator-actions`, which does not exist in AGENTS.md and is not in
+   `scripts/retired-rule-ids.txt` — a fabricated ID, structurally indistinguishable from a
+   real one. Pre-existing on `main`; fixed inline rather than deferred.)*
 4. Verify by self-pull (`hr-no-dashboard-eyeball-pull-data-yourself`), then
    `gh issue close 6538 6463`.
 
@@ -254,49 +317,79 @@ persists and every merge needs the skip token. **Time-box: 1 hour.** Past that, 
 PR B (re-add the `web_hosts` key) — state and config re-converge, window closes, retry
 later. **AC-B10** covers this.
 
-## Open Decision — `proxy-tls` cert rotation (P0, unresolved)
+## Resolved Decision — `proxy-tls` cert rotation (was P0; **RESOLVED 2026-07-17**)
+
+**Ruled: Option 1 — bring the cert + `doppler_secret.proxy_tls_cert` into PR B's scope
+and re-mint deliberately inside the supervised operator-local apply.** Full rationale and
+rejected alternatives: **[ADR-118](../../engineering/architecture/decisions/ADR-118-proxy-cert-sans-track-the-cluster-roster.md)**
+(CTO ruling, deepen-plan 2026-07-17). `proxy-tls.tf` is **unchanged** — a zero-line diff;
+the existing for-expressions already compute the right answer.
+
+**The B-GATE is cleared. B0–B6 may proceed.**
 
 `apps/web-platform/infra/proxy-tls.tf`:
 
 ```hcl
 resource "tls_self_signed_cert" "proxy_server" {
-  ip_addresses = [for h in values(var.web_hosts) : h.private_ip]
-  dns_names    = concat(keys(var.web_hosts), ["localhost"])
+  ip_addresses = [for h in values(var.web_hosts) : h.private_ip]   # RequiresReplace
+  dns_names    = concat(keys(var.web_hosts), ["localhost"])        # RequiresReplace
 }
 resource "doppler_secret" "proxy_tls_cert" { ... }
 ```
 
-Both inputs are **ForceNew**. Removing web-2 **replaces the cert** and rotates
-`PROXY_TLS_CERT` / `PROXY_TLS_KEY` in Doppler `prd` — the runtime value the proxying
-client pins as `ca:` with `rejectUnauthorized: true`.
+Removing web-2 **replaces the cert** and rotates `PROXY_TLS_CERT` in Doppler `prd` — the
+value the proxying client pins as `ca:` with `rejectUnauthorized: true`.
 
 **It contains no `web-2` literal**, so B0's grep, AC-B4, and the measurement (outside the
-2-target scope) **all miss it**. It fires at neither merge nor the 5-target apply — it is
-*latent*, surfacing on the next **full** plan: `scheduled-terraform-drift.yml` runs
+2-target scope) **all miss it**. The coupling is by *derivation*, not by mention — a token
+grep is structurally blind to it (see B0's added `var.web_hosts` sweep). Left un-applied it
+is *latent*, surfacing on the next **full** plan: `scheduled-terraform-drift.yml` runs
 `terraform plan -detailed-exitcode` with **no `-target`** → a permanent 12h drift alarm
-auto-filing issues. This **falsifies** v1's claim that the drift detector is
-"independent confirmation".
+(`cron: 0 6,18 * * *`, one issue + a "Drift still present" comment every 12h + 2 emails/day
+to ops, with no allow-list to silence it). This **falsifies** v1's claim that the drift
+detector is "independent confirmation".
 
-Three options, none free — **route to `/soleur:deepen-plan`** (the plan skill mandates it
-at `single-user incident`, and its data-integrity + security triad is the right lens):
+### Two corrections to this section's own v2 text (verified 2026-07-17)
 
-1. **Bring cert + both Doppler secrets into the retire scope.** Correct end-state, but
-   rotates the pinned CA under a **running web-1** that baked the old cert at container
-   start → mismatch until web-1's next restart. Blast radius on the live origin.
-2. **Accept + document the drift.** Permanent 12h alarm until someone runs the
-   operator-local full apply — which then rotates the cert anyway, unsupervised.
-3. **Decouple the cert from `var.web_hosts`** (pin the SAN list, or fan `for_each`) so
-   removing a host is not ForceNew. Cleanest; adjacent to #6574.
+1. **Only `PROXY_TLS_CERT` rotates — NOT `PROXY_TLS_KEY`.** This section previously named
+   both. `doppler_secret.proxy_tls_key` reads `tls_private_key.proxy_server.private_key_pem`,
+   and that resource has **zero** dependency on `var.web_hosts`, so it is never replaced.
+   Same key, new cert.
+2. **The "blast radius on the live origin" that motivated the deferral does not exist.** The
+   proxy path is dark behind three independent locks (`GIT_DATA_STORE_ENABLED` unset;
+   `SOLEUR_HOST_ROSTER` unset → `owner-unresolved`, never `proxy`; `SOLEUR_PROXY_BIND` unset
+   → no listener). Further, a mismatch is *structurally impossible*: the TLS server cert and
+   the pinned client CA are the same PEM read from the same env var on the same host, so a
+   stale host verifies against itself; skew needs two hosts of different vintages, which the
+   destroy removes. §User-Brand Impact repeats this vacuous risk and is corrected below.
 
-**Do not start B3 until this is decided.**
+### The three options, and why Option 1 won (summary; ADR-118 is authoritative)
+
+1. **Bring cert + the cert's Doppler secret into the retire scope.** **CHOSEN.** The cost is
+   provably zero *today* (path dark, one host, cert unconsumed) and monotonically increasing
+   after the 3.D cutover. `terraform-target-parity.test.ts` already carries a *tested*
+   rationale that the cert *"belong[s] to the web-host cluster (SANs = web host private IPs)
+   and ride[s] the same cluster apply"* — PR B's local apply **is** that cluster apply.
+2. **Accept + document the drift.** Rejected — dominated: pays a permanent alarm *and* still
+   ends in the same rotation, later, unbounded. Alarm fatigue on the detector guarding prod
+   is itself the harm.
+3. **Decouple / pin the SAN list.** Rejected despite being a *proven* no-op (measured:
+   `No changes.`). It falsifies the parity test's rationale in place, and at 3.D a new host
+   gets no SAN → TLS verification fails on the live path **with the drift detector blinded**
+   (a static pin doesn't drift when a host is added). Trading a loud alarm for a quiet break
+   is not conservative.
 
 ## User-Brand Impact
 
 - **If this lands broken, the user experiences:** a total prod outage if the destroy
-  mis-scopes onto **web-1** (the live origin — app A-record; only tunnel connector), or
-  a TLS handshake failure across the proxy path if the cert rotates under a running
-  web-1 (§Open Decision). web-2's own retirement is user-invisible: never served, no LB,
-  empty volume.
+  mis-scopes onto **web-1** (the live origin — app A-record; only tunnel connector).
+  web-2's own retirement is user-invisible: never served, no LB, empty volume.
+  *(Corrected 2026-07-17, ADR-118: this bullet previously also claimed "a TLS handshake
+  failure across the proxy path if the cert rotates under a running web-1". That risk is
+  **vacuous** — the proxy path is dark behind three independent locks, and the server cert
+  and pinned client CA are the same PEM from the same env var on the same host, so a stale
+  host verifies against itself. Vintage skew requires two hosts; the destroy leaves one.
+  The mis-scope-onto-web-1 risk is the sole survivor, and it is what the gate defends.)*
 - **If this leaks, the user's data is exposed via:** n/a — volume empty, never held a
   worktree; all DCs EU (CLO: residency neutral).
 - **Brand-survival threshold:** `single-user incident` — from the destroy path's blast
@@ -336,9 +429,9 @@ failure_modes:
   - mode: "concurrent merge during the window"
     detection: "push-apply destroy-guard HALTs on destroy_count>0 (measured: 1)"
     alert_route: "merge fails loudly; B2 makes its error text name the CORRECT recovery"
-  - mode: "proxy-tls cert drift (latent — see Open Decision)"
-    detection: "scheduled-terraform-drift.yml full plan (no -target)"
-    alert_route: "auto-filed drift issue"
+  - mode: "proxy-tls cert re-mint not applied (would leave a permanent 12h drift alarm)"
+    detection: "in-scope per ADR-118 — the B1.4b counters cert_replaced + doppler_cert_ok, evaluated over the SAVED plan JSON at B6; scheduled-terraform-drift.yml full plan (no -target, cron 0 6,18 * * *) is the backstop that fires if the re-mint never applies"
+    alert_route: "gate fails before apply; else auto-filed drift issue + 12h comment thread + 2 emails/day to ops"
 logs: { where: "in-session apply output + GitHub Actions for the merge", retention: "GitHub default 90d" }
 discoverability_test:
   command: "curl -sS -H \"Authorization: Bearer $HCLOUD_TOKEN\" 'https://api.hetzner.cloud/v1/servers?name=soleur-web-2' | jq '.servers | length'"
@@ -380,18 +473,52 @@ No `ssh` anywhere. Soak follow-through (2.9.1): n/a — verified synchronously.
 ### PR B (pre-merge)
 
 - **AC-B1** — Both measurements re-run at B0 and recorded verbatim in the PR body.
-- **AC-B2** — `web2_retire_allow` has exactly the **5** addresses incl.
-  `hcloud_firewall_attachment.web`.
+  **Per ADR-118 there are now two distinct shapes and they must not be conflated:** the
+  **push-apply-scope** measurement is **unchanged** (`0 to add, 1 to change, 1 to destroy`)
+  — the cert is unreachable from that scope, since `-target` is transitive on *dependencies*,
+  not *dependents*, and nothing in the push-apply list depends on the cert. The **B3
+  local-apply** shape **does** change (a cert replace is `1 to add, 0 to change, 1 to
+  destroy`, so the destroy count increments). **Measure both; encode neither** — a predicted
+  counter here would repeat the v1 P0 miss that the 5th address already cost once.
+- **AC-B2** — `web2_retire_allow` has exactly the **7** addresses *(was 5; ADR-118 adds two)*:
+  the four `["web-2"]` addresses + `hcloud_firewall_attachment.web`, plus
+  `tls_self_signed_cert.proxy_server` (replace: delete+create) and
+  `doppler_secret.proxy_tls_cert` (update-in-place). The **`-target` list is a different
+  list and gains only one entry (5 → 6)**: `-target=doppler_secret.proxy_tls_cert`, which
+  transitively pulls in the cert → key. **Do NOT add `-target=doppler_secret.proxy_tls_key`**
+  — the key does not rotate, and naming it invites the false belief that it does.
+  Two new counters mirroring `firewall_attachment_ok`: `cert_replaced` (`<= 1`,
+  delete+create only) and `doppler_cert_ok` (exactly one `update`, **never `delete`** — a
+  delete strips `PROXY_TLS_CERT` from Doppler `prd`). **Deliberate omission, asserted not
+  assumed:** `tls_private_key.proxy_server` is **NOT** in the allow-list — it must never plan
+  a change, and if it does, that is a key rotation and `web2_out_of_scope_changes` must halt.
+  (`host_creates` is not tripped: that tripwire is type-scoped to `hcloud_server`/
+  `hcloud_volume`.)
 - **AC-B3** — Gate tests (extending `test-destroy-guard-counter-web-platform.sh`) REJECT:
   web-1 touch; non-web-2 volume destroy; server-only partial; firewall-attachment delete;
-  unparseable plan. And ACCEPT a 3-of-4 retry-after-partial. Proven by test, not inspection.
+  unparseable plan; **a `doppler_secret.proxy_tls_cert` `delete` (must be `update`-only)**;
+  and **any `tls_private_key.proxy_server` change (key rotation → halt)**. And ACCEPT a
+  3-of-4 retry-after-partial **and a cert-replaced-but-Doppler-update-not-yet-applied
+  partial** (Terraform applies sequentially and can die between the two — the `<= 1` /
+  subset-not-equality shape must hold here too). Proven by test, not inspection; fixtures
+  synthesized per `cq-test-fixtures-synthesized-only`.
 - **AC-B4** — Reference sweep: `git grep` over the **corrected** path set diffs clean
   against the B0-captured expected hit-set. (Not "returns only historical prose" — v1's
   AC4 had no machine-checkable verdict and returned 311 hits.)
+  **Second sweep, added per ADR-118 — this is the miss that created the B-GATE:** a token
+  grep enumerates *mentions* and is structurally blind to *derived* coupling, which is why
+  `proxy-tls.tf` (zero `web-2` literals) evaded B0's grep, AC-B4 and the measurement all at
+  once. Add `git grep -n 'var\.web_hosts' apps/web-platform/infra` and diff AC-B4 against
+  **that** hit-set too, auditing every dependent — not just every mention. This is
+  `hr-write-boundary-sentinel-sweep-all-write-sites` in its read-side form.
 - **AC-B5** — Destroy-HALT `::error::` text names `[skip-web-platform-apply]` and warns
   that `[ack-destroy]` may be partial.
-- **AC-B6** — §Open Decision resolved and its choice implemented; `terraform validate`
-  clean; `terraform fmt -check` clean.
+- **AC-B6** — §Resolved Decision closed (**done: ADR-118, Option 1**) and its choice
+  implemented — i.e. `web2_retire_allow` at 7, the `-target` list at 6, the two new
+  counters, the key-rotation-halt fixture, and B0's `var.web_hosts` derivation sweep all
+  landed. `proxy-tls.tf` itself must be **byte-identical to `main`** (the ruling is a
+  zero-line diff to that file — if it changed, the wrong option was implemented).
+  `terraform validate` clean; `terraform fmt -check` clean.
 - **AC-B7** — ADR-068 amended with both rejected options; `model.c4`'s two falsified
   descriptions corrected; `c4-code-syntax.test.ts` + `c4-render.test.ts` pass.
 - **AC-B8** — `bash scripts/test-all.sh` green. If a new suite file is added, it is
@@ -442,7 +569,14 @@ Four were mine and would have shipped:
   four per-address counters; RED tests first; operator sees the verdict before apply.
 - **R2 — wedge window.** Fails safe (HALT). B2 fixes the recovery text. Time-boxed to 1h
   with a revert path (AC-B10).
-- **R3 — proxy-tls cert rotation.** Unresolved — §Open Decision, routed to deepen-plan.
+- **R3 — proxy-tls cert rotation.** **Resolved 2026-07-17 — ADR-118, Option 1** (§Resolved
+  Decision): re-mint inside B6's supervised local apply. Mitigated by B1.4b's `cert_replaced`
+  + `doppler_cert_ok` counters over the SAVED plan. The rotation is free today (proxy path
+  dark) and only `PROXY_TLS_CERT` moves — not `PROXY_TLS_KEY`.
+- **R3b — a SECOND `var.web_hosts`-derived coupling: `web-hosts-fanout-parity.test.sh`.**
+  Same class as R3 (derived, not literal), found by review. Removing the web-2 key **red-CIs
+  it** (CI-registered at `.github/workflows/infra-validation.yml:434`) — measured, not
+  predicted. Handled by B3.4; see the derivation sweep at B0 step 2b.
 - **R4 — R2 backend has no state lock.** Confirm no CI apply in flight before the local
   apply (B0.3).
 - **R5 — giving up a held `cx33@fsn1`** (orderable only in `hel1-dc2`). Accepted: an

--- a/knowledge-base/project/specs/feat-6538-web2-fsn1-orphan/tasks.md
+++ b/knowledge-base/project/specs/feat-6538-web2-fsn1-orphan/tasks.md
@@ -109,31 +109,55 @@ and active-active-N (#6459) instead of rescheduling the defect.
 
 ---
 
-## PR B — the destroy (new branch; **blocked on the Open Decision**)
+## PR B — the destroy (new branch; **B-GATE CLEARED 2026-07-17 — unblocked**)
 
-### ⛔ B-GATE — resolve before ANY B-phase work
+### ✅ B-GATE — RESOLVED (ADR-118). B0–B6 may proceed.
 
-- [ ] **B-GATE.1** — Resolve §Open Decision: `proxy-tls.tf` reads
-      `ip_addresses = [for h in values(var.web_hosts) : h.private_ip]` and
-      `dns_names = concat(keys(var.web_hosts), ...)` — both **ForceNew**. Removing web-2
-      **replaces the cert** and rotates `PROXY_TLS_CERT`/`KEY` in Doppler `prd`, the value
-      the proxying client pins as `ca:` with `rejectUnauthorized: true`. It contains no
-      `web-2` literal → invisible to the sweep, the ACs, and the measurement.
-      Options: (1) bring cert + 2 doppler secrets into scope (rotates the pinned CA under
-      a running web-1 that baked the old cert at container start); (2) accept + document a
-      permanent 12h drift alarm; (3) decouple the cert from `var.web_hosts`.
-- [ ] **B-GATE.2** — Route to `/soleur:deepen-plan` (mandated at `single-user incident`;
-      its data-integrity + security triad is the right lens for a pinned-CA rotation).
+- [x] **B-GATE.1** — plan §Resolved Decision (was §Open Decision) — **resolved: Option 1** — bring the cert +
+      `doppler_secret.proxy_tls_cert` into PR B's scope and re-mint inside the supervised
+      operator-local apply. `proxy-tls.tf` is **unchanged (zero-line diff)** — the existing
+      for-expressions already compute the right answer. Rationale + rejected alternatives:
+      **ADR-118** (`knowledge-base/engineering/architecture/decisions/ADR-118-proxy-cert-sans-track-the-cluster-roster.md`).
+      **Two corrections to this task's own prior text:** (a) only **`PROXY_TLS_CERT`**
+      rotates — **not** `PROXY_TLS_KEY` (`tls_private_key.proxy_server` has zero
+      `var.web_hosts` dependency, so it is never replaced); (b) the "rotates the pinned CA
+      under a running web-1" risk is **vacuous** — the proxy path is dark behind three
+      independent locks, and server cert + client CA are the same PEM from the same env var
+      on the same host, so a stale host verifies against itself; skew needs two hosts and
+      the destroy leaves one.
+- [x] **B-GATE.2** — Routed to `/soleur:deepen-plan` → CTO ruling → ADR-118 (2026-07-17).
+- [x] **B-GATE.3** — Sibling issue filed: **#6596** — `terraform-target-parity.test.ts`
+      exempts the proxy cert because it *"ride[s] the same cluster apply"*, but **no
+      cluster-apply job exists**; that apply is an operator ritual, not automation. Mirror of
+      #6574 (*in the graph, claimed out* ↔ *out of the graph, claimed in*). P3, not a blocker
+      for B0–B6 — the proxy path is dark, so this is claim-vs-reality, not a live outage.
 
 ### B0 — Preconditions
 
 - [ ] **B0.1** — Re-run BOTH measurements (baseline + web-2-removed) over the exact
       push-apply scope. Stock/state are time-varying; a stale measurement is not evidence.
-      Record verbatim → AC-B1.
+      Record verbatim → AC-B1. **ADR-118: two shapes, do not conflate.** The push-apply-scope
+      measurement is **unchanged** (`0 to add, 1 to change, 1 to destroy`) — the cert is
+      unreachable from that scope (`-target` is transitive on *dependencies*, not
+      *dependents*). The **B3 local-apply** shape changes (a cert replace is
+      `1 to add, 0 to change, 1 to destroy` → the destroy count increments). **Measure both;
+      encode neither** — a predicted counter repeats the v1 P0 miss the 5th address cost once.
 - [ ] **B0.2** — Reference sweep with the **corrected** paths (v1 greped two zero-hit
       tokens and missed the guard directory):
       `git grep -n 'web-2\|web_2\|web\["web-2"\]' apps/web-platform/infra .github/workflows tests/ scripts/ plugins/soleur/test/`
       Capture the hit-set to a file — AC-B4 **diffs against it**. (Measured: 311 hits / 45 files.)
+- [ ] **B0.2b** — **Derivation sweep (ADR-118 — B0.2 cannot find what created the B-GATE).**
+      `proxy-tls.tf` has **zero** `web-2` literals; it couples by *derivation*, so B0.2,
+      AC-B4 and the measurement all missed it at once. A token grep enumerates *mentions*, not
+      *dependents*: `git grep -ln 'var\.web_hosts' apps/web-platform/infra` → **9 files**
+      (measured 2026-07-17). Audit every dependent for ForceNew-on-membership-change **and for
+      host-count assumptions**; AC-B4 diffs against this set too. The nine: `server.tf`,
+      `network.tf`, `dns.tf`, `placement-group.tf`, `proxy-tls.tf`, `variables.tf`,
+      **`web-hosts-fanout-parity.test.sh`**, **`tests/web-hosts-eu-pin.tftest.hcl`**,
+      **`scripts/deploy-status-fanout-verify.sh`**.
+      ⚠️ The last three were missed by this step's own first draft (six listed from memory
+      instead of running the command) — the ADR-118 lesson recurring inside its own
+      remediation. **Run the sweep, don't recall it**; if it returns >9, audit the extras.
 - [ ] **B0.3** — Confirm **no `apply-web-platform-infra` run is in flight** — the R2
       backend has no state lock (`use_lockfile = false`).
 - [ ] **B0.4** — Do **NOT** join the `web-1-swap` concurrency group (would red-CI
@@ -147,14 +171,29 @@ and active-active-N (#6459) instead of rescheduling the defect.
       fixtures only.
 - [ ] **B1.2** — RED cases that MUST fail: web-1 touch; non-web-2 volume destroy;
       server-only partial (**the measured shape**); firewall-attachment **delete**;
-      unparseable/empty plan JSON.
-- [ ] **B1.3** — RED case that MUST pass: **retry-after-partial** (3 of 4 remaining).
+      unparseable/empty plan JSON; **`doppler_secret.proxy_tls_cert` `delete`** (must be
+      `update`-only — a delete strips `PROXY_TLS_CERT` from Doppler `prd`); **any
+      `tls_private_key.proxy_server` change** (that is a key rotation → halt) *(both ADR-118)*.
+- [ ] **B1.3** — RED cases that MUST pass: **retry-after-partial** (3 of 4 remaining); and
+      **cert-replaced-but-Doppler-update-not-yet-applied** — Terraform applies sequentially
+      and can die between the two, so the `<= 1` / subset-not-equality shape must hold for the
+      new counters too *(ADR-118)*.
 - [ ] **B1.4** — GREEN: add `web2_retire_allow` to
-      `tests/scripts/lib/destroy-guard-filter-web-platform.jq` with **five** addresses:
+      `tests/scripts/lib/destroy-guard-filter-web-platform.jq` with **seven** addresses
+      *(5 + the 2 added by ADR-118)*:
       `hcloud_server.web["web-2"]`, `hcloud_server_network.web["web-2"]`,
       `hcloud_volume_attachment.workspaces["web-2"]`, `hcloud_volume.workspaces["web-2"]`,
-      **`hcloud_firewall_attachment.web`**. *(The 5th is a v1 P0 miss — the measured "1 to
-      change". Omitting it wedges the gate permanently.)*
+      **`hcloud_firewall_attachment.web`**, **`tls_self_signed_cert.proxy_server`**
+      (replace: delete+create), **`doppler_secret.proxy_tls_cert`** (update-in-place).
+      *(The 5th is a v1 P0 miss — the measured "1 to change". Omitting it wedges the gate
+      permanently.)* **`tls_private_key.proxy_server` is deliberately ABSENT** — it must never
+      plan a change; assert that with a fixture, don't assume it. Adding the two cert
+      addresses cannot weaken the gate: membership is exact-equality via
+      `IN(.address; web2_allow[])` over a disjoint resource-type space.
+- [ ] **B1.4b** — GREEN: two new counters mirroring `firewall_attachment_ok` *(ADR-118)*:
+      `cert_replaced` (`<= 1`, delete+create only) and `doppler_cert_ok` (exactly one
+      `update`, **never `delete`**). `host_creates` is **not** tripped — it is type-scoped to
+      `hcloud_server`/`hcloud_volume`, so the cert's create does not fire the mirrored wedge.
 - [ ] **B1.5** — GREEN: `out_of_scope == 0` (necessary, **not sufficient** — it passes the
       partial shape) **plus four named per-address destroy counters**, not a bare
       `length == 4`. Pin the volume counter to the exact address (a bare
@@ -180,8 +219,31 @@ and active-active-N (#6459) instead of rescheduling the defect.
 
 - [ ] **B3.1** — Remove the `"web-2"` key + its cross-DC rationale comment from
       `var.web_hosts`.
-- [ ] **B3.2** — Implement the B-GATE decision for `proxy-tls`.
+- [ ] **B3.2** — Implement the B-GATE decision for `proxy-tls` — **ADR-118, Option 1**.
+      **`proxy-tls.tf` must end byte-identical to `main`** (a zero-line diff — the existing
+      for-expressions already compute the right answer; if that file changed, the wrong option
+      was implemented). The work is entirely in the gate (B1.4/B1.4b) and the `-target` list
+      (B6.2). **Do NOT hardcode/pin the SAN list** — that was rejected Option 3: it falsifies
+      `terraform-target-parity.test.ts`'s exclusion rationale in place, and at the 3.D cutover
+      a new host gets no SAN → TLS verification fails on the live path **with the drift
+      detector blinded**.
 - [ ] **B3.3** — `terraform fmt -check` + `terraform validate` clean.
+- [ ] **B3.4** — **Fix `apps/web-platform/infra/web-hosts-fanout-parity.test.sh` — PR B
+      red-CIs it otherwise.** A *second* `var.web_hosts`-derived coupling (same class as the
+      cert), CI-registered at `.github/workflows/infra-validation.yml:434`. **Measured**
+      against a simulated B3.1: baseline `3 passed, 0 failed`; with web-2 removed →
+      `EXIT=1` (4 failures). Two edits, both required:
+      1. Three workflow literals move in lockstep with the roster —
+         `web-platform-release.yml:563`, `apply-web-platform-infra.yml:710` and `:974`:
+         `WEB_HOST_PRIVATE_IPS: "10.0.1.10,10.0.1.11"` → `"10.0.1.10"`.
+      2. The test's own hardcoded 2-host floor — `if [ "$tf_n" -lt 2 ]; then fail "… — parser
+         drift"` → `-lt 1`. Fixing only the literals still leaves `3 passed, 1 failed`, and it
+         fails blaming *parser drift* rather than the roster — fix the message too.
+      ⚠️ **#6575 ordering trap:** apply-workflow copies #1/#2 live in the
+      `warm_standby`/`web_2_recreate` jobs #6575 deletes after B6, and
+      `check_all_copies "$APPLY_WORKFLOW" … 2` pins `min_copies=2` → deletion trips
+      `expected >=2 copies, found 0`. #6575 must lower `min_copies` in the same PR.
+- [ ] **B3.5** — Re-run `bash apps/web-platform/infra/web-hosts-fanout-parity.test.sh` → exit 0.
 
 ### B4 — ADR + C4
 
@@ -234,7 +296,23 @@ and active-active-N (#6459) instead of rescheduling the defect.
 - [ ] **B6.1** — `/soleur:review` → `/soleur:ship`. Squash commit MUST carry
       `[skip-web-platform-apply]` **on its own line**. Keep the squash single-purpose (the
       token suppresses **all** guards for that merge).
-- [ ] **B6.2** — Produce the saved plan locally: `-target` the 5 addresses, `-out=tfplan`.
+- [ ] **B6.2** — Produce the saved plan locally: `-target` the **6** addresses *(5 + the one
+      added by ADR-118)*, `-out=tfplan`:
+      ```
+      -target='hcloud_server.web["web-2"]'
+      -target='hcloud_server_network.web["web-2"]'
+      -target='hcloud_volume_attachment.workspaces["web-2"]'
+      -target='hcloud_volume.workspaces["web-2"]'
+      -target=hcloud_firewall_attachment.web
+      -target=doppler_secret.proxy_tls_cert          # ADR-118
+      ```
+      One new target suffices — `-target` is transitive on **dependencies**, so
+      `doppler_secret.proxy_tls_cert` pulls in `tls_self_signed_cert.proxy_server` →
+      `tls_private_key.proxy_server` (a graph no-op; not replaced). **Do NOT add
+      `-target=doppler_secret.proxy_tls_key`** — the key does not rotate, and naming it invites
+      the false belief that it does. Note the `-target` list (6) and `web2_retire_allow` (7)
+      are **different lists**: the allow-list names everything that *appears* in the plan; the
+      `-target` list names only what must be *reached*.
 - [ ] **B6.3** — Run the gate: `terraform show -json tfplan | jq -f tests/scripts/lib/destroy-guard-filter-web-platform.jq`.
 - [ ] **B6.4** — **Show the operator the gate verdict AND the exact apply command; wait for
       explicit per-command go-ahead** (`hr-menu-option-ack-not-prod-write-auth` —


### PR DESCRIPTION
Resolves the §Open Decision that blocks PR B of the web-2 retirement. **Decision only — no
B0–B6 work, no infra touched.** `Ref #6538` (never `Closes` — #6538/#6463 close by hand at B6
after the API probe verifies).

## Ruling: Option 1 — re-mint the cert in PR B's supervised operator-local apply

Routed to the `cto` agent (data-plane security architecture, not a product call). Full
rationale + rejected alternatives: **ADR-118**.

**`apps/web-platform/infra/proxy-tls.tf` is byte-identical to `main` — a zero-line diff.**
The existing for-expressions already compute the right answer; the ruling just lets them.
That is the ruling's signature: if that file changed, the wrong option was implemented.

## The gate's premise was partly false

The plan deferred this over "blast radius on the live origin." Verified — it doesn't exist:

- **The proxy path is dark**, behind three independent locks (any one sufficient):
  `GIT_DATA_STORE_ENABLED` unset gates the only call site; `SOLEUR_HOST_ROSTER` unset →
  `owner-unresolved`, never `proxy`; `SOLEUR_PROXY_BIND` unset → no listener.
  `session-proxy.ts`: *"INERT until 3.D."* No TF provisions those vars; no LB exists;
  `dns.tf` pins `app.soleur.ai` to web-1 as a singleton.
- **A mismatch is structurally impossible.** Server cert and pinned client CA are the same PEM
  from the same env var on the same host — a stale host verifies against itself. Skew needs two
  hosts of different vintages; the destroy leaves one.

**Two factual corrections to the plan** (both carried into the ADR):
1. Only `PROXY_TLS_CERT` rotates — **not** `PROXY_TLS_KEY`. `tls_private_key.proxy_server` has
   zero `var.web_hosts` dependency, so it is never replaced.
2. The "TLS handshake failure" risk in §User-Brand Impact is vacuous.

**What is true:** the 12h drift alarm (`cron: 0 6,18 * * *`, untargeted plan → one issue + a
comment every 12h + 2 emails/day, unsilenceable), and the cert being unreachable from every
`-target`-scoped CI path.

## Measured, not argued

Empirical, against the pinned `hashicorp/tls 4.3.0`, reproducing the real state SANs:

| Config | `terraform plan` |
|---|---|
| SANs hardcoded to current values, web-2 dropped | `No changes.` — a true no-op |
| SANs derived (status quo), web-2 dropped | `must be replaced` → `1 to add, 0 to change, 1 to destroy` |
| SANs hardcoded but reordered | `must be replaced` — order-sensitive |

So Option 3 genuinely works. It was rejected anyway: it falsifies
`terraform-target-parity.test.ts`'s tested exclusion rationale in place, and at the 3.D cutover
a new host gets no SAN → TLS verification fails on the live path **with the drift detector
blinded** (a static pin doesn't drift when a host is added). Trading a loud alarm for a quiet
break is not conservative.

## Propagated to `tasks.md` (the contract `/work` executes against)

- B-GATE marked resolved → **B0–B6 unblocked**
- `web2_retire_allow` **5 → 7**; `-target` list **5 → 6** (different lists — the allow-list
  names what *appears* in the plan; `-target` names what must be *reached*)
- New `cert_replaced` / `doppler_cert_ok` counters; key-rotation-halt fixture
- **B0.2b derivation sweep** (`git grep var.web_hosts`) — the miss that created this gate: a
  token grep enumerates *mentions* and is blind to *derived* coupling
- AC-B1: two shapes, measure both, **encode neither**

## Follow-up filed

**#6596** (P3) — the parity test exempts the cert because it *"ride[s] the same cluster
apply"*, but no cluster-apply job exists; that apply is an operator ritual. Mirror of #6574.

## Verification

- `bash scripts/test-all.sh` → **178/178 suites passed**, exit 0
- `scripts/check-adr-ordinals.sh` → passed (ADR-118 derived from fresh `origin/main`)
- Diff is 3 docs files; `proxy-tls.tf`, the legal docs and the T&C are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)