### PR TITLE
fix(infra): widen the GHCR pull retry beyond auth-denied to cover transient/network stderr (#6525)

### DIFF
--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -531,6 +531,24 @@ _pull_result_is_auth_denied() {
   printf '%s' "${1:-}" | grep -qiE 'unauthorized|authentication required|denied|forbidden'
 }
 
+# _pull_result_is_transient <stderr-content>: the SINGLE source of truth for "is this docker
+# pull stderr a TRANSIENT/network failure that a warm retry can absorb?" (#6525). Same anti-drift
+# contract as _pull_result_is_auth_denied: BOTH pull_failure_event's `network` classifier arm AND
+# the pull-site retry gate (_ghcr_pull_or_recover) call this predicate, so they agree BY
+# CONSTRUCTION — a second inline copy of the regex would drift. Classifies the stderr CONTENT ($1),
+# never a file path. The token set is verified NON-OVERLAPPING with the auth-denied class handled by
+# _pull_result_is_auth_denied above AND with the manifest-unknown/not-found class handled by
+# pull_failure_event's manifest arm: note the transient `no such host` shares a `no such` prefix
+# with the manifest `no such manifest`, so this anchors on the full host token and precedence stays
+# auth then manifest then transient in pull_failure_event. `timeout` subsumes i/o timeout / TLS
+# handshake timeout / connection timeout; case-insensitive word-boundary EOF subsumes `unexpected
+# EOF`. Deepen docker-stderr research adds the canonical Go timeout (deadline-exceeded), the
+# registry-5xx unexpected-status shape, the net/http client cancel-while-waiting shape, and the
+# DNS-resolver misbehaving shape.
+_pull_result_is_transient() {
+  printf '%s' "${1:-}" | grep -qiE 'context deadline exceeded|timeout|timed out|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|server misbehaving|request canceled while waiting|received unexpected http status: 5|\bEOF\b'
+}
+
 # pull_failure_event: loud, no-SSH page on an authenticated PRIVATE-pull denial
 # (#6005). Every deploy + fresh boot now hard-depends on a valid GHCR credential
 # (M2 SPOF), so a pull auth failure must be Sentry/Better-Stack-diagnosable, not
@@ -546,7 +564,7 @@ pull_failure_event() {
   local ref="$1" detail_raw="${2:-}" recovery_stage="${3:-}" pull_result
   if   _pull_result_is_auth_denied "$detail_raw"; then pull_result="auth_denied"
   elif printf '%s' "$detail_raw" | grep -qiE 'manifest unknown|not found|no such manifest'; then pull_result="manifest_unknown"
-  elif printf '%s' "$detail_raw" | grep -qiE 'timeout|timed out|temporary failure|no route|connection refused'; then pull_result="network"
+  elif _pull_result_is_transient "$detail_raw"; then pull_result="network"   # #6525: shared predicate (was a narrower inline regex); precedence stays auth → manifest → transient. Tag value `network` UNCHANGED (Sentry grouping / zot_mirror_fallback_rate key on it). Widens the `network` set vs pre-#6525 — see the recovery gate + reclassification-safety check.
   else pull_result="pull_failed"
   fi
   logger -t "$LOG_TAG" "IMAGE_PULL_FAIL: ref=$ref result=$pull_result recovery_stage=${recovery_stage:-none}"
@@ -1363,37 +1381,77 @@ zot_gate_and_login() {
   ztoken=""
 }
 
-# _ghcr_pull_or_recover <perr> (#6400): pull ${IMAGE}:${TAG} from GHCR; on an
-# AUTH-denied failure (classified from the stderr CONTENT, not the file path),
-# re-fetch the prd cred, relogin, and retry the pull EXACTLY ONCE before giving up.
-# Returns 0 on success (first pull OR recovered retry). On failure returns 1 and
-# sets the global RECOVERY_STAGE for the caller's pull_failure_event tag (empty when
-# no recovery was attempted — a non-auth failure never enters the branch, so
-# pull_failure_event fires byte-identically to pre-#6400). Fail-open: a recovery miss
-# leaves the caller's terminal image_pull_failed state unchanged. No loop — retrying
-# a genuinely-invalid prd cred would burn the deploy window (Sharp Edge). The
-# `200>&-` closes the FD-200 advisory lock for the pull children (#5062), preserved.
+# _ghcr_pull_or_recover <perr> (#6400 + #6525): pull ${IMAGE}:${TAG} from GHCR and, on a
+# recoverable failure (classified from the stderr CONTENT, not the file path), recover in-band
+# before giving up. TWO recovery classes, disjoint by construction:
+#   • AUTH-denied (#6400): re-fetch the prd cred, relogin, and retry the pull EXACTLY ONCE. This
+#     branch NEVER loops — a genuinely-invalid prd cred would burn the deploy window (Sharp Edge).
+#   • TRANSIENT/network (#6525): a timeout / connection-reset / EOF / no-such-host / registry-5xx
+#     blip retries with a bounded, capped backoff (PULL_TRANSIENT_RETRY_SLEEPS, default "2 4" =
+#     2 retries, ≤6 s added wall-clock/leg). This is the fix for the "first attempt fails, rerun
+#     succeeds" shape (#6525): pre-#6525 a transient stderr took the return-1 path with ZERO retries.
+# Returns 0 on success (first pull OR either recovered retry). On failure returns 1 and sets the
+# global RECOVERY_STAGE for the caller's pull_failure_event tag: empty for a non-recoverable class
+# (manifest/unknown — pull_failure_event fires byte-identically to pre-#6400); transient_exhausted
+# only when a TRANSIENT failure spent all its retries (the Sentry transient-vs-durable
+# discriminator, #6415/#6565). Retry stays at ONE level — the caller (pull_image_with_fallback)
+# does NOT retry; zot is already an immediate different-registry fallback upstream (one-level-retry
+# rule, 2026-06-30). Fail-open: a recovery miss leaves the terminal image_pull_failed state
+# unchanged. `200>&-` closes the FD-200 advisory lock for the pull children (#5062), preserved.
 _ghcr_pull_or_recover() {
   local perr="$1"
   RECOVERY_STAGE=""
-  docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr" && return 0
-  # classify the stderr CONTENT (tail -c 400), never the path — else recovery no-ops (P2-E).
-  if _pull_result_is_auth_denied "$(tail -c 400 "$perr" 2>/dev/null)"; then
-    # `|| true`: helper returns non-zero on a miss; a bare assignment would abort the
-    # deploy under set -euo. We parse the stage STRING (that string, not the rc, is what
-    # gets copied into RECOVERY_STAGE below; the rc is discarded via `|| true`).
-    local stage; stage="$(refetch_ghcr_and_relogin)" || true   # recovered|refetch_unavailable|relogin_failed
-    if [[ "$stage" == "recovered" ]]; then
-      if docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr"; then
-        pull_auth_recovery_event "${IMAGE}:${TAG}" recovered   # info breadcrumb, distinct op
-        return 0
-      fi
-      RECOVERY_STAGE="pull_still_denied"                       # relogin ok but retry pull still denied
-    else
-      RECOVERY_STAGE="$stage"                                  # refetch_unavailable|relogin_failed
+  # #6525 transient backoff schedule. PULL_TRANSIENT_RETRY_SLEEPS is a test-only override seam
+  # (mirrors the SOLEUR_GHCR_READ_FILE precedent); tests pass "0 0" for a zero-sleep 2-retry loop.
+  # Setting it to "" yields max=0 and DISABLES the transient retry (intentional; tests never use "").
+  # shellcheck disable=SC2206  # intentional word-split of the space-separated schedule into the array
+  local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )
+  local max=${#_sleeps[@]} attempt=0 detail
+  while :; do
+    if docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr"; then
+      # attempt>0 ⇒ we are here only after ≥1 TRANSIENT retry (attempt increments ONLY on the
+      # transient arm below), so this breadcrumb is DISJOINT from the auth block's `recovered`.
+      [[ "$attempt" -gt 0 ]] && pull_auth_recovery_event "${IMAGE}:${TAG}" transient_recovered
+      return 0
     fi
-  fi
-  return 1
+    # classify the stderr CONTENT (tail -c 400), never the path — else recovery no-ops (P2-E).
+    if _pull_result_is_auth_denied "$(tail -c 400 "$perr" 2>/dev/null)"; then
+      # ---- #6400 auth recovery, VERBATIM — keeps its OWN inner success `return 0`, then a
+      # terminal `return 1`: auth is recover-once-then-terminal and MUST NOT loop (a
+      # MOCK_GHCR_PULL_DENY_ALWAYS cred would otherwise burn the window — AC2/AC14 guard this).
+      # `|| true`: helper returns non-zero on a miss; a bare assignment would abort the deploy
+      # under set -euo. We parse the stage STRING (not the rc, which is discarded via `|| true`).
+      local stage; stage="$(refetch_ghcr_and_relogin)" || true   # recovered|refetch_unavailable|relogin_failed
+      if [[ "$stage" == "recovered" ]]; then
+        if docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr"; then
+          pull_auth_recovery_event "${IMAGE}:${TAG}" recovered   # info breadcrumb, distinct op — label stays `recovered`
+          return 0
+        fi
+        RECOVERY_STAGE="pull_still_denied"                       # relogin ok but retry pull still denied
+      else
+        RECOVERY_STAGE="$stage"                                  # refetch_unavailable|relogin_failed
+      fi
+      return 1
+    fi
+    detail="$(tail -c 400 "$perr" 2>/dev/null)"
+    if _pull_result_is_transient "$detail" && (( attempt < max )); then
+      # transient blip with retries left → back off and retry the SAME registry.
+      sleep "${_sleeps[$attempt]}"; attempt=$((attempt + 1)); continue
+    elif _pull_result_is_transient "$detail"; then
+      # transient but retries SPENT (attempt == max) → tag the terminal-transient class so the
+      # Sentry recovery_stage discriminates transient-exhausted from durable host-degradation
+      # (#6415/#6565). Set ONLY here (deepen GAP-7), NEVER in the else below.
+      RECOVERY_STAGE="transient_exhausted"
+      return 1
+    else
+      # manifest_unknown / unknown → no retry, and NO false transient_exhausted tag. The gate
+      # deliberately omits an explicit manifest arm (deepen GAP-5b): the transient regex is
+      # verified non-overlapping with the manifest tokens, so a manifest stderr lands HERE with
+      # EMPTY RECOVERY_STAGE — a transient→manifest tail is therefore carried by
+      # pull_failure_event's own pull_result classification, not mislabeled transient_exhausted.
+      return 1
+    fi
+  done
 }
 
 # pull_image_with_fallback <image_kind>: pull $IMAGE:$TAG zot-primary with an ATOMIC

--- a/apps/web-platform/infra/ci-deploy.sh
+++ b/apps/web-platform/infra/ci-deploy.sh
@@ -1403,9 +1403,13 @@ _ghcr_pull_or_recover() {
   RECOVERY_STAGE=""
   # #6525 transient backoff schedule. PULL_TRANSIENT_RETRY_SLEEPS is a test-only override seam
   # (mirrors the SOLEUR_GHCR_READ_FILE precedent); tests pass "0 0" for a zero-sleep 2-retry loop.
-  # Setting it to "" yields max=0 and DISABLES the transient retry (intentional; tests never use "").
+  # UNSET (the prod default) → "2 4" = 2 retries, ≤6 s added wall-clock/leg. Setting it to "" (empty)
+  # → an empty array → max=0 → DISABLES the transient retry — a deliberate operator break-glass lever.
+  # Hence the `-` default (NOT `:-`): `:-` would substitute the default on an EMPTY value too, silently
+  # defeating the disable lever; `-` substitutes only when UNSET, leaving an explicit "" empty. Prod
+  # never sets the var (unset ⇒ default). Tests exercise all three: unset (T-6525-8), "0 0", "" (T-6525-9).
   # shellcheck disable=SC2206  # intentional word-split of the space-separated schedule into the array
-  local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )
+  local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS-2 4} )
   local max=${#_sleeps[@]} attempt=0 detail
   while :; do
     if docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr"; then
@@ -1414,7 +1418,11 @@ _ghcr_pull_or_recover() {
       [[ "$attempt" -gt 0 ]] && pull_auth_recovery_event "${IMAGE}:${TAG}" transient_recovered
       return 0
     fi
-    # classify the stderr CONTENT (tail -c 400), never the path — else recovery no-ops (P2-E).
+    # classify the stderr CONTENT (tail -c 400), never the path — else recovery no-ops (P2-E). The
+    # inline `tail` here (rather than reusing the `detail` computed just below) is INTENTIONAL: #6400
+    # AC3 anchors on the literal `_pull_result_is_auth_denied "$(tail -c 400 "$perr"` call shape to
+    # prove content-not-path classification. `$perr` is unchanged since the pull, so the re-read below
+    # is byte-identical and cheap (a ≤400-byte file read); do not "simplify" it away — it breaks AC3.
     if _pull_result_is_auth_denied "$(tail -c 400 "$perr" 2>/dev/null)"; then
       # ---- #6400 auth recovery, VERBATIM — keeps its OWN inner success `return 0`, then a
       # terminal `return 1`: auth is recover-once-then-terminal and MUST NOT loop (a

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -358,6 +358,30 @@ if [[ "${1:-}" == "pull" ]]; then
         exit 1
       fi
     fi
+    # #6525: simulate a TRANSIENT/network GHCR pull failure so the bounded transient-retry
+    # loop in _ghcr_pull_or_recover can be exercised. TRANSIENT_COUNT_FILE is an integer
+    # countdown — emit a network-class stderr while >0 (decrement each GHCR pull), then fall
+    # through (a lower arm, or success). TRANSIENT_ALWAYS=1 emits transient on every GHCR pull
+    # (the exhaust scenario). MANIFEST_ALWAYS=1 emits a manifest-unknown stderr (the no-retry
+    # regression guard; also, composed with a TRANSIENT_COUNT_FILE=1, the GAP-7 transient→manifest
+    # tail). The transient stderr string mirrors the fleet-real shape used at T-5B-5c (:3568).
+    _T6525_TRANSIENT='read tcp 10.0.1.10:44444->140.82.112.34:443: read: connection reset by peer'
+    if [[ -n "${MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE:-}" && -f "${MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE}" ]]; then
+      _tn=$(cat "$MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE" 2>/dev/null || echo 0)
+      if [[ "$_tn" =~ ^[0-9]+$ ]] && (( _tn > 0 )); then
+        echo $(( _tn - 1 )) > "$MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE"
+        echo "$_T6525_TRANSIENT" >&2
+        exit 1
+      fi
+    fi
+    if [[ "${MOCK_GHCR_PULL_TRANSIENT_ALWAYS:-}" == "1" ]]; then
+      echo "$_T6525_TRANSIENT" >&2
+      exit 1
+    fi
+    if [[ "${MOCK_GHCR_PULL_MANIFEST_ALWAYS:-}" == "1" ]]; then
+      echo "manifest unknown: manifest unknown" >&2
+      exit 1
+    fi
   fi
 fi
 
@@ -3466,6 +3490,191 @@ if printf '%s' "$HELPER_BODY" | grep -qE '_docker_login_capture ghcr\.io "\$du" 
   PASS=$((PASS + 1)); echo "  PASS: recovery relogin writes ghcr.io auth into the same \$GHCR_DOCKER_CONFIG (cosign continuity)"
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: AC13 — recovery relogin must target ghcr.io"
+fi
+
+# --- #6525: widen the GHCR retry beyond auth-denied to cover TRANSIENT/network stderr ----
+# Root cause: _ghcr_pull_or_recover retried a failed GHCR pull ONLY when the stderr was
+# auth-classified (_pull_result_is_auth_denied). A transient first-attempt failure (timeout,
+# connection reset, EOF, no-such-host, ...) took the return-1 path with ZERO retries — the
+# observed v0.216.1/.2 "first attempt fails, rerun succeeds" shape. The fix adds a shared
+# _pull_result_is_transient predicate + a bounded, capped backoff loop; the both-registries
+# fail-closed semantics and the entire #6400 auth-recovery branch stay byte-identical.
+
+# T-6525-1..2: _pull_result_is_transient classifies the fleet's real transient stderr as
+# transient (return 0) and does NOT swallow the higher-precedence auth/manifest classes
+# (return non-zero). Sources the real predicate body (pure grep|printf, no deps — like
+# _login_kw/_login_tok at T-5B-16) rather than re-running the deploy per fixture.
+echo "--- #6525 T-6525-1..2: _pull_result_is_transient classifier (positive + negative) ---"
+TOTAL=$((TOTAL + 1))
+PT_BODY="$(awk '/^_pull_result_is_transient\(\) \{/,/^\}/' "$DEPLOY_SCRIPT")"
+PT_LIB=$(mktemp)
+printf '%s\n' "$PT_BODY" > "$PT_LIB"
+# shellcheck disable=SC1090
+source "$PT_LIB" 2>/dev/null || true
+# Positive fixtures — the fleet-real transient shapes (mirror :3555-3600) plus the deepen
+# docker-stderr research additions (context deadline exceeded / registry 5xx / net-http
+# client-timeout / DNS server-misbehaving).
+PT_POS=(
+  'read tcp 10.0.1.10:44444->140.82.112.34:443: read: connection reset by peer'
+  'Get "https://ghcr.io/v2/": dial tcp 140.82.112.34:443: connect: network is unreachable'
+  'Get "https://ghcr.io/v2/": EOF'
+  'dial tcp: lookup ghcr.io: no such host'
+  'dial tcp 140.82.112.34:443: connect: connection refused'
+  'Get "https://ghcr.io/v2/": net/http: TLS handshake timeout'
+  'Get "https://ghcr.io/v2/": read: i/o timeout'
+  'temporary failure in name resolution'
+  'Get "https://ghcr.io/v2/": context deadline exceeded'
+  'received unexpected HTTP status: 503 Service Unavailable'
+  'Get "https://ghcr.io/v2/": request canceled while waiting for connection'
+  'dial tcp: lookup ghcr.io on 10.0.0.1:53: server misbehaving'
+)
+# Negative fixtures — auth (higher precedence, owned by _pull_result_is_auth_denied) and
+# manifest (note `no such manifest` shares the `no such` prefix with the transient
+# `no such host` — the predicate must anchor on the full token and NOT match manifest).
+PT_NEG=(
+  'denied: requested access to the resource is denied'
+  'manifest unknown: manifest unknown'
+  'manifest for ghcr.io/x:v1 not found: no such manifest'
+)
+PT_BAD=""
+if ! declare -F _pull_result_is_transient >/dev/null; then
+  FAIL=$((FAIL + 1)); echo "  FAIL: could not source _pull_result_is_transient (fixture error / function absent)"
+else
+  for _s in "${PT_POS[@]}"; do
+    if ! _pull_result_is_transient "$_s"; then PT_BAD+=$'\n'"    positive NOT matched: $_s"; fi
+  done
+  for _s in "${PT_NEG[@]}"; do
+    if _pull_result_is_transient "$_s"; then PT_BAD+=$'\n'"    negative WRONGLY matched: $_s"; fi
+  done
+  if [[ -z "$PT_BAD" ]]; then
+    PASS=$((PASS + 1)); echo "  PASS: all ${#PT_POS[@]} transient shapes matched; all ${#PT_NEG[@]} auth/manifest shapes rejected"
+  else
+    FAIL=$((FAIL + 1)); echo "  FAIL: classifier mismatch:$PT_BAD"
+  fi
+fi
+rm -f "$PT_LIB"
+
+# T-6525-3: transient retry RECOVERS — count=1 (first pull transient, retry succeeds),
+# PULL_TRANSIENT_RETRY_SLEEPS="0 0" (no real sleep): 2 GHCR pulls, a transient_recovered
+# breadcrumb (op:image-pull-recovery), NO pull_failure_event, overall success.
+echo "--- #6525 T-6525-3: transient retry RECOVERS (count=1 → 2 pulls, transient_recovered) ---"
+T6525=$(mktemp -d)
+echo 1 > "$T6525/transient-count"
+export MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE="$T6525/transient-count"
+export PULL_TRANSIENT_RETRY_SLEEPS="0 0"
+export MOCK_PULL_ARGS_FILE="$T6525/pulls.txt";  : > "$MOCK_PULL_ARGS_FILE"
+export MOCK_SENTRY_CAPTURE_FILE="$T6525/sentry.txt"; : > "$MOCK_SENTRY_CAPTURE_FILE"
+run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v9.9.9" >/dev/null 2>&1 || true
+TOTAL=$((TOTAL + 1))
+T3_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
+if [[ "$T3_PULLS" -eq 2 ]] \
+   && grep -q 'image pull recovered (transient_recovered)' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && ! grep -q 'image pull failed' "$MOCK_SENTRY_CAPTURE_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: transient recovered — 2 GHCR pulls (blip+retry), transient_recovered event, no failure event"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-3 (ghcr_pulls=$T3_PULLS; expected 2 + transient_recovered, no failure event)"
+  echo "        sentry:"; sed 's/^/          /' "$MOCK_SENTRY_CAPTURE_FILE"
+fi
+unset MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE PULL_TRANSIENT_RETRY_SLEEPS MOCK_PULL_ARGS_FILE MOCK_SENTRY_CAPTURE_FILE
+rm -rf "$T6525"
+
+# T-6525-4: transient retry EXHAUSTS — transient on every pull, PULL_TRANSIENT_RETRY_SLEEPS="0 0"
+# (max=2): exactly 3 GHCR pulls (1 + 2 retries), pull_failure_event with pull_result=network
+# AND recovery_stage=transient_exhausted, overall FAILURE (old container stays live — fail-closed),
+# NO recovery event.
+echo "--- #6525 T-6525-4: transient retry EXHAUSTS (3 pulls, network/transient_exhausted, fail-closed) ---"
+T6525=$(mktemp -d)
+export MOCK_GHCR_PULL_TRANSIENT_ALWAYS=1
+export PULL_TRANSIENT_RETRY_SLEEPS="0 0"
+export MOCK_PULL_ARGS_FILE="$T6525/pulls.txt";  : > "$MOCK_PULL_ARGS_FILE"
+export MOCK_SENTRY_CAPTURE_FILE="$T6525/sentry.txt"; : > "$MOCK_SENTRY_CAPTURE_FILE"
+run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v9.9.9" >/dev/null 2>&1 && T4_RC=0 || T4_RC=$?
+TOTAL=$((TOTAL + 1))
+T4_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
+if [[ "$T4_RC" -ne 0 ]] && [[ "$T4_PULLS" -eq 3 ]] \
+   && grep -q 'image pull failed (network)' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && grep -q 'transient_exhausted' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && ! grep -q 'image pull recovered' "$MOCK_SENTRY_CAPTURE_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: exhausted — rc=$T4_RC, 3 GHCR pulls (1+2 retries), failure tagged network/transient_exhausted, no recovery"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-4 (rc=$T4_RC ghcr_pulls=$T4_PULLS; expected nonzero + 3 pulls + network + transient_exhausted)"
+  echo "        sentry:"; sed 's/^/          /' "$MOCK_SENTRY_CAPTURE_FILE"
+fi
+unset MOCK_GHCR_PULL_TRANSIENT_ALWAYS PULL_TRANSIENT_RETRY_SLEEPS MOCK_PULL_ARGS_FILE MOCK_SENTRY_CAPTURE_FILE
+rm -rf "$T6525"
+
+# T-6525-5: manifest/unknown stderr → exactly 1 GHCR pull (NO retry), pull_result=manifest_unknown,
+# empty recovery_stage. Regression guard: we did NOT widen retries to the manifest class.
+echo "--- #6525 T-6525-5: manifest stderr → exactly 1 pull, no retry (regression guard) ---"
+T6525=$(mktemp -d)
+export MOCK_GHCR_PULL_MANIFEST_ALWAYS=1
+export PULL_TRANSIENT_RETRY_SLEEPS="0 0"
+export MOCK_PULL_ARGS_FILE="$T6525/pulls.txt";  : > "$MOCK_PULL_ARGS_FILE"
+export MOCK_SENTRY_CAPTURE_FILE="$T6525/sentry.txt"; : > "$MOCK_SENTRY_CAPTURE_FILE"
+run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v9.9.9" >/dev/null 2>&1 && T5_RC=0 || T5_RC=$?
+TOTAL=$((TOTAL + 1))
+T5_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
+if [[ "$T5_RC" -ne 0 ]] && [[ "$T5_PULLS" -eq 1 ]] \
+   && grep -q 'image pull failed (manifest_unknown)' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && grep -q '"recovery_stage": *""' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && ! grep -q 'transient_exhausted' "$MOCK_SENTRY_CAPTURE_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: manifest → 1 GHCR pull (no retry), manifest_unknown, empty recovery_stage"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-5 (rc=$T5_RC ghcr_pulls=$T5_PULLS; expected nonzero + 1 pull + manifest_unknown + empty recovery_stage)"
+  echo "        sentry:"; sed 's/^/          /' "$MOCK_SENTRY_CAPTURE_FILE"
+fi
+unset MOCK_GHCR_PULL_MANIFEST_ALWAYS PULL_TRANSIENT_RETRY_SLEEPS MOCK_PULL_ARGS_FILE MOCK_SENTRY_CAPTURE_FILE
+rm -rf "$T6525"
+
+# T-6525-6 (deepen GAP-7): a transient blip FOLLOWED BY a manifest failure — arm transient
+# once, then manifest on the retry: exactly 2 GHCR pulls, terminal pull_result=manifest_unknown,
+# and recovery_stage EMPTY (NOT transient_exhausted — the retries were not spent AND the
+# terminal cause is manifest). Guards against polluting the transient_exhausted Sentry
+# discriminator with manifest tails.
+echo "--- #6525 T-6525-6 (GAP-7): transient→manifest tail → 2 pulls, manifest_unknown, empty recovery_stage ---"
+T6525=$(mktemp -d)
+echo 1 > "$T6525/transient-count"
+export MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE="$T6525/transient-count"
+export MOCK_GHCR_PULL_MANIFEST_ALWAYS=1
+export PULL_TRANSIENT_RETRY_SLEEPS="0 0"
+export MOCK_PULL_ARGS_FILE="$T6525/pulls.txt";  : > "$MOCK_PULL_ARGS_FILE"
+export MOCK_SENTRY_CAPTURE_FILE="$T6525/sentry.txt"; : > "$MOCK_SENTRY_CAPTURE_FILE"
+run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v9.9.9" >/dev/null 2>&1 && T6_RC=0 || T6_RC=$?
+TOTAL=$((TOTAL + 1))
+T6_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
+if [[ "$T6_RC" -ne 0 ]] && [[ "$T6_PULLS" -eq 2 ]] \
+   && grep -q 'image pull failed (manifest_unknown)' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && grep -q '"recovery_stage": *""' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && ! grep -q 'transient_exhausted' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && ! grep -q 'image pull recovered' "$MOCK_SENTRY_CAPTURE_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: transient→manifest tail — 2 pulls, manifest_unknown, empty recovery_stage (discriminator not polluted)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-6 (rc=$T6_RC ghcr_pulls=$T6_PULLS; expected nonzero + 2 pulls + manifest_unknown + empty recovery_stage, no transient_exhausted/recovery)"
+  echo "        sentry:"; sed 's/^/          /' "$MOCK_SENTRY_CAPTURE_FILE"
+fi
+unset MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE MOCK_GHCR_PULL_MANIFEST_ALWAYS PULL_TRANSIENT_RETRY_SLEEPS MOCK_PULL_ARGS_FILE MOCK_SENTRY_CAPTURE_FILE
+rm -rf "$T6525"
+
+# T-6525-7: single-source-of-truth wiring — _pull_result_is_transient is defined exactly ONCE,
+# pull_failure_event's network arm CALLS it (not a second inline regex), mirroring the
+# _pull_result_is_auth_denied shared-predicate guard at AC3 (:3419-3427). Anchored on the
+# call shape + a distinctive regex token that must live ONLY in the predicate, per the file's
+# own "anchor on the construct, not a bare token" discipline.
+echo "--- #6525 T-6525-7: pull_failure_event network arm calls the shared _pull_result_is_transient ---"
+TOTAL=$((TOTAL + 1))
+# Anchored on the CALL shape + the DEFINITION, never a bare regex token a comment could also carry
+# (the file's own "anchor on syntax, not a bare token" discipline). Three checks: (a) the predicate
+# is defined exactly once; (b) pull_failure_event's body CALLS it; (c) pull_failure_event's body no
+# longer carries the pre-#6525 inline network regex `timeout|timed out|temporary failure|...` — so
+# the classification was REWIRED to the shared predicate, not duplicated (single source of truth).
+TRANSIENT_DEF_COUNT=$(grep -cE '^_pull_result_is_transient\(\) \{' "$DEPLOY_SCRIPT")
+PFE_BODY="$(awk '/^pull_failure_event\(\) \{/,/^\}/' "$DEPLOY_SCRIPT")"
+if [[ "$TRANSIENT_DEF_COUNT" -eq 1 ]] \
+   && printf '%s' "$PFE_BODY" | grep -qE '_pull_result_is_transient "\$detail_raw"' \
+   && ! printf '%s' "$PFE_BODY" | grep -qE "grep -qiE '[^']*timed out\|temporary failure\|no route"; then
+  PASS=$((PASS + 1)); echo "  PASS: single _pull_result_is_transient definition; pull_failure_event calls the shared predicate (no inline network regex)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-7 (transient_def=$TRANSIENT_DEF_COUNT; expected exactly 1 def + shared-predicate call + no inline network regex in pull_failure_event)"
 fi
 
 # --- #6497: zot login failure is DISCRIMINATING (WEB-PLATFORM-5B) -----------------------

--- a/apps/web-platform/infra/ci-deploy.test.sh
+++ b/apps/web-platform/infra/ci-deploy.test.sh
@@ -627,6 +627,17 @@ MOCK
 # Shared mock scaffold: creates all common mock binaries in $MOCK_DIR.
 # Docker/curl behavior is driven by MOCK_DOCKER_MODE / MOCK_CURL_MODE env vars
 # (see factory docs above). Specialized overrides are rare after consolidation.
+# #6525: opt-in no-op `sleep` mock so a test can exercise the DEFAULT transient backoff schedule
+# (unset PULL_TRANSIENT_RETRY_SLEEPS ⇒ "2 4" = 6 s of REAL sleeps) without the wall-clock cost.
+# Gated on MOCK_SLEEP_NOOP=1 so every OTHER test keeps the real `sleep` (lease/lock/drain timing).
+create_mock_sleep() {
+  cat > "$1/sleep" << 'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+  chmod +x "$1/sleep"
+}
+
 create_base_mocks() {
   local mock_dir="$1"
   create_mock_logger "$mock_dir"
@@ -640,6 +651,9 @@ create_base_mocks() {
   create_mock_df "$mock_dir"
   create_mock_doppler "$mock_dir"
   create_mock_layer3 "$mock_dir"
+  # `if` (not `[[ … ]] && …`): create_base_mocks runs under `set -euo pipefail`, where a bare
+  # `[[ false ]] && cmd` statement exits non-zero and aborts the whole suite.
+  if [[ "${MOCK_SLEEP_NOOP:-}" == "1" ]]; then create_mock_sleep "$mock_dir"; fi
 }
 
 # Parse .reason and .exit_code out of a ci-deploy.state JSON file.
@@ -3528,13 +3542,21 @@ PT_POS=(
   'Get "https://ghcr.io/v2/": request canceled while waiting for connection'
   'dial tcp: lookup ghcr.io on 10.0.0.1:53: server misbehaving'
 )
-# Negative fixtures — auth (higher precedence, owned by _pull_result_is_auth_denied) and
-# manifest (note `no such manifest` shares the `no such` prefix with the transient
-# `no such host` — the predicate must anchor on the full token and NOT match manifest).
+# Negative fixtures — auth (higher precedence, owned by _pull_result_is_auth_denied), manifest, and
+# durable non-transient failures. EVERY token in the auth regex (unauthorized|authentication
+# required|denied|forbidden) gets its OWN fixture: with only `denied` present, a transient regex
+# widened to overlap the other three auth tokens would pass the "all negatives rejected" assertion
+# vacuously (test-design M12). Manifest carries both tokens (`no such manifest` shares the `no such`
+# prefix with the transient `no such host`); the durable classes (disk-full, bad reference) must
+# never be retried as transient.
 PT_NEG=(
   'denied: requested access to the resource is denied'
+  'unauthorized: authentication required'
+  'Get "https://ghcr.io/v2/token": 403 Forbidden'
   'manifest unknown: manifest unknown'
   'manifest for ghcr.io/x:v1 not found: no such manifest'
+  'failed to register layer: write /var/lib/docker: no space left on device'
+  'invalid reference format'
 )
 PT_BAD=""
 if ! declare -F _pull_result_is_transient >/dev/null; then
@@ -3555,8 +3577,10 @@ fi
 rm -f "$PT_LIB"
 
 # T-6525-3: transient retry RECOVERS — count=1 (first pull transient, retry succeeds),
-# PULL_TRANSIENT_RETRY_SLEEPS="0 0" (no real sleep): 2 GHCR pulls, a transient_recovered
-# breadcrumb (op:image-pull-recovery), NO pull_failure_event, overall success.
+# PULL_TRANSIENT_RETRY_SLEEPS="0 0" (no real sleep): the GHCR pull leg recovers on the 2nd pull —
+# 2 GHCR pulls, a transient_recovered breadcrumb (op:image-pull-recovery), NO pull_failure_event.
+# (Asserts the pull-leg recovery via events, not the full-deploy exit code — mirrors #6400 AC1,
+# which likewise verifies recovery by event, since a later mocked deploy step is out of scope here.)
 echo "--- #6525 T-6525-3: transient retry RECOVERS (count=1 → 2 pulls, transient_recovered) ---"
 T6525=$(mktemp -d)
 echo 1 > "$T6525/transient-count"
@@ -3593,7 +3617,7 @@ TOTAL=$((TOTAL + 1))
 T4_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
 if [[ "$T4_RC" -ne 0 ]] && [[ "$T4_PULLS" -eq 3 ]] \
    && grep -q 'image pull failed (network)' "$MOCK_SENTRY_CAPTURE_FILE" \
-   && grep -q 'transient_exhausted' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && grep -q '"recovery_stage": *"transient_exhausted"' "$MOCK_SENTRY_CAPTURE_FILE" \
    && ! grep -q 'image pull recovered' "$MOCK_SENTRY_CAPTURE_FILE"; then
   PASS=$((PASS + 1)); echo "  PASS: exhausted — rc=$T4_RC, 3 GHCR pulls (1+2 retries), failure tagged network/transient_exhausted, no recovery"
 else
@@ -3676,6 +3700,56 @@ if [[ "$TRANSIENT_DEF_COUNT" -eq 1 ]] \
 else
   FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-7 (transient_def=$TRANSIENT_DEF_COUNT; expected exactly 1 def + shared-predicate call + no inline network regex in pull_failure_event)"
 fi
+
+# T-6525-8 (test-design M10/M11): the PRODUCTION DEFAULT schedule must actually retry. Every other
+# #6525 test overrides PULL_TRANSIENT_RETRY_SLEEPS="0 0", so none exercises the prod wiring — a
+# one-char edit making the default empty (`${VAR-2 4}` → `${VAR-}`) silently reverts to the pre-#6525
+# ZERO-retry bug while staying green. Here the var is UNSET (prod path) so the real "2 4" default is
+# used; MOCK_SLEEP_NOOP=1 no-ops the 6 s of real sleeps so the test stays fast. Assert EXACTLY 3 GHCR
+# pulls (1 + 2 retries) → also pins the retry COUNT (a wrong default like "9 9 9 9 9" would give 6).
+echo "--- #6525 T-6525-8 (M10/M11): DEFAULT schedule (var UNSET) retries — exactly 3 pulls, transient_exhausted ---"
+T6525=$(mktemp -d)
+export MOCK_GHCR_PULL_TRANSIENT_ALWAYS=1
+export MOCK_SLEEP_NOOP=1            # no-op the real "2 4" default sleeps so the test stays fast
+unset PULL_TRANSIENT_RETRY_SLEEPS   # exercise the PROD default (2 4) — the wiring M10 leaves untested
+export MOCK_PULL_ARGS_FILE="$T6525/pulls.txt";  : > "$MOCK_PULL_ARGS_FILE"
+export MOCK_SENTRY_CAPTURE_FILE="$T6525/sentry.txt"; : > "$MOCK_SENTRY_CAPTURE_FILE"
+run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v9.9.9" >/dev/null 2>&1 && T8_RC=0 || T8_RC=$?
+TOTAL=$((TOTAL + 1))
+T8_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
+if [[ "$T8_RC" -ne 0 ]] && [[ "$T8_PULLS" -eq 3 ]] \
+   && grep -q 'image pull failed (network)' "$MOCK_SENTRY_CAPTURE_FILE" \
+   && grep -q '"recovery_stage": *"transient_exhausted"' "$MOCK_SENTRY_CAPTURE_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: default schedule (unset ⇒ 2 4) retries — exactly 3 GHCR pulls (1+2), transient_exhausted (kills the empty-default regression)"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-8 (rc=$T8_RC ghcr_pulls=$T8_PULLS; expected nonzero + 3 pulls + network + transient_exhausted — the DEFAULT '2 4' must produce 2 retries; an empty default gives 1 pull)"
+  echo "        sentry:"; sed 's/^/          /' "$MOCK_SENTRY_CAPTURE_FILE"
+fi
+unset MOCK_GHCR_PULL_TRANSIENT_ALWAYS MOCK_SLEEP_NOOP MOCK_PULL_ARGS_FILE MOCK_SENTRY_CAPTURE_FILE
+rm -rf "$T6525"
+
+# T-6525-9 (pattern/code-quality F1): PULL_TRANSIENT_RETRY_SLEEPS="" DISABLES the retry. This locks
+# the `-` (not `:-`) default contract: an empty value yields an empty array → max=0 → exactly 1 pull,
+# no retry. Under the old buggy `:-`, empty would fall back to "2 4" and give 3 pulls → this test
+# FAILS, catching the regression. max=0 means no sleep is ever reached, so no MOCK_SLEEP_NOOP needed.
+echo "--- #6525 T-6525-9: PULL_TRANSIENT_RETRY_SLEEPS=\"\" DISABLES retry (break-glass lever) — 1 pull ---"
+T6525=$(mktemp -d)
+export MOCK_GHCR_PULL_TRANSIENT_ALWAYS=1
+export PULL_TRANSIENT_RETRY_SLEEPS=""   # empty ⇒ max=0 ⇒ no retry (the `-` default contract)
+export MOCK_PULL_ARGS_FILE="$T6525/pulls.txt";  : > "$MOCK_PULL_ARGS_FILE"
+export MOCK_SENTRY_CAPTURE_FILE="$T6525/sentry.txt"; : > "$MOCK_SENTRY_CAPTURE_FILE"
+run_deploy "deploy web-platform ghcr.io/jikig-ai/soleur-web-platform v9.9.9" >/dev/null 2>&1 && T9_RC=0 || T9_RC=$?
+TOTAL=$((TOTAL + 1))
+T9_PULLS=$(grep -c '^PULL:ghcr.io/' "$MOCK_PULL_ARGS_FILE" 2>/dev/null || true)
+if [[ "$T9_RC" -ne 0 ]] && [[ "$T9_PULLS" -eq 1 ]] \
+   && grep -q 'image pull failed (network)' "$MOCK_SENTRY_CAPTURE_FILE"; then
+  PASS=$((PASS + 1)); echo "  PASS: empty override disables the retry — exactly 1 GHCR pull (no retry), still classified network"
+else
+  FAIL=$((FAIL + 1)); echo "  FAIL: T-6525-9 (rc=$T9_RC ghcr_pulls=$T9_PULLS; expected nonzero + exactly 1 pull — empty must DISABLE via the \`-\` default, not fall back to \"2 4\")"
+  echo "        sentry:"; sed 's/^/          /' "$MOCK_SENTRY_CAPTURE_FILE"
+fi
+unset MOCK_GHCR_PULL_TRANSIENT_ALWAYS PULL_TRANSIENT_RETRY_SLEEPS MOCK_PULL_ARGS_FILE MOCK_SENTRY_CAPTURE_FILE
+rm -rf "$T6525"
 
 # --- #6497: zot login failure is DISCRIMINATING (WEB-PLATFORM-5B) -----------------------
 # The gate discarded `docker login` stderr (`>/dev/null 2>&1`), so `login_failed` was one

--- a/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
@@ -60,6 +60,15 @@ managed registry. Then:
    > pull site (`ci-deploy.sh` `_ghcr_pull_or_recover`), fail-open (a recovery miss leaves
    > the unchanged `image_pull_failed` terminal state), retry exactly once. This contract
    > retires with the GHCR pull path at Phase 5.
+   >
+   > **Transient-retry co-tenant (#6525).** The same `_ghcr_pull_or_recover` gate also
+   > absorbs a **transient/network** first-attempt pull failure (timeout, connection reset,
+   > EOF, no-such-host, registry 5xx) with a bounded capped backoff
+   > (`PULL_TRANSIENT_RETRY_SLEEPS`, default 2 retries, ≤6 s/leg), emitting
+   > `recovery_stage=transient_recovered` on a save and `transient_exhausted` on a
+   > fail-closed exhaustion. It is a sibling of the auth recovery above — same one-level
+   > retry, same fail-open both-registries semantics — and **retires together with it at
+   > Phase 5** (the retirement structurally subsumes both by deleting the GHCR pull leg).
 3. **cosign (Phase 4):** unchanged trust anchor — same pinned cosign SHA, same offline
    `trusted_root.json`, same GitHub-Actions-OIDC identity regexp. Registry-agnostic (Phase-0
    proved a read-only user fetches a zot-stored `.sig` and gc does not reap it).

--- a/knowledge-base/project/learnings/2026-07-17-test-only-override-seam-leaves-prod-default-untested.md
+++ b/knowledge-base/project/learnings/2026-07-17-test-only-override-seam-leaves-prod-default-untested.md
@@ -1,0 +1,66 @@
+# Learning: a test-only override seam used by 100% of tests leaves the production default untested
+
+**Date:** 2026-07-17 · **PR:** #6621 · **Issue:** #6525 · **Surface:** `apps/web-platform/infra/ci-deploy.sh` + `ci-deploy.test.sh`
+
+## Problem
+
+The #6525 fix added a bounded transient-retry loop to `_ghcr_pull_or_recover`, wired through a
+test-only override seam `PULL_TRANSIENT_RETRY_SLEEPS` (default `"2 4"` in prod; tests pass `"0 0"`
+so the loop runs instantly). All six initial `#6525` tests set the seam to `"0 0"`. That made a
+one-character regression **invisible**: mutating the default `${PULL_TRANSIENT_RETRY_SLEEPS-2 4}`
+→ `${PULL_TRANSIENT_RETRY_SLEEPS-}` (empty default → `max=0` → **zero retries**) is byte-for-byte
+the pre-#6525 bug the PR exists to fix, yet the suite stayed **green** — because no test ever
+exercised the unset/default path. The seam that makes the tests fast also made them blind to the
+production wiring.
+
+Two adjacent authoring foot-guns surfaced on the same change:
+
+- The shared-predicate **doc comment** reproduced the sibling regex's exact pipe-sequence literal
+  (`unauthorized|authentication required|denied|forbidden` and a distinctive token `server
+  misbehaving`). A comment is scanned by grep-based Single-Source-of-Truth / count guards
+  (#6400 AC3 asserts that auth regex appears exactly once; a self-written T-6525-7 counted a
+  distinctive token). The prose literal inflated both counts → guard false-fail.
+- A bare `[[ cond ]] && cmd` **standalone statement** added to a helper that runs under
+  `set -euo pipefail` returns the failed `[[ ]]`'s non-zero exit when the condition is false →
+  `set -e` aborts the whole suite early (looks like a mysterious mid-run crash, not a test FAIL).
+
+## Solution
+
+- **Test the seam's absence.** For every "test-only override" seam (fast-path sleep schedules,
+  injected clocks, `MOCK_*` toggles, `SOLEUR_*_FILE` overrides), add at least one companion test
+  that runs with the seam **unset** so the production default is actually exercised. Here: T-6525-8
+  runs with `PULL_TRANSIENT_RETRY_SLEEPS` unset (default `"2 4"`) and a no-op `sleep` mock
+  (`MOCK_SLEEP_NOOP=1`) to stay fast, asserting exactly 3 pulls (1 + 2 retries) — which pins both
+  that the default is non-empty (kills the zero-retry mutation) and the exact retry count.
+  **Mutation-proven:** with the default emptied in-place, T-6525-8 FAILS (1 pull); restored via a
+  pre-mutation backup copied back in a separate Bash call.
+- **`-` vs `:-` for a disable lever.** The seam documented `""` as "disable the retry", but
+  `${VAR:-default}` substitutes the default on empty *and* unset, so empty silently gave the
+  default. Use `${VAR-default}` (no colon) when empty must mean empty; add a test locking it
+  (T-6525-9: empty → exactly 1 pull).
+- **Never reproduce a sibling regex's literal in a doc comment** near a grep-based count/SSOT
+  guard — describe the class in prose (`the auth-denied class`) instead of pasting the pipe
+  sequence. Verify with the guard's own grep before the full run.
+- **Never write a bare `[[ … ]] && cmd` standalone under `set -e`** — use `if [[ … ]]; then cmd; fi`
+  (an `if` always exits 0 when the condition is false).
+
+## Key Insight
+
+A fast-path override seam is a **coverage hole disguised as a convenience**: the value that makes
+tests fast is the exact value production never uses, so 100%-override adoption means the prod
+default has zero executable coverage. Every override seam needs a companion "seam-absent" test.
+Corollary from this file's long history: a comment is not inert — grep-based guards read comments,
+so a literal pasted into prose participates in the count it was meant to only describe.
+
+## Session Errors
+
+1. **RED test run exceeded the 120 s foreground limit** — Recovery: re-ran in `run_in_background`. Prevention: `ci-deploy.test.sh` is a ~5-min suite; always background it. (one-off / known)
+2. **Monitor timed out at 300 s** waiting for the >5-min suite — Recovery: polled the log file directly. Prevention: for this suite, poll via `run_in_background` completion notification, not a 300 s Monitor. (one-off)
+3. **Doc comment reproduced sibling regex literals** (`unauthorized|…|forbidden`, `server misbehaving`) → would trip #6400 AC3 `count==1` + T-6525-7 token count — Recovery: reworded to prose, verified with the guards' grep pre-run. Prevention: describe regex classes by name in comments; never paste the sibling's pipe-sequence near a count guard. (recurring)
+4. **`[[ "${MOCK_SLEEP_NOOP:-}" == "1" ]] && create_mock_sleep` standalone under `set -euo pipefail`** aborted the whole suite when the condition was false — Recovery: changed to `if [[ … ]]; then … fi`. Prevention: never use bare `[[ ]] && cmd` as a statement in a `set -e` region. (recurring)
+5. **Sandbox mutation run aborted (EXIT=2)** — the copied test resolves `DEPLOY_SCRIPT` + canary/lib siblings relative to its own dir, absent in a 2-file sandbox copy — Recovery: mutated `ci-deploy.sh` in place with a backup, restored from the backup in a separate Bash call. Prevention: to mutation-prove this file, mutate in place (backup first, restore in a separate call, run under a timeout). (recurring for this file)
+
+## Tags
+category: test-failures
+module: apps/web-platform/infra
+related: [[2026-07-16-a-mutation-battery-only-covers-what-you-mutate]], [[2026-07-15-narrowing-is-not-anchoring-and-a-documented-class-recurred-four-times-in-one-pr]]

--- a/knowledge-base/project/plans/2026-07-17-fix-image-pull-transient-retry-plan.md
+++ b/knowledge-base/project/plans/2026-07-17-fix-image-pull-transient-retry-plan.md
@@ -10,6 +10,19 @@ branch: feat-one-shot-6525-image-pull-transient-retry
 
 # 🐛 fix: first-attempt `image_pull_failed` on consecutive releases — widen the GHCR retry to cover transient/network stderr (#6525)
 
+## Deepen-Plan Enhancement Summary
+
+**Deepened:** 2026-07-17 · **Agents:** verify-the-negative (grep), network-outage deep-dive, architecture-strategist, code-simplicity-reviewer, pattern-recognition (control-flow), best-practices-researcher (docker-stderr). All 10 verify-the-negative premises **confirmed** against the live worktree; no blockers.
+
+**Applied changes:**
+1. **Control-flow (GAP-7, MED):** `RECOVERY_STAGE=transient_exhausted` moved into the transient arm (set only at `attempt == max`), so a transient→manifest tail no longer mislabels a manifest failure as `transient_exhausted` and pollutes the Sentry discriminator. New Phase-1 test 8 + AC.
+2. **Architecture (M1, MED):** Phase 2.3 now carries the EXPLICIT loop skeleton so the auth-`recovered` success (inside the verbatim #6400 block) and the loop-top `transient_recovered` cannot collapse — invariant stated (`attempt` increments only on the transient arm).
+3. **Docker-stderr research:** widened `_pull_result_is_transient` regex with `context deadline exceeded`, `received unexpected HTTP status: 5` (registry 5xx), `request canceled while waiting`, `server misbehaving`; added test fixtures.
+4. **Simplicity:** added the ≤6 s retry-window rationale ("minutes later" = human-reaction latency, not condition duration; targets the fast-recovery subset; residual surfaced via `transient_exhausted` telemetry + tunable `PULL_TRANSIENT_RETRY_SLEEPS`).
+5. **Architecture L1 + L3:** reclassification-safety AC (widened `network` set must not break `pull_result`-keyed alerts/soaks) and an inline `# shellcheck disable=SC2206` for the intentional array split.
+6. **Network deep-dive + GAP-5b:** explicit L3→L7 opt-out layer-mapping; documented the gate's deliberate omission of an explicit manifest arm.
+7. **ADR L2 (optional hygiene):** one-line ADR-096 amendment note so the Phase-5.3 retirement reader knows the transient loop retires with the auth recovery.
+
 ## Overview
 
 `pull_image_with_fallback` (`apps/web-platform/infra/ci-deploy.sh`) pulls the release image zot-primary with an atomic GHCR fallback (ADR-096 / #6122). Its GHCR leg — `_ghcr_pull_or_recover` (`ci-deploy.sh:1376-1397`) — retries a failed pull **exactly once, and only when the stderr is auth-classified** (`_pull_result_is_auth_denied` at `:530-532`, grepping `unauthorized|authentication required|denied|forbidden`). A **transient/network** first-attempt failure (timeout, connection reset, network-unreachable, EOF, no-such-host, temporary-failure) is **not** auth-classified, so it takes the `return 1` path with **zero retries**. Because `pull_image_with_fallback` returns failure only when **both** registries fail (fail-closed, old container stays live — downtime-safe), the whole deploy fails fast (~5 s) and a human `gh run rerun --failed` — hitting a warmer path minutes later — succeeds. That is exactly the observed v0.216.1 / v0.216.2 shape.
@@ -17,6 +30,8 @@ branch: feat-one-shot-6525-image-pull-transient-retry
 **The fix (per the #6594/PR-B handover comment on #6525):** add a transient-error classifier `_pull_result_is_transient` alongside `_pull_result_is_auth_denied`, and widen the GHCR leg so a transient failure retries with a **bounded, capped backoff** (not just the auth-denied class). The both-registries fail-closed semantics and the entire #6400 auth-recovery branch stay **byte-identical**.
 
 **This is a code-side change to an already-provisioned script** — no new infrastructure, no operator SSH. Delivery is automatic on merge (see `## Delivery`).
+
+**Retry-window rationale (why ≤6 s absorbs the observed class, deepen simplicity finding):** the "rerun succeeds *minutes* later" observation measures **human-reaction latency** (time for a person to notice the red deploy and click rerun), NOT the duration of the transient condition. The transport-blip class this fix targets — `connection reset`, `EOF`, `i/o`/handshake `timeout`, `network is unreachable` on a cold path, `context deadline exceeded`, registry 5xx, mirror/token warm-up — clears in sub-second-to-few-seconds; a 2-retry `[2 s, 4 s]` in-process backoff has a real chance of catching it on the same run. It deliberately targets the **fast-recovery subset**; a genuinely minutes-long condition still exhausts and fails-closed, and the `recovery_stage=transient_exhausted` telemetry surfaces that residual so the backoff schedule can be tuned (one-line `PULL_TRANSIENT_RETRY_SLEEPS` default change, no code change) if the exhaustion rate warrants it. Not over-claimed as a universal cure.
 
 **Scope discipline (do NOT over-claim):** this absorbs the **transient** first-attempt failure class. A subset of #6525's later occurrences (v0.217.0: `inngest-server`/`vector` inactive, no seccomp profile, `sandbox_canary.verdict: unknown`, rerun did NOT clear it) are **durable host-degradation** (private-NIC / IMDS first-boot race, tracked by #6400 / #6415 / #6565 / #6497), for which a bounded retry correctly **exhausts and fails-closed**. This PR closes the retry-starvation gap; it does not repair a wedged host. See `## Hypotheses` and `## Out of Scope`.
 
@@ -66,7 +81,9 @@ branch: feat-one-shot-6525-image-pull-transient-retry
 
 ## Hypotheses
 
-Feature keywords (`timeout`, `connection reset`, `network`, `unreachable`) trip the Network-Outage gate. This plan is a **code-side absorption fix**, not a host-outage diagnosis, so the L3→L7 host-layer checks are **opted out** with the artifact below (per the checklist's Opt-out clause), because the failure has already been root-caused and the two failure classes are separated:
+Feature keywords (`timeout`, `connection reset`, `network`, `unreachable`) trip the Network-Outage gate. This plan is a **code-side absorption fix**, not a host-outage diagnosis, so the L3→L7 host-layer checks are **opted out** with the artifact below (per the checklist's Opt-out clause), because the failure has already been root-caused and the two failure classes are separated.
+
+**Layer-mapping (explicit substitution).** The checklist's four literal checks (L3 `hcloud firewall describe`, L3 `dig`, L7 `curl -Iv`, L7 `journalctl`) target SSH/HTTP **host-reachability** incidents on a live server (its #2654/#2681 origin case). This failure is a `docker`-client GHCR pull inside an **ephemeral CI/deploy job** — there is no standing host-reachability question to verify; the pull's own stderr classification IS the L3/L7 artifact. So the four literal layers are **n/a-by-construction** and are substituted by the transient-vs-durable class split below (durable host-degradation, where a real L3 firewall/NIC check WOULD apply, is owned by #6415/#6565, not this code change):
 
 1. **Transient first-attempt condition on the pull path (the class THIS PR fixes).** Verification artifact: the #6594/PR-B handover comment on #6525 traced `_ghcr_pull_or_recover` and established the retry-starvation mechanism (auth-only retry ⇒ zero retries for network stderr); both artifacts (zot mirror `MIRROR_STATUS: ok`, GHCR image present before the deploy) confirm the image existed in both registries when the host pulled fast-fail — i.e. a transport-layer blip, not a missing artifact. This is the v0.216.1/.2 shape (rerun succeeds). **[verified: handover comment + issue body registry-presence evidence]**
 2. **Durable host degradation (the class THIS PR does NOT fix — L3 host layer).** v0.217.0's own state dump reports `inngest_server/vector: inactive`, `seccomp_profile_host_present: false`, and the rerun did NOT clear it. This is the private-NIC/IMDS first-boot race owned by #6415 (`soleur-private-nic-guard.sh`) / #6400 / #6565. For this class the bounded retry correctly **exhausts and fails-closed** (old container stays live) and emits `recovery_stage=transient_exhausted` so the durable case is Sentry-distinguishable from a transient one. **[opt-out artifact: this class is tracked and remediated on #6415/#6400/#6565 — L3 firewall/NIC verification is their scope, not this code change's; retrying a down NIC cannot succeed by construction.]**
@@ -81,33 +98,76 @@ Feature keywords (`timeout`, `connection reset`, `network`, `unreachable`) trip 
 
 Add to `ci-deploy.test.sh`:
 
-1. **Classifier positive/negative fixtures for `_pull_result_is_transient`** — source the script and assert the predicate returns 0 for each fleet-real transient string (reuse `:3555-3600` verbatim): `network is unreachable`, `read: connection reset by peer`, `: EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`. Assert it returns non-zero for an **auth** string (`denied: requested access to the resource is denied`) and a **manifest** string (`manifest unknown`) — the predicate must NOT swallow the higher-precedence classes.
+1. **Classifier positive/negative fixtures for `_pull_result_is_transient`** — source the script and assert the predicate returns 0 for each fleet-real transient string (reuse `:3555-3600` verbatim): `network is unreachable`, `read: connection reset by peer`, `: EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`, PLUS the deepen-research additions: `context deadline exceeded`, `received unexpected HTTP status: 503`, `request canceled while waiting for connection`, `server misbehaving`. Assert it returns non-zero for an **auth** string (`denied: requested access to the resource is denied`) and a **manifest** string (`manifest unknown` / `no such manifest` — note the `no such` shared prefix with the transient `no such host`) — the predicate must NOT swallow the higher-precedence classes.
 2. **`pull_failure_event` still tags `network`** for a transient stderr after the refactor (proves the extracted predicate is wired into the classifier arm; grouping tag value unchanged).
 3. **Transient retry recovers** — new mock arm `MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE` (countdown emitting a transient stderr, then succeed). With count=1 and `PULL_TRANSIENT_RETRY_SLEEPS="0 0"`, assert: 2 GHCR pulls, a `transient_recovered` recovery event (`op:image-pull-recovery`), NO `pull_failure_event`, overall success.
 4. **Transient retry exhausts → fail-closed + tagged** — transient stderr on every pull, `PULL_TRANSIENT_RETRY_SLEEPS="0 0"`: assert 3 GHCR pulls (1 + 2 retries), `pull_failure_event` fired with `pull_result=network` and `recovery_stage=transient_exhausted`, overall failure (old container stays live), NO recovery event.
 5. **Non-transient, non-auth (manifest) → NO retry** — manifest stderr: assert exactly 1 GHCR pull, `pull_result=manifest_unknown`, empty `recovery_stage`, failure (regression guard: we did not widen retries to manifest-unknown).
 6. **Auth path unchanged** — re-assert #6400 AC1/AC2/AC14 semantics hold byte-for-byte (these existing tests must not be edited except where the shared mock arm is added; run the full file).
 7. **Single-source-of-truth wiring guard** — grep-assert `pull_failure_event`'s network arm calls `_pull_result_is_transient` (not a second inline regex), mirroring the existing `_pull_result_is_auth_denied` shared-predicate guard at `:3423-3427`.
+8. **Mixed transient→manifest tail → correct tag (deepen GAP-7)** — arm the transient mock to fail transient once, then emit a manifest stderr on the next pull (`PULL_TRANSIENT_RETRY_SLEEPS="0 0"`): assert exactly 2 GHCR pulls, `pull_result=manifest_unknown`, and `recovery_stage` is **empty** (NOT `transient_exhausted` — retries were not spent and the terminal cause is manifest). Guards the false-`transient_exhausted` pollution of the Sentry discriminator.
 
 ### Phase 2 — GREEN: source changes in `ci-deploy.sh`
 
-1. **Add `_pull_result_is_transient`** beside `_pull_result_is_auth_denied` (`~:533`), same single-source-of-truth doc comment. Regex (case-insensitive, docker-stderr substrings, non-overlapping with auth/manifest):
-   `timeout|timed out|i/o timeout|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|tls handshake timeout|\bEOF\b`
-2. **Rewire `pull_failure_event`'s `network` arm** (`:549`) to call `_pull_result_is_transient "$detail_raw"`. Keep precedence auth → manifest_unknown → transient → pull_failed and keep the emitted tag value `network` (Sentry grouping/alert keys unchanged).
-3. **Add the transient branch to `_ghcr_pull_or_recover`** (`:1376-1397`). Structure — a bounded loop whose auth branch `return`s from inside (never loops), preserving #6400:
-   - Declare the backoff schedule with a test-only override: `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )` (production `2 4`; tests set `"0 0"`). Mirrors the file's `SOLEUR_GHCR_READ_FILE` test-only-override precedent; `local max=${#_sleeps[@]}`, `attempt=0`.
-   - Loop: `docker pull … 200>&- 2>"$perr"` → on success, if `attempt>0` emit `pull_auth_recovery_event "${IMAGE}:${TAG}" transient_recovered` then `return 0`.
-   - On failure classify `detail="$(tail -c 400 "$perr")"`:
-     - `_pull_result_is_auth_denied` → **existing #6400 recovery, verbatim** (refetch+relogin+single retry, sets `RECOVERY_STAGE`), then `return 1` — auth never enters the transient loop.
-     - `_pull_result_is_transient` && `attempt < max` → `sleep "${_sleeps[$attempt]}"`; `attempt=$((attempt+1))`; continue.
-     - else (transient exhausted OR manifest/unknown) → if `attempt>0` set `RECOVERY_STAGE="transient_exhausted"`; `return 1`.
+1. **Add `_pull_result_is_transient`** beside `_pull_result_is_auth_denied` (`~:533`), same single-source-of-truth doc comment. Regex (case-insensitive, docker/containerd-stderr substrings, verified NON-overlapping with the auth regex and the manifest arm — see Sharp Edges):
+   `context deadline exceeded|timeout|timed out|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|server misbehaving|request canceled while waiting|received unexpected http status: 5|\bEOF\b`
+   (Backed by the deepen docker-stderr research: `context deadline exceeded` is the canonical Go timeout; `received unexpected http status: 5` catches registry 5xx (503/502); `request canceled while waiting` is the net/http client-timeout shape; `server misbehaving` is a DNS-resolver transient. `timeout` already subsumes `i/o timeout`/`tls handshake timeout`/`connection … timeout`; case-insensitive `\bEOF\b` subsumes `unexpected EOF`.)
+2. **Rewire `pull_failure_event`'s `network` arm** (`:549`) to call `_pull_result_is_transient "$detail_raw"`. Keep precedence auth → manifest_unknown → transient → pull_failed and keep the emitted tag value `network` (Sentry grouping/alert keys unchanged). **Reclassification note (deepen L1):** the shared predicate is WIDER than the old inline `:549` regex, so some stderrs that were `pull_result=pull_failed` now tag `network` (and the `pull_failed` set shrinks). This is the intended improvement (Phase 1 test 2 guards it); Phase 3 asserts no alert/soak query keys on `pull_result=pull_failed` or on the narrow pre-widening `network` set (they key on `op:image-pull` broadly + `registry:`/`stage:` signals, not `pull_result` sub-values — confirm, don't assume).
+3. **Add the transient branch to `_ghcr_pull_or_recover`** (`:1376-1397`) as a bounded loop. Carry the EXPLICIT skeleton below (deepen M1) so the auth-`recovered` and transient-`recovered` success emitters cannot be collapsed and #6400 stays byte-for-byte. Load-bearing invariant: `attempt` increments **only** in the transient arm, so the loop-top `transient_recovered` emitter is reachable **only after** ≥1 transient retry — disjoint from the auth block's `recovered` by construction.
+
+   ```bash
+   _ghcr_pull_or_recover() {
+     local perr="$1"
+     RECOVERY_STAGE=""
+     # Test-only backoff override (mirrors the SOLEUR_GHCR_READ_FILE test-only precedent).
+     # Prod "2 4" = 2 retries, ≤6 s total added wall-clock. NOTE: setting this to "" (empty)
+     # yields max=0 and DISABLES the transient retry — intentional; tests use "0 0", never "".
+     # shellcheck disable=SC2206  # intentional word-split into the backoff array
+     local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )
+     local max=${#_sleeps[@]} attempt=0 detail stage
+     while :; do
+       if docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr"; then
+         [[ "$attempt" -gt 0 ]] && pull_auth_recovery_event "${IMAGE}:${TAG}" transient_recovered
+         return 0
+       fi
+       detail="$(tail -c 400 "$perr" 2>/dev/null)"
+       if _pull_result_is_auth_denied "$detail"; then
+         # ---- #6400 auth recovery, VERBATIM — keeps its OWN inner success `return 0` ----
+         stage="$(refetch_ghcr_and_relogin)" || true
+         if [[ "$stage" == "recovered" ]]; then
+           if docker pull "${IMAGE}:${TAG}" 200>&- 2>"$perr"; then
+             pull_auth_recovery_event "${IMAGE}:${TAG}" recovered   # label stays `recovered`
+             return 0
+           fi
+           RECOVERY_STAGE="pull_still_denied"
+         else
+           RECOVERY_STAGE="$stage"                                 # refetch_unavailable|relogin_failed
+         fi
+         return 1                            # auth = terminal-after-one-retry; NEVER loops
+       elif _pull_result_is_transient "$detail" && (( attempt < max )); then
+         sleep "${_sleeps[$attempt]}"; attempt=$((attempt + 1)); continue
+       elif _pull_result_is_transient "$detail"; then
+         RECOVERY_STAGE="transient_exhausted"  # set ONLY when the TERMINAL failure is itself transient AND retries are spent (deepen GAP-7)
+         return 1
+       else
+         # manifest_unknown / unknown → no retry, and NO false transient_exhausted tag.
+         # A transient→manifest tail lands here with empty RECOVERY_STAGE; the manifest
+         # cause is carried by pull_failure_event's own pull_result classification.
+         return 1
+       fi
+     done
+   }
+   ```
+
+   **Gate-precedence note (deepen GAP-5b):** the gate is `auth → transient(retry) → else`, deliberately omitting an explicit manifest arm (unlike `pull_failure_event`, which keeps `auth → manifest → transient`). This is safe because (a) docker/containerd emit ONE error class per failure and (b) the transient regex is verified non-overlapping with the manifest tokens (`manifest unknown|not found|no such manifest`), so a real manifest failure never matches the transient arm and lands in `else` → `return 1`, no retry — the correct outcome. The only theoretical divergence is a single stderr containing BOTH a manifest AND a transient token, which does not occur in practice.
 4. **Comment** the one-level-retry decision (zot stays immediate-fallback = a different-registry retry; the caller does not retry) and the ≤6 s added-wall-clock bound.
 
 ### Phase 3 — Verify budget + delivery guards
 
 1. Run `bash apps/web-platform/infra/ci-deploy.test.sh` — full suite green (including the #5145 drift guard at `:2890-2972` — it must stay green; the pull sleeps are upstream of the verify loop and are not health/cron attempts, so they do not enter `DG_RIGHT`).
-2. `shellcheck apps/web-platform/infra/ci-deploy.sh` (if wired in CI) — no new findings.
-3. Confirm the added worst-case wall-clock: `2` retries × `[2 s, 4 s]` = **≤6 s per GHCR leg**, ≤12 s across the web + inngest pulls — negligible vs the deploy budget; state it in the PR body.
+2. `shellcheck apps/web-platform/infra/ci-deploy.sh` (if wired in CI) — no new findings; the intentional array word-split carries an inline `# shellcheck disable=SC2206` (deepen L3) so the "no new findings" claim holds.
+3. **Reclassification safety (deepen L1)** — grep `apps/web-platform/infra/sentry/` and any soak script (`zot-soak-6122.sh`, `*op-contract*`) for `pull_result` to confirm no alert/soak query keys on `pull_result=pull_failed` or on the narrow pre-widening `network` set. Expected: alerts key on `op:image-pull` + `registry:`/`stage:` signals, not `pull_result` sub-values (so widening `network` is safe). Assert, don't assume.
+4. Confirm the added worst-case wall-clock: `2` retries × `[2 s, 4 s]` = **≤6 s per GHCR leg**, ≤12 s across the web + inngest pulls — negligible vs the deploy budget; state it in the PR body.
 
 ## Delivery
 
@@ -120,8 +180,10 @@ Add to `ci-deploy.test.sh`:
 - [ ] `pull_failure_event`'s network arm calls `_pull_result_is_transient` (grep guard) — single source of truth, no second inline regex.
 - [ ] Transient failure retries with bounded backoff: count=1 mock recovers (2 pulls, `transient_recovered` event, no failure event); exhaust mock fails after exactly 3 pulls with `pull_result=network` + `recovery_stage=transient_exhausted`.
 - [ ] Manifest/unknown stderr gets exactly 1 pull (no retry); regression guard green.
-- [ ] #6400 AC1/AC2/AC14 (auth recovery) pass unchanged; `pull_image_with_fallback` still returns 1 only when BOTH registries fail (fail-closed).
-- [ ] Full `bash apps/web-platform/infra/ci-deploy.test.sh` green, including the #5145 drift guard.
+- [ ] Mixed transient→manifest tail (deepen GAP-7): 2 pulls, `pull_result=manifest_unknown`, `recovery_stage` **empty** (not `transient_exhausted`) — the discriminator is not polluted.
+- [ ] Reclassification safety (deepen L1): no Sentry alert / soak query keys on `pull_result=pull_failed` or the narrow pre-widening `network` set (grep `infra/sentry/` + soak scripts).
+- [ ] #6400 AC1/AC2/AC14 (auth recovery) pass unchanged; `pull_image_with_fallback` still returns 1 only when BOTH registries fail (fail-closed); auth-`recovered` and transient-`recovered` labels stay disjoint (attempt increments only on the transient arm).
+- [ ] Full `bash apps/web-platform/infra/ci-deploy.test.sh` green, including the #5145 drift guard; `shellcheck` clean with the intentional `# shellcheck disable=SC2206`.
 - [ ] Added wall-clock ≤6 s/leg documented in the PR body.
 - [ ] PR body uses `Ref #6525` (NOT `Closes`) — see below.
 
@@ -154,7 +216,7 @@ logs:
   where: journald tag ci-deploy → Better Stack (vector.toml allowlist); Sentry store endpoint
   retention: Better Stack + Sentry defaults (unchanged)
 discoverability_test:
-  command: "gh run list --workflow=apply-deploy-pipeline-fix.yml --limit 3  # then query Sentry issues op:image-pull-recovery recovery_stage=transient_recovered on hetzner-150638239 — NO ssh"
+  command: "gh run list --workflow=apply-deploy-pipeline-fix.yml --limit 3  # then query the Sentry issues API for op:image-pull-recovery recovery_stage=transient_recovered on hetzner-150638239 (host-login-free, gh + Sentry API only)"
   expected_output: "post-fix, a transient blip on hetzner-150638239 yields a transient_recovered recovery event (absorbed) instead of an image_pull_failed deploy abort; a durable host still yields recovery_stage=transient_exhausted (routes to #6415/#6565)"
 ```
 
@@ -181,7 +243,7 @@ discoverability_test:
 
 **Domains relevant:** none
 
-Infrastructure/CI bug fix on an already-provisioned script (`apps/web-platform/infra/ci-deploy.sh` + its test). No user-facing surface (no `components/**`, `app/**/page.tsx`, `app/**/layout.tsx` — mechanical UI-surface override does not fire), no regulated-data surface (GDPR gate 2.7 skipped), no new infrastructure/secret/vendor (IaC gate 2.8 skipped — edits an existing hashed-trigger script, delivered by the existing `apply-deploy-pipeline-fix.yml`), no architectural-decision change (ADR gate 2.10 skipped — the ADR-096 zot-primary/GHCR-fallback topology and the both-registries fail-closed contract are UNCHANGED; a bounded retry-classifier widening on an existing leg is a refinement, not a new boundary — a competent engineer reading ADR-096 would not be misled).
+Infrastructure/CI bug fix on an already-provisioned script (`apps/web-platform/infra/ci-deploy.sh` + its test). No user-facing surface (no `components/**`, `app/**/page.tsx`, `app/**/layout.tsx` — mechanical UI-surface override does not fire), no regulated-data surface (GDPR gate 2.7 skipped), no new infrastructure/secret/vendor (IaC gate 2.8 skipped — edits an existing hashed-trigger script, delivered by the existing `apply-deploy-pipeline-fix.yml`), no architectural-decision change (ADR gate 2.10 skipped — the ADR-096 zot-primary/GHCR-fallback topology and the both-registries fail-closed contract are UNCHANGED; a bounded retry-classifier widening on an existing leg is a refinement, not a new boundary — a competent engineer reading ADR-096 would not be misled). Optional documentation hygiene (deepen L2, NOT a gate requirement): add one line to ADR-096's "Interim-GHCR pull-recovery contract (#6400)" block (lines 51-62) noting the transient-retry loop now co-resides with the auth recovery at `_ghcr_pull_or_recover`, so the Phase-5.3 retirement reader knows both retire together (the retirement already structurally subsumes the loop).
 
 ## Sharp Edges
 
@@ -189,4 +251,9 @@ Infrastructure/CI bug fix on an already-provisioned script (`apps/web-platform/i
 - The auth branch in `_ghcr_pull_or_recover` MUST `return` from inside the loop (never `continue`), or a `MOCK_GHCR_PULL_DENY_ALWAYS` auth failure would loop and burn the window — breaking #6400 AC2/AC14. Keep the transient loop strictly for the transient class.
 - `_pull_result_is_transient` regex must stay non-overlapping with `_pull_result_is_auth_denied` (`unauthorized|denied|forbidden|authentication required`) and the manifest arm (`manifest unknown|not found|no such manifest`). Note `no such host` (transient) vs `no such manifest` (manifest) share `no such` — anchor on the full token (`no such host`), and keep classifier precedence auth → manifest → transient in `pull_failure_event`.
 - Do NOT rename the `pull_result` tag value `network` — Sentry grouping and the `zot_mirror_fallback_rate` alert key on it. The new predicate is the source of the SAME tag value.
+- `RECOVERY_STAGE="transient_exhausted"` is set ONLY in the transient arm when retries are genuinely spent (`attempt == max`), NEVER in the generic `else` (deepen GAP-7). A transient→manifest tail must land in `else` with EMPTY `recovery_stage` — otherwise the `transient_exhausted` Sentry signal (the transient-vs-durable discriminator) is polluted with manifest failures.
+- The gate's precedence is `auth → transient(retry) → else`, deliberately WITHOUT an explicit manifest arm (deepen GAP-5b). Safe because docker emits one error class per failure and the transient regex is verified non-overlapping with the manifest tokens, so a manifest failure lands in `else` (no retry). Only `pull_failure_event` keeps the full `auth → manifest → transient` precedence.
+- The auth-recovered success (`pull_auth_recovery_event … recovered`) MUST stay INSIDE the verbatim #6400 block with its own inner `return 0`; the loop-top `transient_recovered` emitter is gated on `attempt>0` and `attempt` increments only on the transient arm, so the two labels are disjoint by construction (deepen M1). Do not collapse the two success paths.
+- The backoff array `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )` carries an inline `# shellcheck disable=SC2206` (intentional word-split, deepen L3). Setting the override to `""` yields `max=0` and disables the retry — intentional; tests use `"0 0"`, never `""`.
+- Rewiring `pull_failure_event`'s network arm to the shared predicate WIDENS the `network`-tagged set (deepen L1) — confirm no alert/soak query keys on `pull_result=pull_failed` or the narrow old `network` set before shipping (Phase 3.3).
 - Use `Ref #6525` in the PR body, not `Closes` — the fix only exercises on real deploys; auto-closing at merge before the soak confirms absorption would false-resolve it (`wg-use-closes-n-in-pr-body-not-title-to` / ops-remediation Closes-vs-Ref pattern).

--- a/knowledge-base/project/plans/2026-07-17-fix-image-pull-transient-retry-plan.md
+++ b/knowledge-base/project/plans/2026-07-17-fix-image-pull-transient-retry-plan.md
@@ -1,0 +1,192 @@
+---
+title: "fix: image-pull transient retry (widen GHCR retry beyond auth-denied)"
+issue: 6525
+type: bug
+lane: single-domain
+brand_survival_threshold: aggregate pattern
+created: 2026-07-17
+branch: feat-one-shot-6525-image-pull-transient-retry
+---
+
+# 🐛 fix: first-attempt `image_pull_failed` on consecutive releases — widen the GHCR retry to cover transient/network stderr (#6525)
+
+## Overview
+
+`pull_image_with_fallback` (`apps/web-platform/infra/ci-deploy.sh`) pulls the release image zot-primary with an atomic GHCR fallback (ADR-096 / #6122). Its GHCR leg — `_ghcr_pull_or_recover` (`ci-deploy.sh:1376-1397`) — retries a failed pull **exactly once, and only when the stderr is auth-classified** (`_pull_result_is_auth_denied` at `:530-532`, grepping `unauthorized|authentication required|denied|forbidden`). A **transient/network** first-attempt failure (timeout, connection reset, network-unreachable, EOF, no-such-host, temporary-failure) is **not** auth-classified, so it takes the `return 1` path with **zero retries**. Because `pull_image_with_fallback` returns failure only when **both** registries fail (fail-closed, old container stays live — downtime-safe), the whole deploy fails fast (~5 s) and a human `gh run rerun --failed` — hitting a warmer path minutes later — succeeds. That is exactly the observed v0.216.1 / v0.216.2 shape.
+
+**The fix (per the #6594/PR-B handover comment on #6525):** add a transient-error classifier `_pull_result_is_transient` alongside `_pull_result_is_auth_denied`, and widen the GHCR leg so a transient failure retries with a **bounded, capped backoff** (not just the auth-denied class). The both-registries fail-closed semantics and the entire #6400 auth-recovery branch stay **byte-identical**.
+
+**This is a code-side change to an already-provisioned script** — no new infrastructure, no operator SSH. Delivery is automatic on merge (see `## Delivery`).
+
+**Scope discipline (do NOT over-claim):** this absorbs the **transient** first-attempt failure class. A subset of #6525's later occurrences (v0.217.0: `inngest-server`/`vector` inactive, no seccomp profile, `sandbox_canary.verdict: unknown`, rerun did NOT clear it) are **durable host-degradation** (private-NIC / IMDS first-boot race, tracked by #6400 / #6415 / #6565 / #6497), for which a bounded retry correctly **exhausts and fails-closed**. This PR closes the retry-starvation gap; it does not repair a wedged host. See `## Hypotheses` and `## Out of Scope`.
+
+## Research Insights
+
+**Code map (verified against `origin`/working tree at plan time):**
+- `_pull_result_is_auth_denied` — `ci-deploy.sh:530-532`. Single source of truth: called by BOTH `pull_failure_event`'s classifier (`:547`) and the recovery gate `_ghcr_pull_or_recover` (`:1381`) so they agree by construction. The file explicitly warns a second regex copy would drift.
+- `pull_failure_event` classifier arms — `ci-deploy.sh:545-551`. Order: `auth_denied` → `manifest_unknown` (`manifest unknown|not found|no such manifest`) → `network` (`timeout|timed out|temporary failure|no route|connection refused`) → `pull_failed`. The `network` arm's inline regex is the **narrower** sibling of the classifier we are adding.
+- `_ghcr_pull_or_recover` — `ci-deploy.sh:1376-1397`. Pull once; on auth-denied → `refetch_ghcr_and_relogin` → single retry; sets global `RECOVERY_STAGE ∈ {'', recovered(implicit), pull_still_denied, refetch_unavailable, relogin_failed}`.
+- `refetch_ghcr_and_relogin` — subshell-called (`stage="$(...)"`), so it CANNOT set `RECOVERY_STAGE` (subshell boundary); it `printf`s the stage string. `_ghcr_pull_or_recover` is called DIRECTLY, so it CAN set the global. This asymmetry is load-bearing — the transient loop lives in `_ghcr_pull_or_recover` (direct call) so it can set `RECOVERY_STAGE=transient_exhausted`.
+- `pull_image_with_fallback` — `ci-deploy.sh:1408-1468`. Two branches (zot-active fallback `:1450`; zot-dark direct `:1461`), both route the GHCR pull through `_ghcr_pull_or_recover`, so a loop added there covers both. Caller does NOT retry — retry stays at ONE level.
+- `pull_auth_recovery_event` — `ci-deploy.sh:580-597`. Fail-open, env-guarded, `op:image-pull-recovery`, `level:info`, `jq -n --arg` (never raw stderr), host_id-tagged. Reusable for a `transient_recovered` breadcrumb.
+
+**Established retry idiom in this file** (`ci-deploy.sh:1157-1158`, `1232-1236`, and `refetch_ghcr_and_relogin`): `n=0; until <cmd>; do n=$((n+1)); [[ "$n" -ge 3 ]] && break; sleep 5; done` — hardcoded `sleep`, 3-attempt cap. The new loop mirrors the cap idiom but uses an **explicit backoff array** (see Alternatives) with a **test-only override seam**.
+
+**Test harness** (`ci-deploy.test.sh`):
+- Mock docker deny machinery — `:340-362`: `MOCK_GHCR_PULL_DENY_ALWAYS=1` (every GHCR pull denies), `MOCK_GHCR_PULL_DENY_COUNT_FILE` (integer countdown, deny while `>0` then succeed). Deny payload is `"denied: requested access to the resource is denied"` (auth-classified). **New transient tests need a transient-stderr mock arm** (a new `MOCK_GHCR_PULL_TRANSIENT_*` countdown emitting a network-class stderr).
+- #6400 retry tests — `:3338-3417` (AC1 count=1→recovered; AC2 `pull_still_denied`; AC14 relogin-fail→no retry; AC4 recovery is GHCR-scoped, not zot). These MUST stay green unchanged.
+- Transient stderr fixtures the fleet actually produces — `:3555-3600` (`network is unreachable`, `read: connection reset by peer`, `EOF`, `no such host`, `connection refused`). Reuse these exact strings as the classifier's positive fixtures.
+- **No sleep-mock exists** — existing retry tests avoid sleeping only because the mock succeeds before the sleep is reached. A test that EXHAUSTS the transient loop would sleep for real → introduce the override seam (below).
+
+**Institutional learnings applied:**
+- `2026-06-30-adaptive-ci-poll-gate-wall-clock-ceiling-not-attempt-count.md` — **apply retry at one level only** (avoid multiplicative attempts). Loop stays in `_ghcr_pull_or_recover`, not the caller. (The wall-clock-vs-attempt-count guidance is noted but a fixed 2-element backoff array is already deterministically bounded to ≤6 s; a `date +%s` ceiling would add epoch-math complexity for no benefit — see Alternatives.)
+- `2026-07-13-web-2-fsn1-fresh-boot-image-pull-auth-denied-stale-baked-cred.md` — re-fetch/retry on USE-FAILURE not just absence; the `stage`/`recovery_stage` tag makes boot-vs-deploy pull failures Sentry-queryable without SSH.
+- `2026-07-15-silent-fallback-masked-a-dead-primary-for-14-days.md` — **alarm on fallback/recovery USAGE**: emit a monitored `transient_recovered` breadcrumb so retry-saves are visible (a working retry that masks a chronically flaky path is a signal, not silence).
+- `2026-07-07-immutable-redeploy.md` (SE 1-3, #6400/#6415) — **over-claim guard**: a private-NIC-down host is NOT a transient timeout; retry will exhaust and fail. Do not assert this "fixes #6525" wholesale.
+- `2026-06-12-octokit-wraps-undici-connect-timeout...md` — classify only genuine transients, narrowly. (bash analogue: match docker's stderr **substrings** for the fleet's real shapes, not broad tokens that would swallow `manifest unknown` / auth.)
+
+**Premise Validation:** #6525 is OPEN (`gh issue view 6525` → `state: OPEN`, `closedByPullRequestsReferences: []`) — premise holds, this is a genuine unfixed bug. The cited functions/predicates all exist at the lines above (grepped). The #6594/PR-B handover comment is present on the issue and lays out exactly this fix direction ("widen the retry classifier to cover transient/network stderr (bounded backoff), not to touch the fail-closed both-registries semantics"). No stale premise.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Handover / issue claim | Codebase reality (verified) | Plan response |
+|---|---|---|
+| "GHCR leg retries once, auth-only" | `_ghcr_pull_or_recover:1381` gates the single retry on `_pull_result_is_auth_denied` only | Add a transient branch with bounded backoff; auth branch untouched |
+| "transient failure gets ZERO retries" | Confirmed — a non-auth stderr falls straight to `return 1` (`:1396`) with empty `RECOVERY_STAGE` | Transient stderr now enters a capped retry loop |
+| "returns failure only when BOTH registries fail" | Confirmed (`pull_image_with_fallback` returns 1 only after zot AND `_ghcr_pull_or_recover` fail) | **Unchanged** — fail-closed downtime-safe semantics preserved |
+| A `network` classifier "already exists" | Only inline inside `pull_failure_event:549`, narrower than the fleet's real shapes; not shared with the recovery gate | Extract `_pull_result_is_transient` as the shared predicate; `pull_failure_event` calls it (anti-drift, mirrors `_pull_result_is_auth_denied`) |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** at worst a marginally slower deploy (bounded ≤ ~6 s per GHCR leg of added backoff). A logic error in the loop still resolves to the existing fail-closed path — the prior container keeps serving prod (no new user-facing outage is introduced by this change). A regressed classifier that mis-retries a genuine auth/manifest failure would delay the (still-correct) fail-closed abort by ≤ the backoff budget, not change its outcome.
+
+**If this leaks, the user's data is exposed via:** nothing new. The retry adds no data to any telemetry: docker stderr is already scrubbed to a coarse class BEFORE any Sentry payload (`pull_failure_event:538`), and the new `transient_recovered` breadcrumb carries only `ref` + `stage` + `host_id` via `jq -n --arg` (no raw stderr), reusing the audited `pull_auth_recovery_event` transport.
+
+**Brand-survival threshold:** aggregate pattern — a regression in the shared pull path degrades **deploy reliability across all releases** (aggregate), not a single-user data incident. No per-PR CPO sign-off required; the section is present per preflight Check 6.
+
+## Hypotheses
+
+Feature keywords (`timeout`, `connection reset`, `network`, `unreachable`) trip the Network-Outage gate. This plan is a **code-side absorption fix**, not a host-outage diagnosis, so the L3→L7 host-layer checks are **opted out** with the artifact below (per the checklist's Opt-out clause), because the failure has already been root-caused and the two failure classes are separated:
+
+1. **Transient first-attempt condition on the pull path (the class THIS PR fixes).** Verification artifact: the #6594/PR-B handover comment on #6525 traced `_ghcr_pull_or_recover` and established the retry-starvation mechanism (auth-only retry ⇒ zero retries for network stderr); both artifacts (zot mirror `MIRROR_STATUS: ok`, GHCR image present before the deploy) confirm the image existed in both registries when the host pulled fast-fail — i.e. a transport-layer blip, not a missing artifact. This is the v0.216.1/.2 shape (rerun succeeds). **[verified: handover comment + issue body registry-presence evidence]**
+2. **Durable host degradation (the class THIS PR does NOT fix — L3 host layer).** v0.217.0's own state dump reports `inngest_server/vector: inactive`, `seccomp_profile_host_present: false`, and the rerun did NOT clear it. This is the private-NIC/IMDS first-boot race owned by #6415 (`soleur-private-nic-guard.sh`) / #6400 / #6565. For this class the bounded retry correctly **exhausts and fails-closed** (old container stays live) and emits `recovery_stage=transient_exhausted` so the durable case is Sentry-distinguishable from a transient one. **[opt-out artifact: this class is tracked and remediated on #6415/#6400/#6565 — L3 firewall/NIC verification is their scope, not this code change's; retrying a down NIC cannot succeed by construction.]**
+
+**Absence-of-signal note:** if post-deploy Sentry shows `image-pull-recovery / recovery_stage=transient_recovered` events on `hetzner-150638239`, the transient class was real and is now absorbed; if it shows only `image pull failed / recovery_stage=transient_exhausted`, the occurrence was durable host-degradation (route to #6415/#6565), confirming the two-class split rather than a fix regression.
+
+## Implementation Phases
+
+> TDD: write the failing tests first (`cq-write-failing-tests-before`), then the source. Test path: `apps/web-platform/infra/ci-deploy.test.sh` (run offline via `bash apps/web-platform/infra/ci-deploy.test.sh`; CI runs it in `infra-validation.yml` `deploy-script-tests`, which fires on `apps/*/infra/**`).
+
+### Phase 1 — RED: transient-classifier + transient-retry tests
+
+Add to `ci-deploy.test.sh`:
+
+1. **Classifier positive/negative fixtures for `_pull_result_is_transient`** — source the script and assert the predicate returns 0 for each fleet-real transient string (reuse `:3555-3600` verbatim): `network is unreachable`, `read: connection reset by peer`, `: EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`. Assert it returns non-zero for an **auth** string (`denied: requested access to the resource is denied`) and a **manifest** string (`manifest unknown`) — the predicate must NOT swallow the higher-precedence classes.
+2. **`pull_failure_event` still tags `network`** for a transient stderr after the refactor (proves the extracted predicate is wired into the classifier arm; grouping tag value unchanged).
+3. **Transient retry recovers** — new mock arm `MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE` (countdown emitting a transient stderr, then succeed). With count=1 and `PULL_TRANSIENT_RETRY_SLEEPS="0 0"`, assert: 2 GHCR pulls, a `transient_recovered` recovery event (`op:image-pull-recovery`), NO `pull_failure_event`, overall success.
+4. **Transient retry exhausts → fail-closed + tagged** — transient stderr on every pull, `PULL_TRANSIENT_RETRY_SLEEPS="0 0"`: assert 3 GHCR pulls (1 + 2 retries), `pull_failure_event` fired with `pull_result=network` and `recovery_stage=transient_exhausted`, overall failure (old container stays live), NO recovery event.
+5. **Non-transient, non-auth (manifest) → NO retry** — manifest stderr: assert exactly 1 GHCR pull, `pull_result=manifest_unknown`, empty `recovery_stage`, failure (regression guard: we did not widen retries to manifest-unknown).
+6. **Auth path unchanged** — re-assert #6400 AC1/AC2/AC14 semantics hold byte-for-byte (these existing tests must not be edited except where the shared mock arm is added; run the full file).
+7. **Single-source-of-truth wiring guard** — grep-assert `pull_failure_event`'s network arm calls `_pull_result_is_transient` (not a second inline regex), mirroring the existing `_pull_result_is_auth_denied` shared-predicate guard at `:3423-3427`.
+
+### Phase 2 — GREEN: source changes in `ci-deploy.sh`
+
+1. **Add `_pull_result_is_transient`** beside `_pull_result_is_auth_denied` (`~:533`), same single-source-of-truth doc comment. Regex (case-insensitive, docker-stderr substrings, non-overlapping with auth/manifest):
+   `timeout|timed out|i/o timeout|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|tls handshake timeout|\bEOF\b`
+2. **Rewire `pull_failure_event`'s `network` arm** (`:549`) to call `_pull_result_is_transient "$detail_raw"`. Keep precedence auth → manifest_unknown → transient → pull_failed and keep the emitted tag value `network` (Sentry grouping/alert keys unchanged).
+3. **Add the transient branch to `_ghcr_pull_or_recover`** (`:1376-1397`). Structure — a bounded loop whose auth branch `return`s from inside (never loops), preserving #6400:
+   - Declare the backoff schedule with a test-only override: `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )` (production `2 4`; tests set `"0 0"`). Mirrors the file's `SOLEUR_GHCR_READ_FILE` test-only-override precedent; `local max=${#_sleeps[@]}`, `attempt=0`.
+   - Loop: `docker pull … 200>&- 2>"$perr"` → on success, if `attempt>0` emit `pull_auth_recovery_event "${IMAGE}:${TAG}" transient_recovered` then `return 0`.
+   - On failure classify `detail="$(tail -c 400 "$perr")"`:
+     - `_pull_result_is_auth_denied` → **existing #6400 recovery, verbatim** (refetch+relogin+single retry, sets `RECOVERY_STAGE`), then `return 1` — auth never enters the transient loop.
+     - `_pull_result_is_transient` && `attempt < max` → `sleep "${_sleeps[$attempt]}"`; `attempt=$((attempt+1))`; continue.
+     - else (transient exhausted OR manifest/unknown) → if `attempt>0` set `RECOVERY_STAGE="transient_exhausted"`; `return 1`.
+4. **Comment** the one-level-retry decision (zot stays immediate-fallback = a different-registry retry; the caller does not retry) and the ≤6 s added-wall-clock bound.
+
+### Phase 3 — Verify budget + delivery guards
+
+1. Run `bash apps/web-platform/infra/ci-deploy.test.sh` — full suite green (including the #5145 drift guard at `:2890-2972` — it must stay green; the pull sleeps are upstream of the verify loop and are not health/cron attempts, so they do not enter `DG_RIGHT`).
+2. `shellcheck apps/web-platform/infra/ci-deploy.sh` (if wired in CI) — no new findings.
+3. Confirm the added worst-case wall-clock: `2` retries × `[2 s, 4 s]` = **≤6 s per GHCR leg**, ≤12 s across the web + inngest pulls — negligible vs the deploy budget; state it in the PR body.
+
+## Delivery
+
+`ci-deploy.sh` is pushed to the host solely by `terraform_data.deploy_pipeline_fix` (`server.tf:933-942`, whose `triggers_replace` hashes `ci-deploy.sh`). The dedicated workflow **`apply-deploy-pipeline-fix.yml`** auto-applies on `push` to `main` touching `apps/web-platform/infra/ci-deploy.sh` (path filter `:66`) and `-target`s that resource over the CF-Tunnel SSH bridge. **So merging this PR delivers the fix to the host automatically — no operator SSH, no manual `terraform apply`** (satisfies the automation-feasibility gate and `hr-all-infrastructure-provisioning-servers`). The change takes effect on the FIRST deploy after the apply completes.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- [ ] `_pull_result_is_transient` exists beside `_pull_result_is_auth_denied` and matches all fixtures at `ci-deploy.test.sh:3555-3600`; returns non-zero for auth + manifest strings (test: classifier positive/negative).
+- [ ] `pull_failure_event`'s network arm calls `_pull_result_is_transient` (grep guard) — single source of truth, no second inline regex.
+- [ ] Transient failure retries with bounded backoff: count=1 mock recovers (2 pulls, `transient_recovered` event, no failure event); exhaust mock fails after exactly 3 pulls with `pull_result=network` + `recovery_stage=transient_exhausted`.
+- [ ] Manifest/unknown stderr gets exactly 1 pull (no retry); regression guard green.
+- [ ] #6400 AC1/AC2/AC14 (auth recovery) pass unchanged; `pull_image_with_fallback` still returns 1 only when BOTH registries fail (fail-closed).
+- [ ] Full `bash apps/web-platform/infra/ci-deploy.test.sh` green, including the #5145 drift guard.
+- [ ] Added wall-clock ≤6 s/leg documented in the PR body.
+- [ ] PR body uses `Ref #6525` (NOT `Closes`) — see below.
+
+### Post-merge (automatic — no operator action)
+- [ ] `apply-deploy-pipeline-fix.yml` runs on merge and applies `terraform_data.deploy_pipeline_fix` (the fix reaches the host). Verify via the workflow run conclusion (Automation: `gh run list --workflow=apply-deploy-pipeline-fix.yml`).
+- [ ] Issue closure is soak-gated, not merge-gated (the fix only exercises on real deploys). Close #6525 only after observability confirms the transient class is absorbed (see `## Observability` soak) — hence `Ref`, not `Closes`.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: registry_pull_event (zot|ghcr-fallback) fires on every successful deploy pull
+  cadence: per deploy (6-12/day)
+  alert_target: Sentry op:image-pull / zot_mirror_fallback_rate alert (issue-alerts.tf) — unchanged
+  configured_in: apps/web-platform/infra/ci-deploy.sh registry_pull_event + infra/sentry/issue-alerts.tf
+error_reporting:
+  destination: Sentry (pull_failure_event, op:image-pull, level:error, host_id + recovery_stage tags) + journald IMAGE_PULL_FAIL (Better Stack via vector, SYSLOG_IDENTIFIER=ci-deploy)
+  fail_loud: yes — terminal both-registries failure emits pull_failure_event before final_write_state 1 image_pull_failed
+failure_modes:
+  - mode: transient GHCR pull failure absorbed by retry
+    detection: pull_auth_recovery_event op:image-pull-recovery, recovery_stage=transient_recovered, host_id-tagged (in-band: emitted from the deploy host itself, no SSH)
+    alert_route: Sentry op:image-pull-recovery (info) — sustained volume = chronically flaky pull path signal (per 2026-07-15 learning)
+  - mode: transient failure exhausts the bounded retry (durable/degraded host)
+    detection: pull_failure_event pull_result=network, recovery_stage=transient_exhausted
+    alert_route: Sentry op:image-pull (error) — recovery_stage discriminates transient-exhausted (this class) from durable host-degradation triage (#6415/#6565)
+  - mode: auth/manifest failure (unchanged)
+    detection: pull_failure_event pull_result=auth_denied|manifest_unknown, recovery_stage per #6400
+    alert_route: Sentry op:image-pull (error)
+logs:
+  where: journald tag ci-deploy → Better Stack (vector.toml allowlist); Sentry store endpoint
+  retention: Better Stack + Sentry defaults (unchanged)
+discoverability_test:
+  command: "gh run list --workflow=apply-deploy-pipeline-fix.yml --limit 3  # then query Sentry issues op:image-pull-recovery recovery_stage=transient_recovered on hetzner-150638239 — NO ssh"
+  expected_output: "post-fix, a transient blip on hetzner-150638239 yields a transient_recovered recovery event (absorbed) instead of an image_pull_failed deploy abort; a durable host still yields recovery_stage=transient_exhausted (routes to #6415/#6565)"
+```
+
+**Soak (issue-close gate):** keep #6525 open until either (a) a post-fix deploy on `hetzner-150638239` emits `transient_recovered` (the transient class is provably absorbed), or (b) ≥7 days of releases pass with no first-attempt `image_pull_failed` of the transient class. This is a lightweight observability check, not a scripted follow-through enrollment — no new `scripts/followthroughs/` probe is warranted for a single-issue close gate (the signal is already in Sentry).
+
+## Out of Scope
+
+- **#6565 (zot/GHCR login failure, cred_store classifier / errno_chars).** Diagnosable, not part of this fix — recovering the host means the `cred_store` classifier + `errno_chars` field run there and pin the exact errno on the next occurrence. No change here.
+- **Durable host-degradation occurrences of #6525** (v0.217.0 class: private-NIC/IMDS first-boot, inngest/vector inactive) — owned by #6400 / #6415 (`soleur-private-nic-guard.sh`) / #6497. The bounded retry correctly fails-closed for these; it does not repair a wedged host.
+- **Wrapping each `docker pull` in an outer `timeout N`** to bound per-attempt latency — a separate hardening (docker has its own client timeouts); the fixed backoff array already bounds ADDED wall-clock regardless. Considered; deferred (no tracking issue — low value, docker-client timeouts already apply).
+- **In-place zot-leg retry** — deliberately not added: a zot failure already falls back to GHCR (a different-registry retry), and retrying both legs would violate the one-level-retry rule (multiplicative attempts).
+
+## Alternatives Considered
+
+| Alternative | Decision |
+|---|---|
+| Wall-clock ceiling (`date +%s` epoch math) instead of a fixed backoff array | **Rejected.** The 2026-06-30 learning targets loops whose per-iteration latency is unbounded (chained API calls). Here each attempt is one `docker pull` and the backoff is a fixed 2-element array — added wall-clock is deterministically ≤6 s. Epoch math adds complexity for no bound benefit. |
+| Reuse the file's `until … sleep 5 … n≥3` idiom verbatim | **Rejected** for the sleep interval (5 s×2 = 10 s is heavier than needed and hardcoded blocks fast tests). Kept the 3-attempt cap idiom; used an explicit `[2 4]` schedule with a test-only override seam (`SOLEUR_GHCR_READ_FILE` precedent). |
+| Add retry in `pull_image_with_fallback` (caller) instead of `_ghcr_pull_or_recover` | **Rejected** — one-level-retry rule (2026-06-30); the caller cannot set `RECOVERY_STAGE` cleanly and would multiply attempts against the auth retry. |
+| A second inline `network` regex in the recovery gate | **Rejected** — regex drift (the exact hazard the file documents for `_pull_result_is_auth_denied`). Extract one shared `_pull_result_is_transient`. |
+| Broaden `_pull_result_is_transient` to also retry `manifest_unknown` | **Rejected** — a missing manifest is not transient; retrying wastes the deploy window. Regression-guarded (Phase 1 test 5). |
+
+## Domain Review
+
+**Domains relevant:** none
+
+Infrastructure/CI bug fix on an already-provisioned script (`apps/web-platform/infra/ci-deploy.sh` + its test). No user-facing surface (no `components/**`, `app/**/page.tsx`, `app/**/layout.tsx` — mechanical UI-surface override does not fire), no regulated-data surface (GDPR gate 2.7 skipped), no new infrastructure/secret/vendor (IaC gate 2.8 skipped — edits an existing hashed-trigger script, delivered by the existing `apply-deploy-pipeline-fix.yml`), no architectural-decision change (ADR gate 2.10 skipped — the ADR-096 zot-primary/GHCR-fallback topology and the both-registries fail-closed contract are UNCHANGED; a bounded retry-classifier widening on an existing leg is a refinement, not a new boundary — a competent engineer reading ADR-096 would not be misled).
+
+## Sharp Edges
+
+- The `## User-Brand Impact` section is populated (threshold `aggregate pattern`); do not blank it — an empty/`TBD` section fails `deepen-plan` Phase 4.6 and preflight Check 6.
+- The auth branch in `_ghcr_pull_or_recover` MUST `return` from inside the loop (never `continue`), or a `MOCK_GHCR_PULL_DENY_ALWAYS` auth failure would loop and burn the window — breaking #6400 AC2/AC14. Keep the transient loop strictly for the transient class.
+- `_pull_result_is_transient` regex must stay non-overlapping with `_pull_result_is_auth_denied` (`unauthorized|denied|forbidden|authentication required`) and the manifest arm (`manifest unknown|not found|no such manifest`). Note `no such host` (transient) vs `no such manifest` (manifest) share `no such` — anchor on the full token (`no such host`), and keep classifier precedence auth → manifest → transient in `pull_failure_event`.
+- Do NOT rename the `pull_result` tag value `network` — Sentry grouping and the `zot_mirror_fallback_rate` alert key on it. The new predicate is the source of the SAME tag value.
+- Use `Ref #6525` in the PR body, not `Closes` — the fix only exercises on real deploys; auto-closing at merge before the soak confirms absorption would false-resolve it (`wg-use-closes-n-in-pr-body-not-title-to` / ops-remediation Closes-vs-Ref pattern).

--- a/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/session-state.md
@@ -1,0 +1,19 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-17-fix-image-pull-transient-retry-plan.md
+- Status: complete
+
+### Errors
+None. CWD verified on first call; #6525 confirmed OPEN; all deepen-plan hard gates (network, user-brand, observability, PAT, UI) passed; no broken KB citations. One correction: initial plan Write blocked by worktrees-exist guard — re-issued to correct worktree path.
+
+### Decisions
+- Fix shape: shared `_pull_result_is_transient` classifier (single source of truth, wired into `pull_failure_event`'s `network` arm to avoid regex drift) + bounded `[2s,4s]` transient-retry loop inside `_ghcr_pull_or_recover` only. #6400 auth-recovery branch and both-registries fail-closed semantics stay byte-identical. Retry at ONE level (not caller).
+- Scope honesty: does NOT claim to "fix #6525" wholesale — durable host-degradation (private-NIC/IMDS, #6415/#6565) correctly exhausts-and-fails-closed; `transient_recovered` vs `transient_exhausted` telemetry is the transient-vs-durable discriminator.
+- Delivery automatic: `apply-deploy-pipeline-fix.yml` auto-applies `ci-deploy.sh` edits on merge — no operator SSH.
+- Deepen corrections folded: GAP-7 (`transient_exhausted` only at attempt==max), M1 (disjoint labels), widened docker-stderr regex, ≤6s window justification, L1 reclassification-safety AC.
+- Threshold: aggregate pattern (deploy-reliability blast radius; no per-PR CPO sign-off).
+
+### Components Invoked
+- Skills: soleur:plan, soleur:deepen-plan
+- Agents: learnings-researcher, repo-research-analyst, best-practices-researcher, architecture-strategist, code-simplicity-reviewer, pattern-recognition-specialist, 2x general-purpose

--- a/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/tasks.md
@@ -5,29 +5,29 @@ Lane: single-domain (engineering / infra) — no spec.md preexisted; lane set fr
 
 ## Phase 1 — RED (write failing tests first) — `apps/web-platform/infra/ci-deploy.test.sh`
 
-- [ ] 1.1 Add `_pull_result_is_transient` classifier positive tests: assert return 0 for each fleet-real transient stderr from `ci-deploy.test.sh:3555-3600` (`network is unreachable`, `read: connection reset by peer`, `EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`) PLUS deepen-research additions (`context deadline exceeded`, `received unexpected HTTP status: 503`, `request canceled while waiting for connection`, `server misbehaving`).
-- [ ] 1.2 Add classifier negative tests: assert non-zero for an auth string (`denied: requested access to the resource is denied`) and manifest strings (`manifest unknown`, `no such manifest` — note `no such` shared prefix with transient `no such host`) — must not swallow higher-precedence classes.
-- [ ] 1.3 Assert `pull_failure_event` still tags `pull_result=network` for a transient stderr after the refactor (grouping value unchanged).
-- [ ] 1.4 Add a transient mock arm (`MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE` countdown emitting a network-class stderr) next to the `:340-362` deny machinery.
-- [ ] 1.5 Test — transient retry RECOVERS: count=1 + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ 2 GHCR pulls, `transient_recovered` event (`op:image-pull-recovery`), NO `pull_failure_event`, success.
-- [ ] 1.6 Test — transient retry EXHAUSTS: transient every pull + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ exactly 3 GHCR pulls, `pull_failure_event` with `pull_result=network` + `recovery_stage=transient_exhausted`, failure, NO recovery event.
-- [ ] 1.7 Test — manifest/unknown stderr ⇒ exactly 1 GHCR pull (no retry), `pull_result=manifest_unknown`, empty `recovery_stage` (regression guard).
-- [ ] 1.8 Test (deepen GAP-7) — mixed transient→manifest tail: transient once then manifest stderr ⇒ 2 GHCR pulls, `pull_result=manifest_unknown`, `recovery_stage` EMPTY (NOT `transient_exhausted`).
-- [ ] 1.9 Grep guard — `pull_failure_event` network arm calls `_pull_result_is_transient` (single source of truth), mirroring `:3423-3427`.
-- [ ] 1.10 Confirm #6400 AC1/AC2/AC14 + AC4 remain (do not edit except to add the shared mock arm); auth-`recovered` vs transient-`recovered` labels stay disjoint.
+- [x] 1.1 Add `_pull_result_is_transient` classifier positive tests: assert return 0 for each fleet-real transient stderr from `ci-deploy.test.sh:3555-3600` (`network is unreachable`, `read: connection reset by peer`, `EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`) PLUS deepen-research additions (`context deadline exceeded`, `received unexpected HTTP status: 503`, `request canceled while waiting for connection`, `server misbehaving`).
+- [x] 1.2 Add classifier negative tests: assert non-zero for an auth string (`denied: requested access to the resource is denied`) and manifest strings (`manifest unknown`, `no such manifest` — note `no such` shared prefix with transient `no such host`) — must not swallow higher-precedence classes.
+- [x] 1.3 Assert `pull_failure_event` still tags `pull_result=network` for a transient stderr after the refactor (grouping value unchanged).
+- [x] 1.4 Add a transient mock arm (`MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE` countdown emitting a network-class stderr) next to the `:340-362` deny machinery.
+- [x] 1.5 Test — transient retry RECOVERS: count=1 + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ 2 GHCR pulls, `transient_recovered` event (`op:image-pull-recovery`), NO `pull_failure_event`, success.
+- [x] 1.6 Test — transient retry EXHAUSTS: transient every pull + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ exactly 3 GHCR pulls, `pull_failure_event` with `pull_result=network` + `recovery_stage=transient_exhausted`, failure, NO recovery event.
+- [x] 1.7 Test — manifest/unknown stderr ⇒ exactly 1 GHCR pull (no retry), `pull_result=manifest_unknown`, empty `recovery_stage` (regression guard).
+- [x] 1.8 Test (deepen GAP-7) — mixed transient→manifest tail: transient once then manifest stderr ⇒ 2 GHCR pulls, `pull_result=manifest_unknown`, `recovery_stage` EMPTY (NOT `transient_exhausted`).
+- [x] 1.9 Grep guard — `pull_failure_event` network arm calls `_pull_result_is_transient` (single source of truth), mirroring `:3423-3427`.
+- [x] 1.10 Confirm #6400 AC1/AC2/AC14 + AC4 remain (do not edit except to add the shared mock arm); auth-`recovered` vs transient-`recovered` labels stay disjoint.
 
 ## Phase 2 — GREEN (source) — `apps/web-platform/infra/ci-deploy.sh`
 
-- [ ] 2.1 Add `_pull_result_is_transient` beside `_pull_result_is_auth_denied` (`~:533`) with the anti-drift doc comment. Regex (case-insensitive): `context deadline exceeded|timeout|timed out|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|server misbehaving|request canceled while waiting|received unexpected http status: 5|\bEOF\b` (verified non-overlapping with auth + manifest tokens).
-- [ ] 2.2 Rewire `pull_failure_event`'s network arm (`:549`) to call `_pull_result_is_transient`; keep precedence auth → manifest_unknown → transient → pull_failed; keep emitted tag value `network`. (Note: widens the `network` set — see 3.3.)
-- [ ] 2.3 In `_ghcr_pull_or_recover` (`:1376-1397`) add the bounded transient loop per the EXPLICIT skeleton in the plan (Phase 2.3): `# shellcheck disable=SC2206` + `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )`; loop `docker pull`; success with `attempt>0` emit `pull_auth_recovery_event … transient_recovered` + `return 0`; auth branch = #6400 recovery VERBATIM (its inner `pull_auth_recovery_event … recovered; return 0` stays inside) then `return 1`, NEVER loops; transient branch = `sleep "${_sleeps[$attempt]}"` + `attempt++` + continue while `attempt<max`; transient-exhausted arm (transient && attempt==max) sets `RECOVERY_STAGE=transient_exhausted` + `return 1`; else (manifest/unknown) `return 1` with EMPTY recovery_stage (no false exhausted tag — deepen GAP-7).
-- [ ] 2.4 Comment the one-level-retry decision (zot stays immediate-fallback; caller does not retry), the disjoint-label invariant (attempt increments only on transient arm), the gate-omits-manifest-arm rationale (deepen GAP-5b), and the ≤6 s added-wall-clock bound.
+- [x] 2.1 Add `_pull_result_is_transient` beside `_pull_result_is_auth_denied` (`~:533`) with the anti-drift doc comment. Regex (case-insensitive): `context deadline exceeded|timeout|timed out|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|server misbehaving|request canceled while waiting|received unexpected http status: 5|\bEOF\b` (verified non-overlapping with auth + manifest tokens).
+- [x] 2.2 Rewire `pull_failure_event`'s network arm (`:549`) to call `_pull_result_is_transient`; keep precedence auth → manifest_unknown → transient → pull_failed; keep emitted tag value `network`. (Note: widens the `network` set — see 3.3.)
+- [x] 2.3 In `_ghcr_pull_or_recover` (`:1376-1397`) add the bounded transient loop per the EXPLICIT skeleton in the plan (Phase 2.3): `# shellcheck disable=SC2206` + `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )`; loop `docker pull`; success with `attempt>0` emit `pull_auth_recovery_event … transient_recovered` + `return 0`; auth branch = #6400 recovery VERBATIM (its inner `pull_auth_recovery_event … recovered; return 0` stays inside) then `return 1`, NEVER loops; transient branch = `sleep "${_sleeps[$attempt]}"` + `attempt++` + continue while `attempt<max`; transient-exhausted arm (transient && attempt==max) sets `RECOVERY_STAGE=transient_exhausted` + `return 1`; else (manifest/unknown) `return 1` with EMPTY recovery_stage (no false exhausted tag — deepen GAP-7).
+- [x] 2.4 Comment the one-level-retry decision (zot stays immediate-fallback; caller does not retry), the disjoint-label invariant (attempt increments only on transient arm), the gate-omits-manifest-arm rationale (deepen GAP-5b), and the ≤6 s added-wall-clock bound.
 
 ## Phase 3 — Verify
 
-- [ ] 3.1 `bash apps/web-platform/infra/ci-deploy.test.sh` fully green (incl. #5145 drift guard `:2890-2972`).
-- [ ] 3.2 `shellcheck apps/web-platform/infra/ci-deploy.sh` — no new findings (inline `# shellcheck disable=SC2206` on the array line).
-- [ ] 3.3 Reclassification safety (deepen L1): grep `infra/sentry/` + soak scripts (`zot-soak-6122.sh`, `*op-contract*`) for `pull_result` — confirm no alert/soak keys on `pull_result=pull_failed` or the narrow pre-widening `network` set.
+- [x] 3.1 `bash apps/web-platform/infra/ci-deploy.test.sh` fully green (incl. #5145 drift guard `:2890-2972`).
+- [x] 3.2 `shellcheck apps/web-platform/infra/ci-deploy.sh` — no new findings (inline `# shellcheck disable=SC2206` on the array line).
+- [x] 3.3 Reclassification safety (deepen L1): grep `infra/sentry/` + soak scripts (`zot-soak-6122.sh`, `*op-contract*`) for `pull_result` — confirm no alert/soak keys on `pull_result=pull_failed` or the narrow pre-widening `network` set.
 - [ ] 3.4 Document worst-case added wall-clock (≤6 s/leg, ≤12 s total) in the PR body.
 
 ## Ship

--- a/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/tasks.md
@@ -1,0 +1,34 @@
+# Tasks — fix: image-pull transient retry (#6525)
+
+Plan: `knowledge-base/project/plans/2026-07-17-fix-image-pull-transient-retry-plan.md`
+Lane: single-domain (engineering / infra) — no spec.md preexisted; lane set from work scope.
+
+## Phase 1 — RED (write failing tests first) — `apps/web-platform/infra/ci-deploy.test.sh`
+
+- [ ] 1.1 Add `_pull_result_is_transient` classifier positive tests: assert return 0 for each fleet-real transient stderr reused verbatim from `ci-deploy.test.sh:3555-3600` (`network is unreachable`, `read: connection reset by peer`, `EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`).
+- [ ] 1.2 Add classifier negative tests: assert non-zero for an auth string (`denied: requested access to the resource is denied`) and a manifest string (`manifest unknown`) — must not swallow higher-precedence classes.
+- [ ] 1.3 Assert `pull_failure_event` still tags `pull_result=network` for a transient stderr after the refactor (grouping value unchanged).
+- [ ] 1.4 Add a transient mock arm (`MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE` countdown emitting a network-class stderr) next to the `:340-362` deny machinery.
+- [ ] 1.5 Test — transient retry RECOVERS: count=1 + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ 2 GHCR pulls, `transient_recovered` event (`op:image-pull-recovery`), NO `pull_failure_event`, success.
+- [ ] 1.6 Test — transient retry EXHAUSTS: transient every pull + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ exactly 3 GHCR pulls, `pull_failure_event` with `pull_result=network` + `recovery_stage=transient_exhausted`, failure, NO recovery event.
+- [ ] 1.7 Test — manifest/unknown stderr ⇒ exactly 1 GHCR pull (no retry), `pull_result=manifest_unknown`, empty `recovery_stage` (regression guard).
+- [ ] 1.8 Grep guard — `pull_failure_event` network arm calls `_pull_result_is_transient` (single source of truth), mirroring `:3423-3427`.
+- [ ] 1.9 Confirm #6400 AC1/AC2/AC14 + AC4 remain (do not edit except to add the shared mock arm).
+
+## Phase 2 — GREEN (source) — `apps/web-platform/infra/ci-deploy.sh`
+
+- [ ] 2.1 Add `_pull_result_is_transient` beside `_pull_result_is_auth_denied` (`~:533`) with the anti-drift doc comment. Regex: `timeout|timed out|i/o timeout|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|tls handshake timeout|\bEOF\b` (case-insensitive).
+- [ ] 2.2 Rewire `pull_failure_event`'s network arm (`:549`) to call `_pull_result_is_transient`; keep precedence auth → manifest_unknown → transient → pull_failed; keep emitted tag value `network`.
+- [ ] 2.3 In `_ghcr_pull_or_recover` (`:1376-1397`) add the bounded transient loop: `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )`; loop `docker pull`; on success with `attempt>0` emit `pull_auth_recovery_event … transient_recovered`; auth branch = existing #6400 recovery verbatim and `return` from inside (never loop); transient branch = `sleep "${_sleeps[$attempt]}"` + `attempt++` + continue while `attempt<max`; else set `RECOVERY_STAGE=transient_exhausted` (when `attempt>0`) and `return 1`.
+- [ ] 2.4 Comment the one-level-retry decision (zot stays immediate-fallback; caller does not retry) and the ≤6 s added-wall-clock bound.
+
+## Phase 3 — Verify
+
+- [ ] 3.1 `bash apps/web-platform/infra/ci-deploy.test.sh` fully green (incl. #5145 drift guard `:2890-2972`).
+- [ ] 3.2 `shellcheck apps/web-platform/infra/ci-deploy.sh` — no new findings (if wired).
+- [ ] 3.3 Document worst-case added wall-clock (≤6 s/leg, ≤12 s total) in the PR body.
+
+## Ship
+
+- [ ] S.1 PR body uses `Ref #6525` (not `Closes`) — soak-gated close.
+- [ ] S.2 Note automatic delivery via `apply-deploy-pipeline-fix.yml` on merge (no operator SSH).

--- a/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6525-image-pull-transient-retry/tasks.md
@@ -5,28 +5,30 @@ Lane: single-domain (engineering / infra) — no spec.md preexisted; lane set fr
 
 ## Phase 1 — RED (write failing tests first) — `apps/web-platform/infra/ci-deploy.test.sh`
 
-- [ ] 1.1 Add `_pull_result_is_transient` classifier positive tests: assert return 0 for each fleet-real transient stderr reused verbatim from `ci-deploy.test.sh:3555-3600` (`network is unreachable`, `read: connection reset by peer`, `EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`).
-- [ ] 1.2 Add classifier negative tests: assert non-zero for an auth string (`denied: requested access to the resource is denied`) and a manifest string (`manifest unknown`) — must not swallow higher-precedence classes.
+- [ ] 1.1 Add `_pull_result_is_transient` classifier positive tests: assert return 0 for each fleet-real transient stderr from `ci-deploy.test.sh:3555-3600` (`network is unreachable`, `read: connection reset by peer`, `EOF`, `no such host`, `connection refused`, `i/o timeout`, `TLS handshake timeout`, `temporary failure`) PLUS deepen-research additions (`context deadline exceeded`, `received unexpected HTTP status: 503`, `request canceled while waiting for connection`, `server misbehaving`).
+- [ ] 1.2 Add classifier negative tests: assert non-zero for an auth string (`denied: requested access to the resource is denied`) and manifest strings (`manifest unknown`, `no such manifest` — note `no such` shared prefix with transient `no such host`) — must not swallow higher-precedence classes.
 - [ ] 1.3 Assert `pull_failure_event` still tags `pull_result=network` for a transient stderr after the refactor (grouping value unchanged).
 - [ ] 1.4 Add a transient mock arm (`MOCK_GHCR_PULL_TRANSIENT_COUNT_FILE` countdown emitting a network-class stderr) next to the `:340-362` deny machinery.
 - [ ] 1.5 Test — transient retry RECOVERS: count=1 + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ 2 GHCR pulls, `transient_recovered` event (`op:image-pull-recovery`), NO `pull_failure_event`, success.
 - [ ] 1.6 Test — transient retry EXHAUSTS: transient every pull + `PULL_TRANSIENT_RETRY_SLEEPS="0 0"` ⇒ exactly 3 GHCR pulls, `pull_failure_event` with `pull_result=network` + `recovery_stage=transient_exhausted`, failure, NO recovery event.
 - [ ] 1.7 Test — manifest/unknown stderr ⇒ exactly 1 GHCR pull (no retry), `pull_result=manifest_unknown`, empty `recovery_stage` (regression guard).
-- [ ] 1.8 Grep guard — `pull_failure_event` network arm calls `_pull_result_is_transient` (single source of truth), mirroring `:3423-3427`.
-- [ ] 1.9 Confirm #6400 AC1/AC2/AC14 + AC4 remain (do not edit except to add the shared mock arm).
+- [ ] 1.8 Test (deepen GAP-7) — mixed transient→manifest tail: transient once then manifest stderr ⇒ 2 GHCR pulls, `pull_result=manifest_unknown`, `recovery_stage` EMPTY (NOT `transient_exhausted`).
+- [ ] 1.9 Grep guard — `pull_failure_event` network arm calls `_pull_result_is_transient` (single source of truth), mirroring `:3423-3427`.
+- [ ] 1.10 Confirm #6400 AC1/AC2/AC14 + AC4 remain (do not edit except to add the shared mock arm); auth-`recovered` vs transient-`recovered` labels stay disjoint.
 
 ## Phase 2 — GREEN (source) — `apps/web-platform/infra/ci-deploy.sh`
 
-- [ ] 2.1 Add `_pull_result_is_transient` beside `_pull_result_is_auth_denied` (`~:533`) with the anti-drift doc comment. Regex: `timeout|timed out|i/o timeout|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|tls handshake timeout|\bEOF\b` (case-insensitive).
-- [ ] 2.2 Rewire `pull_failure_event`'s network arm (`:549`) to call `_pull_result_is_transient`; keep precedence auth → manifest_unknown → transient → pull_failed; keep emitted tag value `network`.
-- [ ] 2.3 In `_ghcr_pull_or_recover` (`:1376-1397`) add the bounded transient loop: `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )`; loop `docker pull`; on success with `attempt>0` emit `pull_auth_recovery_event … transient_recovered`; auth branch = existing #6400 recovery verbatim and `return` from inside (never loop); transient branch = `sleep "${_sleeps[$attempt]}"` + `attempt++` + continue while `attempt<max`; else set `RECOVERY_STAGE=transient_exhausted` (when `attempt>0`) and `return 1`.
-- [ ] 2.4 Comment the one-level-retry decision (zot stays immediate-fallback; caller does not retry) and the ≤6 s added-wall-clock bound.
+- [ ] 2.1 Add `_pull_result_is_transient` beside `_pull_result_is_auth_denied` (`~:533`) with the anti-drift doc comment. Regex (case-insensitive): `context deadline exceeded|timeout|timed out|temporary failure|no route|connection refused|connection reset|network is unreachable|no such host|server misbehaving|request canceled while waiting|received unexpected http status: 5|\bEOF\b` (verified non-overlapping with auth + manifest tokens).
+- [ ] 2.2 Rewire `pull_failure_event`'s network arm (`:549`) to call `_pull_result_is_transient`; keep precedence auth → manifest_unknown → transient → pull_failed; keep emitted tag value `network`. (Note: widens the `network` set — see 3.3.)
+- [ ] 2.3 In `_ghcr_pull_or_recover` (`:1376-1397`) add the bounded transient loop per the EXPLICIT skeleton in the plan (Phase 2.3): `# shellcheck disable=SC2206` + `local -a _sleeps=( ${PULL_TRANSIENT_RETRY_SLEEPS:-2 4} )`; loop `docker pull`; success with `attempt>0` emit `pull_auth_recovery_event … transient_recovered` + `return 0`; auth branch = #6400 recovery VERBATIM (its inner `pull_auth_recovery_event … recovered; return 0` stays inside) then `return 1`, NEVER loops; transient branch = `sleep "${_sleeps[$attempt]}"` + `attempt++` + continue while `attempt<max`; transient-exhausted arm (transient && attempt==max) sets `RECOVERY_STAGE=transient_exhausted` + `return 1`; else (manifest/unknown) `return 1` with EMPTY recovery_stage (no false exhausted tag — deepen GAP-7).
+- [ ] 2.4 Comment the one-level-retry decision (zot stays immediate-fallback; caller does not retry), the disjoint-label invariant (attempt increments only on transient arm), the gate-omits-manifest-arm rationale (deepen GAP-5b), and the ≤6 s added-wall-clock bound.
 
 ## Phase 3 — Verify
 
 - [ ] 3.1 `bash apps/web-platform/infra/ci-deploy.test.sh` fully green (incl. #5145 drift guard `:2890-2972`).
-- [ ] 3.2 `shellcheck apps/web-platform/infra/ci-deploy.sh` — no new findings (if wired).
-- [ ] 3.3 Document worst-case added wall-clock (≤6 s/leg, ≤12 s total) in the PR body.
+- [ ] 3.2 `shellcheck apps/web-platform/infra/ci-deploy.sh` — no new findings (inline `# shellcheck disable=SC2206` on the array line).
+- [ ] 3.3 Reclassification safety (deepen L1): grep `infra/sentry/` + soak scripts (`zot-soak-6122.sh`, `*op-contract*`) for `pull_result` — confirm no alert/soak keys on `pull_result=pull_failed` or the narrow pre-widening `network` set.
+- [ ] 3.4 Document worst-case added wall-clock (≤6 s/leg, ≤12 s total) in the PR body.
 
 ## Ship
 


### PR DESCRIPTION
## Summary
- `_ghcr_pull_or_recover` (`apps/web-platform/infra/ci-deploy.sh`) retried a failed GHCR pull **only** when the stderr was auth-classified (`_pull_result_is_auth_denied`). A transient/network first-attempt failure (timeout, connection reset, EOF, no-such-host, registry 5xx) fell straight to `return 1` with **zero** retries. Since `pull_image_with_fallback` returns failure only when **both** registries fail, the deploy fast-failed and a human `gh run rerun` — hitting a warmer path minutes later — succeeded. That is exactly the observed v0.216.1 / v0.216.2 "first attempt fails, rerun succeeds" shape.
- Adds a shared `_pull_result_is_transient` predicate beside `_pull_result_is_auth_denied` (single source of truth — `pull_failure_event`'s `network` arm and the recovery gate both call it) and a bounded, capped backoff loop inside `_ghcr_pull_or_recover` (`PULL_TRANSIENT_RETRY_SLEEPS`, default `2 4` = 2 retries, ≤6 s added wall-clock per GHCR leg). The #6400 auth-recovery branch and the both-registries fail-closed (downtime-safe) semantics stay **byte-identical**.
- Emits `recovery_stage=transient_recovered` on an absorbed blip and `transient_exhausted` on a fail-closed exhaustion — the Sentry transient-vs-durable discriminator (routes durable host-degradation to #6415 / #6565).

Ref #6525

## User-Brand Impact
- **Artifact exposed if this change misbehaves:** none new. Docker stderr is scrubbed to a coarse class before any Sentry/journald payload; the new `transient_recovered` breadcrumb carries only `ref` + `stage` + `host_id` via `jq -n --arg` (no raw stderr), reusing the audited `pull_auth_recovery_event` transport.
- **Exposure vector:** none new — the retry adds no data to any telemetry surface.
- **Brand-survival threshold:** aggregate pattern — a regression in the shared pull path degrades deploy reliability across all releases (aggregate), not a single-user data event. Worst case if the loop logic errs: the existing fail-closed path keeps the prior container serving production, so no new user-facing disruption is introduced.

## Scope discipline
- Absorbs the **transient** first-attempt failure class only. Durable host-degradation occurrences (private-NIC / IMDS first-boot, tracked on #6415 / #6565 / #6400) correctly **exhaust and fail-closed** — the prior container stays live — and emit `transient_exhausted` so the two classes stay Sentry-distinguishable. This does not repair a wedged host.

## Changelog
### Web Platform (infra)
- Widen the GHCR pull-recovery gate to retry transient/network failures (not just auth-denied) with a bounded ≤6 s/leg backoff; add `transient_recovered` / `transient_exhausted` Sentry discriminators. Auth recovery (#6400) and both-registries fail-closed semantics unchanged.

## Test plan
- [x] `bash apps/web-platform/infra/ci-deploy.test.sh` green (176/176; +9 new `#6525` groups; #6400 auth AC1/AC2/AC14/AC4 byte-identical)
- [x] `bash scripts/test-all.sh` green (189/189 suites)
- [x] `shellcheck apps/web-platform/infra/ci-deploy.sh` — no new findings (intentional `# shellcheck disable=SC2206` on the backoff array)
- [x] Multi-agent review (security / architecture / test-design / pattern / observability / code-quality); all findings fixed inline (`review:` commit)
- [x] `T-6525-8` mutation-proven to fail under the empty-default (zero-retry) regression; `T-6525-9` locks the empty-disables contract

## Delivery
- `apply-deploy-pipeline-fix.yml` auto-applies the `ci-deploy.sh` change to the host on merge (targets `terraform_data.deploy_pipeline_fix`) — no SSH, no manual `terraform apply`. Kill switch: `[skip-deploy-fix-apply]` in a commit message.

## Issue closure (soak-gated)
- Uses `Ref #6525` rather than an auto-close keyword: the fix only exercises on real deploys, so #6525 stays open until observability confirms the transient class is absorbed — a post-fix `transient_recovered` on `hetzner-150638239`, or ~7 days of releases with no first-attempt transient-class `image_pull_failed`.

<!-- gate-override: soak-followthrough-enrollment --> The soak-gated close criterion for #6525 is already verifiable via the pre-existing, monitored Sentry `op:image-pull-recovery` (`transient_recovered`) and `op:image-pull` (`transient_exhausted`) surfaces; the plan evaluated and declined a dedicated `scripts/followthroughs/` probe for a single-issue close gate, since such a probe adds no observability over the existing alert. #6525 carries the soak criterion in its body and is closed once the Sentry signal confirms absorption.

Generated with [Claude Code](https://claude.com/claude-code)
