### PR TITLE
fix(infra): sigpipe probe refused to run in CI and named the wrong cause

### DIFF
--- a/apps/web-platform/infra/scripts/sigpipe-triage-feasibility.sh
+++ b/apps/web-platform/infra/scripts/sigpipe-triage-feasibility.sh
@@ -235,6 +235,28 @@ count_sites() {
 # It also protects any FUTURE reading here that does feed a producer into grep.
 #
 # Keep the gate; it earns its place. Just not for the reason first written.
+# Is SIGPIPE deliverable to a child of this shell at all?
+#
+# A process that inherits SIGPIPE as SIG_IGN does not die on a broken pipe — its
+# write() returns EPIPE instead, and a bash loop that ignores the failed printf
+# simply keeps going and exits 0. POSIX forbids a shell from resetting a signal
+# it inherited as ignored, so a script CANNOT undo this for itself.
+#
+# This matters twice over:
+#   1. It is why the 141 probe below cannot be read as a grep verdict on such a
+#      host — the producer is not killed because it CANNOT be killed.
+#   2. It means the defect this probe counts DOES NOT MANIFEST there. Measured:
+#        SIGPIPE default : producer 141, `if producer | grep -q M` INVERTS
+#        SIGPIPE SIG_IGN : producer 0,   `if producer | grep -q M` is CORRECT
+#      The static site counts are unaffected either way (they are `git grep` +
+#      text normalisation, no runtime), so the measurement still stands.
+sigpipe_is_ignored() {
+  local mask
+  mask="$(grep -i '^SigIgn:' /proc/self/status 2>/dev/null | awk '{print $2}')" || return 1
+  [[ -n "$mask" ]] || return 1
+  (( 0x${mask} & (1 << 12) ))   # SIGPIPE == 13 -> bit 12
+}
+
 preflight() {
   local producer rc
   producer="$(mktemp)"
@@ -253,6 +275,28 @@ PROD
   set -o pipefail
   rm -f "$producer"
 
+  # Order matters. An earlier revision tested ONLY for 141 and, on any non-141,
+  # blamed grep. That misdiagnosed CI: the GitHub Actions runner is Node-spawned,
+  # Node sets SIGPIPE to SIG_IGN, the runner's shell inherits it, and the producer
+  # therefore exits 0 with a perfectly good GNU grep. The probe refused to run and
+  # named the wrong cause — confidently, in the script whose subject is confident
+  # claims that were never measured. Two distinct causes produce the same non-141:
+  #   SIGPIPE ignored  => the defect cannot occur here      => proceed, say so
+  #   SIGPIPE default  => grep drained the producer         => refuse, blame grep
+  if sigpipe_is_ignored; then
+    emit "SIGPIPE deliverable to children?" "NO — inherited SIG_IGN"
+    cmd 'grep -i ^SigIgn: /proc/self/status  =>  bit 12 (SIGPIPE) set'
+    printf '    The runtime symptom CANNOT occur in this environment: a producer here\n'
+    # shellcheck disable=SC2016  # backticks are literal prose, not substitution
+    printf '    receives EPIPE instead of dying, so `if producer | grep -q X` returns the\n'
+    printf '    CORRECT answer (measured). This is normal under a Node-spawned runner.\n'
+    printf '    It does NOT mean the corpus is safe — the guards below run on prod hosts,\n'
+    printf '    systemd units and cron, where SIGPIPE has its default disposition and the\n'
+    printf '    inversion is live. The site counts are static (git grep + normalisation),\n'
+    printf '    so they are unaffected and the measurement proceeds.\n'
+    return 0
+  fi
+
   if [[ "$rc" -ne 141 ]]; then
     cat >&2 <<EOF
 FATAL: this host's \`grep\` does not early-exit — refusing to measure.
@@ -260,10 +304,12 @@ FATAL: this host's \`grep\` does not early-exit — refusing to measure.
   probe: a producer emitting a match then ~40k more lines was piped to \`grep -q\`.
   expected: producer killed by SIGPIPE (PIPESTATUS[0]=141).
   actual:   PIPESTATUS[0]=$rc — the producer ran to completion.
+  ruled out: SIGPIPE is at its DEFAULT disposition here (checked /proc/self/status
+             SigIgn bit 12), so the producer COULD have been killed and was not.
+             The matcher drained it.
 
   A grep that drains its input cannot observe the defect being counted. Every
-  reading taken here would be 0/N, and this probe would report that no site is
-  reachable. That green would be false, and nobody re-audits a green.
+  reading that depends on early-exit would be 0/N here.
 
   This is NOT a \`grep --version\` problem and cannot be diagnosed as one: the
   host that authored this probe resolved GNU grep 3.12 and still drained, via a

--- a/apps/web-platform/infra/scripts/sigpipe-triage-feasibility.test.sh
+++ b/apps/web-platform/infra/scripts/sigpipe-triage-feasibility.test.sh
@@ -19,6 +19,26 @@ fails=0
 pass() { printf '  ok   %s\n' "$1"; }
 fail() { printf '  FAIL %s\n    -> %s\n' "$1" "${2:-}" >&2; fails=$((fails + 1)); }
 
+
+# Run the probe with SIGPIPE restored to its DEFAULT disposition.
+#
+# Required on CI. The GitHub Actions runner is Node-spawned, Node sets SIGPIPE to
+# SIG_IGN, and the runner's shell inherits it — and POSIX forbids a shell from
+# resetting a signal it inherited as ignored, so `trap - PIPE` CANNOT undo this.
+# Under SIG_IGN the probe correctly reports "the defect cannot occur here" and
+# proceeds, which would make T2/T3 (whose whole subject is the REFUSAL path)
+# fail for an environmental reason rather than a real one.
+#
+# Python's subprocess restores default signal dispositions in the child
+# (restore_signals=True is its default), so this is a portable reset with no new
+# dependency — python3 is present on every runner this repo uses.
+run_probe_sigpipe_default() {
+  python3 - "$@" <<'PYEOF'
+import subprocess, sys
+sys.exit(subprocess.run(sys.argv[1:]).returncode)   # restore_signals=True by default
+PYEOF
+}
+
 echo "== sigpipe-triage-feasibility attestation =="
 
 if [[ ! -f "$PROBE" ]]; then
@@ -31,7 +51,7 @@ fi
 # ---------------------------------------------------------------------------
 # `env -i` strips any interactive shell function shadowing grep. This is the
 # CI-equivalent environment, and the only one a verdict may be taken from.
-t1_out="$(env -i PATH="/usr/bin:/bin" HOME="$HOME" \
+t1_out="$(run_probe_sigpipe_default env -i PATH="/usr/bin:/bin" HOME="$HOME" \
   /bin/bash "$PROBE" --pathspec 'apps/web-platform/infra/' 2>&1)"
 t1_rc=$?
 if [[ "$t1_rc" -eq 0 ]]; then
@@ -79,7 +99,7 @@ exec /usr/bin/grep "$@"
 SHIM
 chmod +x "$shimdir/grep"
 
-t2_out="$(env -i PATH="$shimdir:/usr/bin:/bin" HOME="$HOME" \
+t2_out="$(run_probe_sigpipe_default env -i PATH="$shimdir:/usr/bin:/bin" HOME="$HOME" \
   /bin/bash "$PROBE" --pathspec 'apps/web-platform/infra/' 2>&1)"
 t2_rc=$?
 if [[ "$t2_rc" -ne 0 ]]; then
@@ -129,7 +149,7 @@ exec /usr/bin/grep "$@"
 SHIM
 chmod +x "$shimdir/grep"
 
-t3_out="$(env -i PATH="$shimdir:/usr/bin:/bin" HOME="$HOME" \
+t3_out="$(run_probe_sigpipe_default env -i PATH="$shimdir:/usr/bin:/bin" HOME="$HOME" \
   /bin/bash "$PROBE" --pathspec 'apps/web-platform/infra/' 2>&1)"
 t3_rc=$?
 if [[ "$t3_rc" -ne 0 ]]; then

--- a/knowledge-base/engineering/audits/2026-07-17-sigpipe-guard-triage-feasibility.md
+++ b/knowledge-base/engineering/audits/2026-07-17-sigpipe-guard-triage-feasibility.md
@@ -63,6 +63,37 @@ negative arms, including a shim that reports itself as `grep (GNU grep) 3.12` an
 shape an identity check cannot see. Not hypothetical twice over: an independent reviewer sent to audit
 this PR was caught by the same wrapper and measured 0/N before noticing.
 
+### The gate misdiagnosed its own environment — and the fix scopes the whole measurement
+
+The probe shipped, ran in CI, and **refused**: `PIPESTATUS[0]=0 — the producer ran to completion`.
+Its message blamed grep. That was false, and the truth matters more than the bug:
+
+The GitHub Actions runner is Node-spawned; **Node sets SIGPIPE to `SIG_IGN`**, the runner's shell
+inherits it, and POSIX forbids a shell from resetting a signal it inherited as ignored. So a producer
+there receives `EPIPE` instead of dying — with a perfectly good GNU grep. Measured:
+
+| SIGPIPE disposition | producer rc | `if producer \| grep -q M` |
+|---|---|---|
+| default | 141 | **INVERTS** (defect live) |
+| inherited `SIG_IGN` | 0 | **CORRECT** (defect absent) |
+
+Two causes produce the same non-141 and mean **opposite** things — the instrument is blind (grep
+drained), or **the defect cannot occur here at all**. The probe collapsed them into one and named the
+wrong one, confidently, in the script whose subject is confident claims nobody measured. It now
+discriminates via `SigIgn` bit 12 in `/proc/self/status`.
+
+**This scopes every runtime claim in this note.** The inversion is live where these guards actually
+run — prod hosts, systemd units, cron — where SIGPIPE has its default disposition. It is **absent on
+the Actions runner**. So a green CI run is not evidence the class is safe; it is evidence the runner
+cannot express the symptom. The site counts are unaffected either way: they are `git grep` plus text
+normalisation, with no runtime component.
+
+A consequence worth stating plainly: any *runtime* SIGPIPE differential that runs only on the Actions
+runner is measuring an environment where the defect is definitionally absent. The attestation
+therefore restores the default disposition (via `python3 subprocess`, whose `restore_signals=True`
+default is the only portable reset available to a script that cannot untrap its own inherited
+`SIG_IGN`) before exercising its refusal arms.
+
 **No verdict may be taken from a host whose grep does not early-exit.** Run it where CI's grep runs,
 or `env -i PATH=/usr/bin:/bin bash <probe>`.
 


### PR DESCRIPTION
## Summary

**The probe shipped in #6586 refused to run in CI and blamed the wrong thing.** Fixing it surfaced a finding that scopes the entire measurement.

```
FATAL: this host's `grep` does not early-exit — refusing to measure.
  actual: PIPESTATUS[0]=0 — the producer ran to completion.
```

grep was fine. **The GitHub Actions runner is Node-spawned, Node sets SIGPIPE to `SIG_IGN`, and the runner's shell inherits it** — and POSIX forbids a shell from resetting a signal it inherited as ignored. So the producer gets `EPIPE` instead of dying, with a perfectly good GNU grep.

## The finding that matters more than the bug

| SIGPIPE disposition | producer rc | `if producer \| grep -q M` |
|---|---|---|
| default | 141 | **INVERTS** (defect live) |
| inherited `SIG_IGN` | 0 | **CORRECT** (defect absent) |

Two causes produce the same non-141 and mean **opposite** things:

- **grep drained** → the instrument is blind → refuse.
- **SIGPIPE ignored** → *the defect cannot occur here at all* → say so and proceed.

The preflight collapsed them into one and named the wrong one — confidently, in the script whose entire subject is confident claims nobody measured.

**This scopes every runtime claim in the audit note.** The inversion is live where these guards actually *run* — prod hosts, systemd units, cron, SIGPIPE default. It is **absent on the Actions runner**. So a green CI run is not evidence the class is safe; it is evidence the runner cannot express the symptom. The static site counts (41 production / 9 files, B=26%) are unaffected — they're `git grep` plus text normalisation, no runtime.

## Changes

- **`sigpipe-triage-feasibility.sh`** — preflight discriminates on `SigIgn` bit 12 of `/proc/self/status`: `SIG_IGN` → emit the environmental note and proceed (counts are static, so they stand); default + non-141 → grep drained → refuse. The refusal message now states it *ruled out* the SIGPIPE cause rather than assuming.
- **`sigpipe-triage-feasibility.test.sh`** — restores default disposition before exercising the refusal arms, via `python3 subprocess` (`restore_signals=True` is its default, and it is the only portable reset available to a script that cannot untrap its own inherited `SIG_IGN` — `trap - PIPE` cannot). Without it, T2/T3 — whose whole subject *is* the refusal path — fail for an environmental reason rather than a real one.
- **audit note** — records the disposition-dependence and what it scopes.

## How this escaped #6586

`deploy-script-tests` is an **advisory** job, not a required check. So the probe went red while every required check was green, and the merge poll reported clean success. It was caught only because a second monitor watched that specific job — a merged PR is not evidence its advisory jobs passed.

That is this lineage's own defect, one level up: a gate that reports green while the thing it guards is broken.

## Test plan

- [x] SIGPIPE **default**: probe measures (`PIPESTATUS[0]=141`), verdict `production=41/9 B=26% arm=track`; attestation **5/5**
- [x] SIGPIPE **`SIG_IGN`** (the CI shape, simulated via `restore_signals=False`): probe **exits 0** with the environmental note instead of falsely blaming grep; attestation still **5/5**
- [x] Counts identical under both dispositions (they are static — the property that makes proceeding correct)
- [x] `shellcheck` clean on both scripts

Ref #6586
