### PR TITLE
fix(infra): tunnel-ingress verifier cd'd a relative INFRA_DIR — wedged the SSH apply leg (#6595)

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -375,6 +375,9 @@ jobs:
       - name: Run tunnel origin-relative ingress guard (#6594 ADR-114 I2 coin-flipped management plane)
         run: bash apps/web-platform/infra/tunnel-origin-relative-ingress.test.sh
 
+      - name: Run tunnel-ingress verify infra-dir resolution guard (#6595 relative-INFRA_DIR cd)
+        run: bash apps/web-platform/infra/verify-tunnel-ingress-origin-infradir.test.sh
+
       - name: Run ci-deploy-wrapper.sh tests
         run: bash apps/web-platform/infra/ci-deploy-wrapper.test.sh
 

--- a/apps/web-platform/infra/scripts/verify-tunnel-ingress-origin.sh
+++ b/apps/web-platform/infra/scripts/verify-tunnel-ingress-origin.sh
@@ -14,7 +14,14 @@
 
 set -euo pipefail
 
-INFRA_DIR="${INFRA_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+# Resolve the infra dir from THIS script's own location — absolute and
+# CWD-independent. Do NOT honor a relative $INFRA_DIR override (#6595): the workflow
+# exports INFRA_DIR=apps/web-platform/infra AND runs this step with
+# working-directory=$INFRA_DIR, so the CWD is already the infra dir and a
+# `cd apps/web-platform/infra` from there dies "No such file or directory" — which
+# gates (if: success()) and thus SKIPS the SSH-provisioned apply leg that delivers
+# fail2ban's ignoreip grant and every other remote-exec resource.
+INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$INFRA_DIR"
 
 DOPPLER_ARGS=(--project soleur --config prd_terraform)

--- a/apps/web-platform/infra/verify-tunnel-ingress-origin-infradir.test.sh
+++ b/apps/web-platform/infra/verify-tunnel-ingress-origin-infradir.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression guard for #6595: verify-tunnel-ingress-origin.sh must resolve its
+# infra dir from its OWN location (absolute, CWD-independent), NOT by `cd`-ing a
+# possibly-relative $INFRA_DIR env var.
+#
+# The post-merge apply of PR #6595 died here:
+#   verify-tunnel-ingress-origin.sh: line 18: cd: apps/web-platform/infra: No such file or directory
+# because apply-web-platform-infra.yml exports INFRA_DIR=apps/web-platform/infra
+# (relative) AND runs the step with working-directory=$INFRA_DIR — so the CWD is
+# ALREADY the infra dir, and `cd apps/web-platform/infra` from inside it fails.
+# That failure is not cosmetic: the verify step gates the SSH-provisioned apply
+# leg (`if: success()`), so it skipped the apply that delivers the fail2ban
+# `ignoreip` grant and every other SSH-provisioned resource fleet-wide.
+#
+# This test reproduces the CI invocation exactly (CWD = infra dir, INFRA_DIR set
+# to the relative value) with a stub `doppler` on PATH, and asserts the script
+# gets PAST the `cd` — i.e. it reaches its first external call instead of dying
+# on a path that does not exist. Hermetic: no network, no doppler, no prod.
+
+set -euo pipefail
+
+echo "verify-tunnel-ingress-origin-infradir.test.sh"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_ABS="$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TARGET="$INFRA_ABS/scripts/verify-tunnel-ingress-origin.sh"
+# The relative value the workflow exports (env.INFRA_DIR at line 128).
+REL_INFRA_DIR="apps/web-platform/infra"
+
+[[ -f "$TARGET" ]] || { echo "FAIL: $TARGET not found"; exit 1; }
+
+fails=0
+
+# --- Stub PATH: a fake `doppler` that records it was reached, then exits. -----------
+# doppler is the FIRST external command the script runs after the cd, so reaching
+# it proves the cd resolved. It exits 0 with no output; the script then fails its
+# own IP-regex check and exits 1 — expected, and irrelevant to this test.
+STUB_DIR="$(mktemp -d)"
+MARKER="$(mktemp -u)"
+trap 'rm -rf "$STUB_DIR"; rm -f "$MARKER"' EXIT
+cat >"$STUB_DIR/doppler" <<STUB
+#!/usr/bin/env bash
+touch "$MARKER"
+exit 0
+STUB
+chmod +x "$STUB_DIR/doppler"
+
+# --- Reproduce the CI invocation: CWD = absolute infra dir, INFRA_DIR = relative. ---
+set +e
+OUT="$(cd "$INFRA_ABS" && INFRA_DIR="$REL_INFRA_DIR" PATH="$STUB_DIR:$PATH" \
+  bash "$TARGET" 2>&1)"
+set -e
+
+if printf '%s' "$OUT" | grep -qiE 'cd:.*No such file or directory'; then
+  echo "FAIL: script died on the relative-INFRA_DIR cd — #6595 regression:"
+  printf '%s\n' "$OUT" | sed 's/^/    /'
+  fails=1
+elif [[ ! -e "$MARKER" ]]; then
+  echo "FAIL: script never reached its first external call (doppler stub not hit) — it did not get past the cd:"
+  printf '%s\n' "$OUT" | sed 's/^/    /'
+  fails=1
+else
+  echo "PASS: script resolves the infra dir absolutely and reaches its first call with CWD=infra-dir + relative INFRA_DIR"
+fi
+
+# --- Also assert the source no longer honors a relative $INFRA_DIR override. --------
+# A structural belt to the behavioral test above: the resolution must not be
+# `${INFRA_DIR:-...}` (which re-admits the relative env value). It must derive from
+# BASH_SOURCE unconditionally.
+if grep -qE 'INFRA_DIR="\$\{INFRA_DIR:-' "$TARGET"; then
+  echo "FAIL: script still honors a relative \$INFRA_DIR override (\${INFRA_DIR:-...}) — the #6595 bug can recur"
+  fails=1
+else
+  echo "PASS: infra dir is derived from BASH_SOURCE, not a relative env override"
+fi
+
+# --- Self-registration: this suite must be wired into infra-validation.yml. ---------
+INFRA_VALIDATION="$REPO_ROOT/.github/workflows/infra-validation.yml"
+if [[ -f "$INFRA_VALIDATION" ]] && \
+   grep -qE 'bash apps/web-platform/infra/verify-tunnel-ingress-origin-infradir\.test\.sh' "$INFRA_VALIDATION"; then
+  echo "PASS: suite is registered in infra-validation.yml"
+else
+  echo "FAIL: suite is NOT registered in infra-validation.yml — it would be an orphan (#5417 class)"
+  fails=1
+fi
+
+[[ "$fails" -eq 0 ]] || exit 1
+echo "OK"


### PR DESCRIPTION
## What

`verify-tunnel-ingress-origin.sh` (added by #6595) resolved its infra dir via `cd "${INFRA_DIR:-...}"`, honoring the workflow's **relative** `INFRA_DIR: apps/web-platform/infra`. But the step runs with `working-directory: $INFRA_DIR`, so CWD is already the absolute infra dir and the `cd` died:

```
verify-tunnel-ingress-origin.sh: line 18: cd: apps/web-platform/infra: No such file or directory
```

Fix: derive the infra dir from the script's own `BASH_SOURCE` location, unconditionally and CWD-independently.

## Why it matters

The tunnel repoint from #6595 **applied fine — the pin is live on prod.** But the verify step gates the SSH-provisioned apply leg (`if: success()`) and runs *before* it:

```
success  Terraform apply            (non-SSH)
failure  Verify tunnel ingress origins
skipped  CF Tunnel SSH bridge
skipped  Terraform apply (SSH-provisioned resources)   <-- delivers fail2ban ignoreip
```

So the failure **skipped delivery of `terraform_data.fail2ban_tuning`** — the `ignoreip` grant #6595 added to stop a peer connector (`10.0.1.11`) being banned once `ssh.` is pinned — and every other remote-exec resource. It also wedges that leg **fleet-wide**: every future `apply-web-platform-infra` run fails here until this lands.

Prod is **not** in an active outage — the ignoreip exposure is latent (bites only during a `-replace=tls_private_key.ci_ssh` key-mismatch window or a fresh web-1), and the pin serves. But main's SSH-provisioned apply path is broken now.

## Test

`verify-tunnel-ingress-origin-infradir.test.sh` reproduces the CI invocation (CWD = infra dir, `INFRA_DIR` = the relative value) with a stub `doppler` on PATH and asserts the script gets past the `cd`. **RED** against the old script, **GREEN** after. Also asserts the source dropped `${INFRA_DIR:-...}` and that the suite is registered in `infra-validation.yml`.

## Delivery

Merging re-fires `apply-web-platform-infra` (paths: `apps/web-platform/infra/**`), so the fixed verify passes and the SSH leg finally delivers the ignoreip.

## Changelog

- Fixed a relative-path bug in the tunnel-ingress post-apply verifier that was skipping the SSH-provisioned terraform apply leg on every `apply-web-platform-infra` run.

Ref #6595
Ref #6594