### PR TITLE
feat(infra): fail-loud soak probe for ci-deploy.sh Sentry POST failures (#6475 D-6)

### DIFF
--- a/knowledge-base/engineering/operations/runbooks/followthrough-convention.md
+++ b/knowledge-base/engineering/operations/runbooks/followthrough-convention.md
@@ -105,6 +105,10 @@ merge timestamp; its directive declares `secrets=GH_TOKEN`).
 - Issue body content reaches the sweeper via `awk` on stdin (no shell interpolation). Directive values are passed to the verification script as environment values and command-line args, never via shell-evaluated strings.
 - The sweeper uses `gh` CLI for issue close/comment, not raw token interpolation.
 
+## Sharp edges for Better Stack log-content probes
+
+- **Discriminate on the journald SYSLOG_IDENTIFIER FIELD, never a bare payload substring, and model fixtures on the REAL escaped JSONEachRow shape.** The Vector source is shared: inngest ships GitHub-webhook logs (SYSLOG_IDENTIFIER=doppler etc.) that embed branch names, issue/PR bodies, and quoted marker strings — so any marker a human types into GitHub appears in *another* producer's rows, and a bare-substring probe self-contaminates (the tracker's own body quotes the marker → false-FAIL → sweeper re-seeds it). Isolate the field in both byte-forms: server `--grep 'SYSLOG_IDENTIFIER":"<tag>'` (LIKE, unescaped column) + client `grep -F 'SYSLOG_IDENTIFIER\":\"<tag>\"'` (escaped stdout). Fixtures must reproduce the escaped JSON `raw`, not bare syslog. **Run the live discoverability query at /work, not post-merge** — it is the only check that surfaces the escaping and the contamination before merge. See `knowledge-base/project/learnings/2026-07-18-betterstack-followthrough-probe-must-field-isolate-syslog-identifier.md` (#6475).
+
 ## What the sweeper does NOT cover
 
 - **One-shot scheduling**: every sweep checks every open follow-through. If you want a script to run exactly once at a specific timestamp, that's a regular scheduled workflow, not a follow-through.

--- a/knowledge-base/project/learnings/2026-07-18-betterstack-followthrough-probe-must-field-isolate-syslog-identifier.md
+++ b/knowledge-base/project/learnings/2026-07-18-betterstack-followthrough-probe-must-field-isolate-syslog-identifier.md
@@ -1,0 +1,103 @@
+---
+title: A Better Stack log-content follow-through probe must isolate the journald SYSLOG_IDENTIFIER field, not a bare substring — the shared source is contaminated by inngest webhook logs
+date: 2026-07-18
+category: integration-issues
+module: scripts/followthroughs
+tags: [betterstack, followthrough, observability, false-positive, fixture-fidelity, ci-deploy]
+issue: 6475
+pr: 6652
+---
+
+## Problem
+
+`#6475` D-6 shipped a Better Stack **soak follow-through** probe
+(`scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh`) whose exit code
+**auto-closes the tracker**: exit 0 (PASS) → sweeper closes; exit 1 (FAIL) →
+alarm comment; exit 2 (TRANSIENT) → retry. To detect real ci-deploy "Sentry POST
+failed" journald lines, the first implementation queried
+`betterstack-query.sh --grep "Sentry POST failed"` and post-filtered the output
+with a **bare `grep 'ci-deploy'`** — mirroring the `chardevice` precedent's
+`denied_count()` shape and the plan's own design.
+
+Against **live prod** the probe **false-FAILed (exit 1)**. `betterstack-query.sh`'s
+`raw` column is the full journald JSON, and **inngest ships GitHub-webhook
+processing logs to the same Better Stack source** (`SYSLOG_IDENTIFIER=doppler`).
+Those rows embed branch names (`…-ci-deploy-…`) and issue/PR bodies — which quote
+both marker strings **verbatim**, including this tracker's own body. A 14-day
+window matched **2 rows** on the bare substring, **zero** of which were real
+ci-deploy emissions. Worse: self-perpetuating — the sweeper's FAIL comment prints
+the offending rows onto the issue, re-seeding the contamination.
+
+The unit suite was **green** the whole time, because its fixtures modeled `raw`
+as a bare syslog string (`<13>ci-deploy: …`) instead of the real **escaped
+JSONEachRow** shape betterstack-query.sh emits. The detector matched the fixtures;
+neither matched reality.
+
+## Root cause
+
+Two compounding gaps:
+
+1. **Discriminator scoped to a payload SUBSTRING, not a journald FIELD.** `ci-deploy`
+   appears in far more than ci-deploy emissions — any log line (from any producer on
+   the shared Vector source) that mentions the string matches. The only reliable
+   discriminator is the top-level journald field `SYSLOG_IDENTIFIER":"ci-deploy`.
+2. **Fixtures modeled a convenient shape, not the real emission form.** The real
+   `raw` is JSON with backslash-escaped inner quotes on stdout
+   (`\"SYSLOG_IDENTIFIER\":\"ci-deploy\"`); the fixtures used bare syslog, so the
+   test could never reproduce the live contamination (a doppler-tagged row carrying
+   both markers).
+
+The plan *anticipated* the field-spelling risk ("verify the `SYSLOG_IDENTIFIER`
+field spelling in a real `raw` row before freezing the LIKE") and named a live
+discoverability AC (AC9) — but that verification was deferred to post-merge instead
+of run at `/work`, so nothing caught the shape/contamination before review.
+
+## Solution
+
+Isolate the journald field in **both byte-forms** (they differ by context):
+
+- **Server-side** (`betterstack-query.sh --grep`, runs as `raw LIKE '%term%'` against
+  the UNescaped ClickHouse column): `SYSLOG_IDENTIFIER":"ci-deploy`
+- **Client-side** (grep over the JSONEachRow STDOUT, where inner quotes are
+  backslash-escaped): `SYSLOG_IDENTIFIER\":\"ci-deploy\"`
+
+POST-failure detection = server `--grep "Sentry POST failed"` + client
+`grep -F` on the escaped field marker. Liveness = server `--grep` on the LIKE marker
++ client `grep -cF` on the escaped marker. FAIL is evaluated **before** the liveness
+fetch so a liveness-query fault can't mask a real recurrence.
+
+Fixtures rewritten to the real escaped JSON shape, plus a **contamination arm** (a
+`doppler`-tagged webhook row embedding both markers → must PASS, not FAIL) and a
+**FAIL-precedence arm**. Live probe now PASSes (569 real ci-deploy rows, 0 POST
+failures in 14d). Both new arms mutation-proven non-vacuous.
+
+## Key insight
+
+**For any log-content follow-through probe over a SHARED Better Stack / Vector
+source, the discriminator MUST match the journald SYSLOG_IDENTIFIER field, never a
+bare payload substring — and the fixtures MUST reproduce the real escaped
+JSONEachRow shape.** The source carries webhook/app logs that quote arbitrary text
+(branch names, issue bodies, PR diffs), so any marker string a human might type
+into GitHub will appear in the payload of a *different* producer's rows. A
+bare-substring probe is self-contaminating when the tracker's own body quotes the
+marker. Run the live discoverability query (AC9-class) **at /work, not post-merge**
+— it is the only check that surfaces both the escaping and the contamination.
+
+## Session Errors
+
+- **Bare-substring discriminator false-FAILed against live prod** — Recovery:
+  field-isolate on `SYSLOG_IDENTIFIER` (two byte-forms) + live-verify. **Prevention:**
+  followthrough-convention runbook sharp edge (routed below); run the live AC at /work.
+- **Fixtures modeled bare-syslog `raw` instead of real escaped JSON → false green** —
+  Recovery: rewrote fixtures to the captured real shape + contamination arm.
+  **Prevention:** capture one real (redacted) row and model fixtures on it before
+  authoring; same routed sharp edge.
+- **Commit body carried `closes #6475`** (auto-close bigram) — Recovery: history
+  rewrite (soft-reset, no closing-keyword+#N adjacency). **Prevention:** already
+  covered by ship Phase 6 `auto-close-scan.sh` + the documented
+  `auto-closes-meta-content` class; use `Refs #N` in descriptive commit prose.
+- **"eight" emitter overcount in docstring/plan** (one-off) — Recovery: corrected to
+  seven Sentry sites.
+- **AC3 grep matched my own `${VAR:?}` anti-pattern comment** (one-off, documented
+  class `cq-assert-anchor-not-bare-token`) — Recovery: reworded the comment to drop
+  the literal.

--- a/knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
@@ -1,0 +1,337 @@
+---
+title: "Fail-loud on Sentry POST failures from ci-deploy.sh (D-6)"
+issue: 6475
+branch: feat-one-shot-6475-ci-deploy-sentry-fail-loud
+type: feat
+lane: single-domain
+brand_survival_threshold: none
+date: 2026-07-18
+---
+
+# Fail-loud on Sentry POST failures from ci-deploy.sh (D-6) — #6475 Item 2
+
+> No `spec.md` present (one-shot pipeline: plan precedes spec). `lane:` set to
+> `single-domain` — this is a single-domain (engineering / CI-infra observability)
+> change: one follow-through probe script plus a tracker enrollment.
+
+## Overview
+
+`ci-deploy.sh` emits best-effort Sentry events at eight fallback/degraded-state
+sites (CRON_DRAIN timeout, SANDBOX_CANARY fail, IMAGE_VERIFY, IMAGE_PULL,
+IMAGE_PULL_RECOVERY, ZOT_GATE, …). Each POST is fail-open (`curl … --max-time 10`
+followed by `|| logger -t "$LOG_TAG" "<TAG>: Sentry POST failed"`). This is
+**correct** on-host behaviour — a deploy must never abort because Sentry
+telemetry is unreachable — but it means the *failure of the alarm path itself*
+is journald-only. Per `hr-no-ssh-fallback-in-runbooks`, nobody reads a host's
+journald, so a Sentry POST failure during a **real** fallback event is silently
+unalarmed. D-6 closes that blind spot by making the POST-failure signal
+**loud**: actively queried on a schedule and surfaced onto a tracker issue.
+
+**The mechanism is already 90% wired.** The eight emitters already `logger -t
+"$LOG_TAG"` with `LOG_TAG="ci-deploy"`, and `ci-deploy` is **already** in
+`apps/web-platform/infra/vector.toml` Source 4
+(`host_scripts_journald`) SYSLOG_IDENTIFIER allowlist — so every "Sentry POST
+failed" line **already ships to Better Stack Logs** (source 2457081, ClickHouse
+SQL-queryable via `scripts/betterstack-query.sh`). What is missing is the
+*active query + alarm*: a scheduled poller that fails loud when such a line
+appears. The repo already has the exact substrate for this — the
+`scripts/followthroughs/*.sh` + `scheduled-followthrough-sweeper.yml` pattern,
+which the sweeper's **exit-1 = comment + leave-open** branch turns into a loud
+alarm on a tracker issue.
+
+This is a **Soak-shaped follow-through** (per
+`knowledge-base/engineering/operations/runbooks/followthrough-convention.md`
+§Trigger→verification mapping): *"the ci-deploy Sentry-POST-failure rate stays
+at ~0 for N days"*. Zero POST-failure lines over the soak window → PASS (exit 0)
+→ sweeper closes #6475 (both items resolved; Item 1 done via #6458). A POST
+failure appearing in the window → **FAIL (exit 1) → sweeper comments #6475 and
+leaves it open** = the fail-loud alarm. Any query/auth failure or absent
+liveness → TRANSIENT (exit 2) → retry next sweep, never a false close.
+
+Deliverable: **one new probe script + tracker enrollment.** No on-host
+`ci-deploy.sh` change (the emit→ship path is already live and the fail-open POST
+is deliberate), no new secret (the `BETTERSTACK_QUERY_*` creds are already in the
+sweeper env), no Terraform, no ADR/C4 change.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (issue #6475 Item 2) | Reality (verified on this branch) | Plan response |
+|---|---|---|
+| "the earlier design was fabricated — an initial draft proposed a route that does not exist" | Confirmed anti-pattern: a Sentry-*query* probe would PASS vacuously, because a **failed** Sentry POST never reaches Sentry. The only queryable sink for the POST-failure line is Better Stack (journald→Vector), mirroring the exact `#5934` lesson recorded in `chardevice-wedge-nonrecurrence-5934.sh`. | Probe queries **Better Stack**, never Sentry. Documented in-script + here. |
+| "the real mechanism is `scripts/followthroughs/*.sh` + `scheduled-followthrough-sweeper.yml`" | Confirmed. Sweeper wires `BETTERSTACK_QUERY_{HOST,USERNAME,PASSWORD}` already (added for `#5934`/`#5110`). | Build the probe on this substrate; no workflow env change. |
+| Sentry POST failures are "journald-only" | Partly stale: the line is journald-only *for paging*, but `ci-deploy` **is** in `vector.toml` Source 4 allowlist, so it already lands in Better Stack Logs. The gap is the *active query*, not the shipping. | No on-host change; build only the poller. |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing directly — this is an
+internal CI/infra observability watchdog with no user-facing surface. The worst
+failure mode is the *status quo* (a Sentry POST failure stays unalarmed), i.e.
+no regression versus today.
+
+**If this leaks, the user's data is exposed via:** N/A — the probe reads
+operational CI journald log lines (`"<TAG>: Sentry POST failed"`) from Better
+Stack Logs; it handles no user data, PII, secrets, or workflow content. Better
+Stack creds are read-only ClickHouse query creds already provisioned.
+
+**Brand-survival threshold:** none. `threshold: none, reason: internal CI-infra
+observability probe — no user-facing surface, no regulated-data path, no
+sensitive-path file (scripts/followthroughs/*.sh is not schema/migration/auth/API/.sql).`
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify, do not assume)
+
+0.1 Confirm the eight emitter fallback lines still share the greppable marker and
+tag:
+`grep -n '|| logger -t "\$LOG_TAG"' apps/web-platform/infra/ci-deploy.sh` — expect
+the 7 "Sentry POST failed" lines (437, 517, 541, 609, 635, 666, 1157) plus the
+non-Sentry lease line (2596, out of scope). Confirm `readonly LOG_TAG="ci-deploy"`.
+
+0.2 Confirm `ci-deploy` is in `vector.toml` Source 4 allowlist:
+`grep -n '"ci-deploy"' apps/web-platform/infra/vector.toml` (expect the
+`host_scripts_journald` `include_matches.SYSLOG_IDENTIFIER` block).
+
+0.3 Confirm sweeper already exports the Better Stack query creds:
+`grep -n 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml`
+(expect HOST/USERNAME/PASSWORD). No workflow edit needed.
+
+0.4 Confirm `betterstack-query.sh` raw-SQL mode is available for AND-scoping
+(`--grep` is OR-only): read `scripts/betterstack-query.sh` mode-1 branch
+(`^[[:space:]]*(SELECT|WITH|SHOW)` gate) and the `$BS_TABLE` / `$BS_TABLE_S3`
+substitution tokens.
+
+### Phase 1 — Write the follow-through probe (RED then GREEN)
+
+Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh`, structurally
+mirroring `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack query +
+liveness gate + fail-safe TRANSIENT). Contract:
+
+- **Query (AND-scoped, raw-SQL mode)** — count Better Stack rows over the soak
+  window where the raw journald payload contains BOTH the `ci-deploy` identifier
+  AND the marker. Use `betterstack-query.sh` mode-1 with the `$BS_TABLE` /
+  `$BS_TABLE_S3` tokens and a UNION-ALL hot+archive body (so a multi-day window
+  isn't silently truncated to the ~40-min hot window):
+
+  ```sql
+  SELECT dt, raw FROM (
+    SELECT dt, raw FROM remote($BS_TABLE)
+      WHERE dt >= now() - INTERVAL <N> DAY
+        AND raw LIKE '%SYSLOG_IDENTIFIER":"ci-deploy%'
+        AND raw LIKE '%Sentry POST failed%'
+    UNION ALL
+    SELECT dt, raw FROM s3Cluster(primary, $BS_TABLE_S3)
+      WHERE _row_type = 1 AND dt >= now() - INTERVAL <N> DAY
+        AND raw LIKE '%SYSLOG_IDENTIFIER":"ci-deploy%'
+        AND raw LIKE '%Sentry POST failed%'
+  ) ORDER BY dt DESC LIMIT 200 FORMAT JSONEachRow
+  ```
+
+  (Phase 1 verifies the exact `SYSLOG_IDENTIFIER` field spelling in `raw` against
+  one real Better Stack row before freezing the LIKE; if the field is not
+  literally `SYSLOG_IDENTIFIER":"ci-deploy`, fall back to `--grep "Sentry POST
+  failed"` mode-2 + a post-filter `grep 'ci-deploy'` on the JSONEachRow output,
+  as `chardevice`'s `denied_count()` does.)
+
+- **Liveness gate (fail-safe against vacuous PASS, per convention #5934 lesson):**
+  a separate query counts *any* `ci-deploy` rows in the window (proof the
+  emit→Better-Stack path is live and deploys occurred). If zero `ci-deploy` rows
+  → **TRANSIENT (exit 2)** ("no ci-deploy activity observed in window;
+  inconclusive"), NOT PASS — a dark Vector/journald or a quiet deploy period must
+  never read as "zero POST failures".
+
+- **Exit semantics** (`sweep-followthroughs.sh` contract):
+  - `0 = PASS` — liveness ≥ 1 ci-deploy row AND zero POST-failure rows → sweeper closes #6475.
+  - `1 = FAIL` — ≥ 1 POST-failure row → **the fail-loud alarm** (sweeper comments #6475, leaves open); print the offending `dt`/`raw` lines (last-4KB captured as the comment).
+  - `2 = TRANSIENT` — any query/auth/network failure, unparseable count, OR zero-liveness → retry next sweep.
+
+- **Guards (per convention):** `set -uo pipefail`; NO `: "${VAR:?}"` gate (that
+  aborts with status 1 = FAIL under non-interactive shell) — use
+  `if [[ -z "${VAR:-}" ]]; then echo "TRANSIENT: …" >&2; exit 2; fi` for the
+  `BETTERSTACK_QUERY_*` presence check (or delegate to `betterstack-query.sh`'s
+  own exit-3 and map non-zero → exit 2). Window overridable via
+  `CI_DEPLOY_SENTRY_SOAK_WINDOW` (default `7d`, validated `^[0-9]+[hmd]$`).
+
+`chmod +x` the script.
+
+### Phase 2 — Probe unit tests
+
+Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` mirroring
+`chardevice-wedge-nonrecurrence-5934` /`hostname-mislabel-web1-6616` test style
+(stub `betterstack-query.sh` via a PATH shim / `BQ` override; assert exit codes):
+
+- POST-failure row present + liveness present → exit 1 (FAIL, loud). **Load-bearing**: this is the alarm.
+- Zero POST-failure rows + liveness present → exit 0 (PASS).
+- Zero liveness rows → exit 2 (TRANSIENT), never PASS.
+- `betterstack-query.sh` non-zero / unreachable → exit 2 (TRANSIENT).
+- Empty/unset `BETTERSTACK_QUERY_*` → exit 2 (TRANSIENT), never exit 1.
+- Invalid `CI_DEPLOY_SENTRY_SOAK_WINDOW` → exit 2.
+
+Register in the followthrough test convention (whatever `test-all.sh` /
+`validate-vector-config`-adjacent harness discovers `scripts/followthroughs/*.test.sh`;
+confirm discovery in Phase 0).
+
+### Phase 3 — Enroll #6475 as the follow-through tracker (no operator step)
+
+3.1 Add the directive to the #6475 body (via `gh issue edit`, automatable — not
+an operator step). Place inline anywhere:
+
+```html
+<!-- soleur:followthrough
+  script=scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh
+  earliest=<merge-date + 7d, UTC ISO-8601>
+  secrets=BETTERSTACK_QUERY_HOST,BETTERSTACK_QUERY_USERNAME,BETTERSTACK_QUERY_PASSWORD
+-->
+```
+
+3.2 Add the `follow-through` label to #6475 (`gh issue edit 6475 --add-label
+follow-through`). The `.claude/hooks/follow-through-directive-gate.sh` + sweeper
+require the `script=` path to exist + be executable on disk *before* the directive
+is honored — it does (lands in this PR's branch, and the sweeper checks out the
+merged tree).
+
+3.3 The PR body uses **`Ref #6475`, NOT `Closes #6475`** — closure is deferred to
+the soak PASS (the sweeper closes it), matching the ops-remediation
+`Ref-not-Closes` pattern. `earliest = merge + 7d` gives one clean soak window of
+production ci-deploy activity before the first verdict.
+
+## Files to Create
+
+- `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` — the Better Stack POST-failure soak probe.
+- `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` — exit-code unit tests.
+
+## Files to Edit
+
+- **GitHub issue #6475 body + labels** (via `gh issue edit`, in Phase 3) — add the `soleur:followthrough` directive + `follow-through` label. (Not a repo file; a tracker-state edit performed by /work or /ship, automatable.)
+- No repo source file is edited. `ci-deploy.sh`, `vector.toml`, and `scheduled-followthrough-sweeper.yml` are **unchanged** (already wired — see Overview).
+
+## Open Code-Review Overlap
+
+One open code-review issue touches `ci-deploy`: **#3053** (review: empty-mount
+window during ci-deploy seed). **Disposition: Acknowledge** — different concern
+(a seed-time mount race), no file overlap (this plan edits no `ci-deploy.sh`
+line), remains open on its own cycle.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] AC1 — `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` exists, is executable (`test -x`), and `bash -n` parses clean.
+- [ ] AC2 — The probe queries **Better Stack** and **never Sentry**: `grep -c 'sentry\.io\|SENTRY_AUTH_TOKEN\|/api/0/' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0; `grep -c 'betterstack-query.sh' …` returns ≥ 1.
+- [ ] AC3 — The probe has NO `: "${VAR:?}"` exit-gate: `grep -cE ':\s*"\$\{[A-Z_]+:\?' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0.
+- [ ] AC4 — Query is AND-scoped to the ci-deploy identifier: the SQL/post-filter references BOTH `ci-deploy` and `Sentry POST failed` (assert via grep for both literals in the script).
+- [ ] AC5 — `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exits 0 (all six exit-code cases pass, including the FAIL=1 alarm case and zero-liveness=2 fail-safe case).
+- [ ] AC6 — `#6475` carries the `follow-through` label AND a `soleur:followthrough` directive whose `script=` is the new path and `secrets=` names the three `BETTERSTACK_QUERY_*` names: `gh issue view 6475 --json labels,body` shape check. (Verify the sweeper already exports those three: `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 — no workflow edit expected.)
+- [ ] AC7 — PR body says `Ref #6475` (NOT `Closes #6475`): closure is the sweeper's job on soak PASS.
+
+### Post-merge (operator — automatable, no SSH)
+
+- [ ] AC8 — Dry-run the sweeper against #6475: `gh workflow run scheduled-followthrough-sweeper.yml -f dry_run=true` then confirm the run parsed #6475's directive and executed the probe (TRANSIENT expected before `earliest`, or a real verdict after). `Automation: gh CLI` — no operator judgement.
+- [ ] AC9 — Discoverability (no SSH): `doppler run -p soleur -c prd_terraform -- scripts/betterstack-query.sh --since 7d --grep "Sentry POST failed"` returns rows-or-empty (proves the sink is queryable end-to-end). `Automation: doppler + betterstack-query.sh`.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: "≥1 SYSLOG_IDENTIFIER=ci-deploy row in Better Stack Logs over the soak window (proof the emit→Vector→Better Stack path is live and deploys ran)"
+  cadence: "checked each daily sweep (0 18 * * * UTC) once now >= earliest"
+  alert_target: "zero-liveness → probe exits 2 (TRANSIENT); #6475 stays open, never false-closes"
+  configured_in: "scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh (liveness gate) + scheduled-followthrough-sweeper.yml"
+error_reporting:
+  destination: "GitHub issue #6475 comment (sweeper posts last-4KB of probe stderr/stdout on exit 1)"
+  fail_loud: true   # exit 1 = comment + leave-open = the D-6 alarm; the whole feature IS the fail-loud path
+failure_modes:
+  - mode: "ci-deploy Sentry POST failed during a real fallback event"
+    detection: "betterstack-query over Better Stack Logs for raw LIKE ci-deploy AND 'Sentry POST failed' (in-repo GH-cron poll, ADR-096 pattern — not a native Better Stack alert)"
+    alert_route: "probe exit 1 → sweeper comments #6475 (issues:write), leaves open"
+  - mode: "Better Stack query unreachable / auth failure / creds unset"
+    detection: "betterstack-query.sh non-zero OR empty BETTERSTACK_QUERY_* → probe exit 2"
+    alert_route: "TRANSIENT — retry next sweep; #6475 stays open (can never false-close)"
+  - mode: "emit→Better Stack path dark (Vector/journald down) or no deploys in window"
+    detection: "zero ci-deploy liveness rows → probe exit 2"
+    alert_route: "TRANSIENT — inconclusive, never PASS"
+logs:
+  where: "sweeper run logs in GitHub Actions (Scheduled: Follow-Through Sweeper); the underlying ci-deploy 'Sentry POST failed' lines in Better Stack Logs source 2457081"
+  retention: "GitHub Actions default; Better Stack Logs per source retention (hot ~40min + s3 archive)"
+discoverability_test:
+  command: "doppler run -p soleur -c prd_terraform -- scripts/betterstack-query.sh --since 7d --grep 'Sentry POST failed'"
+  expected_output: "JSONEachRow rows (if any POST failures occurred) or empty (clean) — proves the sink is queryable with NO ssh"
+```
+
+### Soak Follow-Through Enrollment
+
+This plan's **primary deliverable IS the soak follow-through** (not a side
+gate). Enrollment fields:
+
+- **Script:** `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` — exit 0 when the soak holds (zero POST-failure rows + liveness), 1 on any POST-failure row (fail-loud), 2 on transient/no-liveness. Mirrors `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack + liveness + fail-safe), not the Sentry-query `reconcile-ff-only-sentry-4977.sh` (D-6's signal never reaches Sentry).
+- **Directive:** `<!-- soleur:followthrough script=scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh earliest=<merge+7d UTC> secrets=BETTERSTACK_QUERY_HOST,BETTERSTACK_QUERY_USERNAME,BETTERSTACK_QUERY_PASSWORD -->` on #6475 + `follow-through` label.
+- **New `secrets=` to wire into `scheduled-followthrough-sweeper.yml`:** none — `BETTERSTACK_QUERY_{HOST,USERNAME,PASSWORD}` are already in the sweeper `env:` (added for #5934/#5110). Verified in Phase 0.3.
+
+## Domain Review
+
+**Domains relevant:** none
+
+No cross-domain (product / marketing / sales / finance / legal / ops / support)
+implications — infrastructure/tooling observability change. Engineering (CTO)
+lens is the plan author's; no business-domain leader spawn warranted.
+
+## Architecture Decision (ADR/C4)
+
+**No ADR, no C4 change.** This applies an existing, ADR-documented pattern
+(follow-through soak probe polling Better Stack Logs — ADR-096, "log-content
+recurrence alarms are in-repo GH-cron pollers, not native Better Stack alerts")
+to a new signal. C4 completeness enumeration (read against
+`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`):
+
+- **External human actors:** none new (founder already the paging endpoint via existing edges).
+- **External systems:** `betterstack` (system, `model.c4:266`) and `sentry` (`model.c4:273`) already modeled; the GitHub-Actions sweeper is the existing `github` system.
+- **Containers / data stores:** none new (Better Stack Logs source 2457081 already modeled).
+- **Access relationships:** the exact edge already exists — `github -> betterstack` "…the follow-through soak probes poll [Better Stack Logs] (ClickHouse SQL via betterstack-query.sh)" (`model.c4:429/433`); ci-deploy journald→Better Stack is `hetzner -> betterstack` (`model.c4:404`). This plan adds one *instance* of an already-modeled edge, not a new edge.
+
+No element/edge/description is falsified by this change → no `.c4` edit.
+
+## Test Scenarios
+
+Covered by Phase 2 unit tests (exit-code matrix). Integration confidence comes
+from AC8 (dry-run sweep parses + runs the probe) and AC9 (live betterstack-query
+end-to-end). No prod-write, no synthetic users, read-only throughout.
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|---|---|
+| Native Better Stack log-based alert (Terraform `betteruptime_*` on the log content) | Per ADR-096, Soleur deliberately uses in-repo GH-cron pollers for log-content recurrence alarms, not native Better Stack alerts. The issue explicitly names the follow-through mechanism. Deferring the native-alert option keeps scope minimal and consistent. |
+| A second Sentry POST on failure (retry to a different DSN) | Pointless: the failure mode is Sentry being unreachable; a second Sentry POST fails identically. Better Stack is the independent second-source sink (`model.c4`: the redundancy is by design). |
+| Make the on-host POST fail-*closed* (abort deploy) | Wrong. A deploy must not depend on Sentry availability; fail-open is deliberate. D-6 is about *observing* the failure, not blocking on it. |
+| A standalone scheduled workflow (not a follow-through) | The follow-through substrate already exists, already wires the creds, and gives auto-close on clean soak + loud comment on failure for free. A bespoke workflow re-implements all of that. |
+| Enroll a NEW tracker instead of #6475 | #6475's only remaining open item IS D-6 (Item 1 done via #6458); enrolling #6475 directly means the soak PASS closes it cleanly. |
+
+## Sharp Edges
+
+- **Query the sink the signal actually reaches.** A **failed** Sentry POST never
+  arrives at Sentry — querying Sentry would PASS vacuously and auto-close #6475
+  blind (the exact `#5934` trap in the convention). The probe MUST query Better
+  Stack. Verify the `SYSLOG_IDENTIFIER` field spelling in a real `raw` row before
+  freezing the LIKE clause.
+- **Liveness gate is load-bearing.** Without requiring ≥1 `ci-deploy` liveness
+  row, a dark Vector/journald or a deploy-free window reads as "zero POST
+  failures" → false PASS + auto-close. Zero-liveness → TRANSIENT, never PASS.
+- **No `: "${VAR:?}"` exit-gate.** Under the sweeper's non-interactive shell it
+  aborts with status 1 (= FAIL = loud alarm on a green codebase). Use an explicit
+  `if [[ -z … ]]; then exit 2; fi`.
+- **`Ref #6475`, not `Closes #6475`.** `Closes` auto-closes at merge, *before* the
+  soak runs — a false-resolved state. The sweeper closes it on soak PASS.
+- **`betterstack-query.sh --grep` is OR-only.** For the AND of (`ci-deploy`) and
+  (`Sentry POST failed`), use raw-SQL mode (mode-1) with two `LIKE`s, or `--grep`
+  the marker + post-filter the JSONEachRow output for `ci-deploy` (as
+  `chardevice`'s `denied_count()` does). A bare `--grep "Sentry POST failed"`
+  could match another allowlisted tag (none known to emit it, but scope
+  precisely).
+- **Include the archive arm.** `remote($BS_TABLE)` alone is the ~40-min hot
+  window; a 7d soak needs `UNION ALL s3Cluster(primary, $BS_TABLE_S3)` or it
+  silently answers 7d with 40 minutes of rows.
+
+## Risks & Mitigations
+
+- **False PASS closing #6475 blind** → mitigated by the liveness gate + TRANSIENT-on-any-failure fail-safe (probe can only ever close on positive proof of a live, clean window).
+- **Marker drift** (an emitter's message changes and the LIKE stops matching) → Phase 0.1 pins the marker; the 7 lines share `"Sentry POST failed"`. A drift-guard could assert the emitter count, but at 7 stable lines this is YAGNI; noted for deepen-plan to weigh.
+- **`SYSLOG_IDENTIFIER` field spelling in `raw`** → resolved empirically in Phase 1 against one real Better Stack row before the LIKE is frozen (post-filter fallback if the field shape differs).

--- a/knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
@@ -49,9 +49,10 @@ ADR-033 exist. `hr-no-ssh-fallback-in-runbooks` active in AGENTS.core.md.
 
 ## Overview
 
-`ci-deploy.sh` emits best-effort Sentry events at eight fallback/degraded-state
-sites (CRON_DRAIN timeout, SANDBOX_CANARY fail, IMAGE_VERIFY, IMAGE_PULL,
-IMAGE_PULL_RECOVERY, ZOT_GATE, …). Each POST is fail-open (`curl … --max-time 10`
+`ci-deploy.sh` emits best-effort Sentry events at seven fail-open sites
+(7 `logger … "Sentry POST failed"` lines across the tags CRON_DRAIN timeout,
+SANDBOX_CANARY fail, IMAGE_VERIFY, IMAGE_PULL [×2], IMAGE_PULL_RECOVERY,
+ZOT_GATE). Each POST is fail-open (`curl … --max-time 10`
 followed by `|| logger -t "$LOG_TAG" "<TAG>: Sentry POST failed"`). This is
 **correct** on-host behaviour — a deploy must never abort because Sentry
 telemetry is unreachable — but it means the *failure of the alarm path itself*
@@ -60,7 +61,7 @@ journald, so a Sentry POST failure during a **real** fallback event is silently
 unalarmed. D-6 closes that blind spot by making the POST-failure signal
 **loud**: actively queried on a schedule and surfaced onto a tracker issue.
 
-**The mechanism is already 90% wired.** The eight emitters already `logger -t
+**The mechanism is already 90% wired.** The seven emitters already `logger -t
 "$LOG_TAG"` with `LOG_TAG="ci-deploy"`, and `ci-deploy` is **already** in
 `apps/web-platform/infra/vector.toml` Source 4
 (`host_scripts_journald`) SYSLOG_IDENTIFIER allowlist — so every "Sentry POST
@@ -243,12 +244,12 @@ line), remains open on its own cycle.
 
 ### Pre-merge (PR)
 
-- [ ] AC1 — `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` exists, is executable (`test -x`), and `bash -n` parses clean.
-- [ ] AC2 — The probe queries **Better Stack** and **never Sentry**: `grep -c 'sentry\.io\|SENTRY_AUTH_TOKEN\|/api/0/' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0; `grep -c 'betterstack-query.sh' …` returns ≥ 1.
-- [ ] AC3 — The probe has NO `: "${VAR:?}"` exit-gate: `grep -cE ':\s*"\$\{[A-Z_]+:\?' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0.
-- [ ] AC4 — Query is AND-scoped to the ci-deploy identifier: the probe both `--grep`s `Sentry POST failed` AND post-filters output for `ci-deploy` (assert via grep for both literals in the script). Guards against a future Source-4 script emitting the same marker (see Sharp Edges).
-- [ ] AC5 — `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exits 0 (all six exit-code cases pass, including the FAIL=1 alarm case and zero-liveness=2 fail-safe case).
-- [ ] AC6 — `#6475` carries the `follow-through` label AND a `soleur:followthrough` directive whose `script=` is the new path and `secrets=` names the three `BETTERSTACK_QUERY_*` names: `gh issue view 6475 --json labels,body` shape check. (Verify the sweeper already exports those three: `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 — no workflow edit expected.)
+- [x] AC1 — `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` exists, is executable (`test -x`), and `bash -n` parses clean.
+- [x] AC2 — The probe queries **Better Stack** and **never Sentry**: `grep -c 'sentry\.io\|SENTRY_AUTH_TOKEN\|/api/0/' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0; `grep -c 'betterstack-query.sh' …` returns ≥ 1.
+- [x] AC3 — The probe has NO `: "${VAR:?}"` exit-gate: `grep -cE ':\s*"\$\{[A-Z_]+:\?' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0.
+- [x] AC4 — Query is AND-scoped to the ci-deploy identifier: the probe both `--grep`s `Sentry POST failed` AND post-filters output for `ci-deploy` (assert via grep for both literals in the script). Guards against a future Source-4 script emitting the same marker (see Sharp Edges).
+- [x] AC5 — `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exits 0 (all six exit-code cases pass, including the FAIL=1 alarm case and zero-liveness=2 fail-safe case).
+- [x] AC6 — `#6475` carries the `follow-through` label AND a `soleur:followthrough` directive whose `script=` is the new path and `secrets=` names the three `BETTERSTACK_QUERY_*` names: `gh issue view 6475 --json labels,body` shape check. (Verify the sweeper already exports those three: `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 — no workflow edit expected.)
 - [ ] AC7 — PR body says `Ref #6475` (NOT `Closes #6475`): closure is the sweeper's job on soak PASS.
 
 ### Post-merge (operator — automatable, no SSH)
@@ -348,14 +349,23 @@ end-to-end). No prod-write, no synthetic users, read-only throughout.
   `if [[ -z … ]]; then exit 2; fi`.
 - **`Ref #6475`, not `Closes #6475`.** `Closes` auto-closes at merge, *before* the
   soak runs — a false-resolved state. The sweeper closes it on soak PASS.
-- **`betterstack-query.sh --grep` is OR-only — post-filter for the discriminator.**
-  For the AND of (`ci-deploy`) and (`Sentry POST failed`), use mode-2
-  `--grep "Sentry POST failed"` then post-filter the JSONEachRow output for `ci-deploy`
-  (exactly `chardevice`'s `denied_count()` shape), or mode-1 raw SQL with two `LIKE`s.
-  A bare `--grep "Sentry POST failed"` is correct *today* (only `ci-deploy` emits it in
-  Better Stack — verified: `scripts/seccomp-unenforced-alert.sh` emits the same string but
-  via a CI `::warning::` echo, not `logger -t`, and is not in Source 4), but the
-  `ci-deploy` post-filter is the defense-in-depth that survives a future Source-4 addition.
+- **The discriminator MUST isolate the SYSLOG_IDENTIFIER FIELD, not a bare `ci-deploy`
+  substring (review correction — was a blocking false-FAIL).** `betterstack-query.sh
+  --grep` is OR-only, so the AND of (ci-deploy) and (Sentry POST failed) is a server-side
+  `--grep "Sentry POST failed"` + a client post-filter. The original plan said post-filter
+  for a bare `ci-deploy` substring — **that false-FAILed against live prod**: inngest ships
+  GitHub-webhook processing logs to the same Better Stack source, and those rows
+  (`SYSLOG_IDENTIFIER=doppler`) embed branch names (`…-ci-deploy-…`) and issue/PR bodies
+  quoting both marker strings verbatim (this tracker's own body among them). Live 14d
+  window: 2 such rows matched the bare substring, zero were real ci-deploy emissions →
+  `exit 1` on a clean codebase, self-perpetuating (the FAIL comment re-seeds the payload).
+  The implemented post-filter isolates the journald field in its two byte-forms — server
+  `--grep 'SYSLOG_IDENTIFIER":"ci-deploy'` (LIKE, unescaped column) and client
+  `grep -F 'SYSLOG_IDENTIFIER\":\"ci-deploy\"'` (escaped JSONEachRow stdout) — empirically
+  verified: live probe now PASSes (569 real ci-deploy rows, zero POST failures in 14d).
+  (Aside: among Source-4 tags only ci-deploy emits "Sentry POST failed" via `logger -t`;
+  `scripts/seccomp-unenforced-alert.sh` emits the same string via a CI `::warning::` echo,
+  not `logger -t`, and is not in Source 4.)
 - **Mode-2 auto-handles the archive arm; raw SQL does not.** `betterstack-query.sh`
   mode-2 (`--grep`) already UNION-ALLs the ~40-min hot window with the s3 archive, so a 7d
   soak is complete. If you drop to mode-1 raw SQL, you MUST write the

--- a/knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
@@ -14,6 +14,39 @@ date: 2026-07-18
 > `single-domain` — this is a single-domain (engineering / CI-infra observability)
 > change: one follow-through probe script plus a tracker enrollment.
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-18
+
+**Deepen-plan gates:** 4.6 User-Brand Impact ✓ (threshold `none` + reason; Files-to-Edit
+touch no sensitive path). 4.7 Observability ✓ (5 fields present, `discoverability_test.command`
+is ssh-free). 4.8 PAT-shaped ✓ (none). 4.9 UI-wireframe — N/A (no UI surface). 4.4
+Scheduled-work precedent — N/A (reuses the existing `scheduled-followthrough-sweeper.yml`;
+follow-throughs are repo/issue-scoped git work → GH Actions is the canonical substrate, not
+Inngest, per the convention). 4.55 Downtime & Cutover — N/A (no serving surface goes offline;
+no infra reboot/replace, DB lock, or router change). 4.5 Network-Outage — the plan mentions
+"unreachable" only as a *fail-safe input* (query unreachable → exit 2 TRANSIENT); it proposes
+no SSH/firewall/host fix and the sweeper hits Better Stack's public ClickHouse HTTPS API (no
+egress-IP allowlist), so no L3 deep-dive applies.
+
+**Live-verified citations:** #6458 MERGED (Item 1 done — "render cloud-init templatefiles
+before schema-checking"). #3053 OPEN (code-review overlap — different concern). ADR-096 +
+ADR-033 exist. `hr-no-ssh-fallback-in-runbooks` active in AGENTS.core.md.
+
+### Key improvements from the deepen pass
+
+1. **Query approach corrected to precedent.** Primary is mode-2 `--grep "Sentry POST failed"`
+   + a `ci-deploy` post-filter (mirrors `chardevice`'s `denied_count()`), NOT a raw-SQL
+   `SYSLOG_IDENTIFIER` LIKE that assumed the raw-payload key spelling. Mode-2 auto-UNIONs
+   hot+archive, removing the manual-UNION footgun.
+2. **Cross-tag false-positive resolved.** Grep found `scripts/seccomp-unenforced-alert.sh`
+   emits an identical `"Sentry POST failed"` string — but via a CI `::warning::` echo (not
+   `logger -t`) and it is not in Source 4, so it never reaches Better Stack. Confirms the
+   marker is unambiguous today AND makes the `ci-deploy` post-filter load-bearing
+   defense-in-depth (documented in Sharp Edges + AC4).
+3. **Source-4 allowlist enumerated** (15 tags): only `ci-deploy` is a Sentry emitter → the
+   discriminator is sound.
+
 ## Overview
 
 `ci-deploy.sh` emits best-effort Sentry events at eight fallback/degraded-state
@@ -106,36 +139,31 @@ Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh`, structurally
 mirroring `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack query +
 liveness gate + fail-safe TRANSIENT). Contract:
 
-- **Query (AND-scoped, raw-SQL mode)** — count Better Stack rows over the soak
-  window where the raw journald payload contains BOTH the `ci-deploy` identifier
-  AND the marker. Use `betterstack-query.sh` mode-1 with the `$BS_TABLE` /
-  `$BS_TABLE_S3` tokens and a UNION-ALL hot+archive body (so a multi-day window
-  isn't silently truncated to the ~40-min hot window):
+- **POST-failure query (mode-2 `--grep` + `ci-deploy` post-filter — precedent-matched
+  to `chardevice`'s `denied_count()`):** fetch candidate rows with
+  `betterstack-query.sh --since "$WINDOW" --grep "Sentry POST failed" --limit 1000`
+  (mode-2 automatically UNION-ALLs the ~40-min hot window with the s3 archive, so a
+  multi-day window is NOT silently truncated — no manual raw-SQL UNION needed), then
+  **post-filter the JSONEachRow output for the `ci-deploy` discriminator**
+  (`printf '%s\n' "$out" | grep -c 'ci-deploy'` — the SYSLOG_IDENTIFIER appears in the
+  raw journald payload). A non-zero post-filtered count is the fail-loud trigger.
 
-  ```sql
-  SELECT dt, raw FROM (
-    SELECT dt, raw FROM remote($BS_TABLE)
-      WHERE dt >= now() - INTERVAL <N> DAY
-        AND raw LIKE '%SYSLOG_IDENTIFIER":"ci-deploy%'
-        AND raw LIKE '%Sentry POST failed%'
-    UNION ALL
-    SELECT dt, raw FROM s3Cluster(primary, $BS_TABLE_S3)
-      WHERE _row_type = 1 AND dt >= now() - INTERVAL <N> DAY
-        AND raw LIKE '%SYSLOG_IDENTIFIER":"ci-deploy%'
-        AND raw LIKE '%Sentry POST failed%'
-  ) ORDER BY dt DESC LIMIT 200 FORMAT JSONEachRow
-  ```
-
-  (Phase 1 verifies the exact `SYSLOG_IDENTIFIER` field spelling in `raw` against
-  one real Better Stack row before freezing the LIKE; if the field is not
-  literally `SYSLOG_IDENTIFIER":"ci-deploy`, fall back to `--grep "Sentry POST
-  failed"` mode-2 + a post-filter `grep 'ci-deploy'` on the JSONEachRow output,
-  as `chardevice`'s `denied_count()` does.)
+  **Why AND-scope to `ci-deploy` (verified load-bearing).** Within Better Stack the
+  marker is *currently* unambiguous — of the 15 Source-4 tags, only `ci-deploy` emits
+  "Sentry POST failed"; the sibling `scripts/seccomp-unenforced-alert.sh` emits an
+  identical-looking `"seccomp-unenforced: Sentry POST failed"` but via a **GitHub-Actions
+  `::warning::` echo, not `logger -t`**, and its tag is **not** in the Source-4 allowlist,
+  so it never reaches Better Stack. The `ci-deploy` post-filter is defense-in-depth: a
+  future Source-4 script emitting the same marker would otherwise cross-contaminate a bare
+  `--grep`. (Phase 1 confirms the `ci-deploy` discriminator's exact substring form against
+  one real Better Stack row before freezing the post-filter — mirror `chardevice`'s
+  `grep -c "command not allowed"` post-filter shape. If a raw-SQL `AND raw LIKE '%…ci-deploy%'`
+  proves cleaner, mode-1 with `$BS_TABLE`/`$BS_TABLE_S3` is the documented alternative.)
 
 - **Liveness gate (fail-safe against vacuous PASS, per convention #5934 lesson):**
-  a separate query counts *any* `ci-deploy` rows in the window (proof the
-  emit→Better-Stack path is live and deploys occurred). If zero `ci-deploy` rows
-  → **TRANSIENT (exit 2)** ("no ci-deploy activity observed in window;
+  a separate `--grep "ci-deploy"` query counts *any* `ci-deploy` rows in the window
+  (proof the emit→Better-Stack path is live and deploys occurred). If zero `ci-deploy`
+  rows → **TRANSIENT (exit 2)** ("no ci-deploy activity observed in window;
   inconclusive"), NOT PASS — a dark Vector/journald or a quiet deploy period must
   never read as "zero POST failures".
 
@@ -218,7 +246,7 @@ line), remains open on its own cycle.
 - [ ] AC1 — `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` exists, is executable (`test -x`), and `bash -n` parses clean.
 - [ ] AC2 — The probe queries **Better Stack** and **never Sentry**: `grep -c 'sentry\.io\|SENTRY_AUTH_TOKEN\|/api/0/' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0; `grep -c 'betterstack-query.sh' …` returns ≥ 1.
 - [ ] AC3 — The probe has NO `: "${VAR:?}"` exit-gate: `grep -cE ':\s*"\$\{[A-Z_]+:\?' scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` returns 0.
-- [ ] AC4 — Query is AND-scoped to the ci-deploy identifier: the SQL/post-filter references BOTH `ci-deploy` and `Sentry POST failed` (assert via grep for both literals in the script).
+- [ ] AC4 — Query is AND-scoped to the ci-deploy identifier: the probe both `--grep`s `Sentry POST failed` AND post-filters output for `ci-deploy` (assert via grep for both literals in the script). Guards against a future Source-4 script emitting the same marker (see Sharp Edges).
 - [ ] AC5 — `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exits 0 (all six exit-code cases pass, including the FAIL=1 alarm case and zero-liveness=2 fail-safe case).
 - [ ] AC6 — `#6475` carries the `follow-through` label AND a `soleur:followthrough` directive whose `script=` is the new path and `secrets=` names the three `BETTERSTACK_QUERY_*` names: `gh issue view 6475 --json labels,body` shape check. (Verify the sweeper already exports those three: `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 — no workflow edit expected.)
 - [ ] AC7 — PR body says `Ref #6475` (NOT `Closes #6475`): closure is the sweeper's job on soak PASS.
@@ -320,15 +348,19 @@ end-to-end). No prod-write, no synthetic users, read-only throughout.
   `if [[ -z … ]]; then exit 2; fi`.
 - **`Ref #6475`, not `Closes #6475`.** `Closes` auto-closes at merge, *before* the
   soak runs — a false-resolved state. The sweeper closes it on soak PASS.
-- **`betterstack-query.sh --grep` is OR-only.** For the AND of (`ci-deploy`) and
-  (`Sentry POST failed`), use raw-SQL mode (mode-1) with two `LIKE`s, or `--grep`
-  the marker + post-filter the JSONEachRow output for `ci-deploy` (as
-  `chardevice`'s `denied_count()` does). A bare `--grep "Sentry POST failed"`
-  could match another allowlisted tag (none known to emit it, but scope
-  precisely).
-- **Include the archive arm.** `remote($BS_TABLE)` alone is the ~40-min hot
-  window; a 7d soak needs `UNION ALL s3Cluster(primary, $BS_TABLE_S3)` or it
-  silently answers 7d with 40 minutes of rows.
+- **`betterstack-query.sh --grep` is OR-only — post-filter for the discriminator.**
+  For the AND of (`ci-deploy`) and (`Sentry POST failed`), use mode-2
+  `--grep "Sentry POST failed"` then post-filter the JSONEachRow output for `ci-deploy`
+  (exactly `chardevice`'s `denied_count()` shape), or mode-1 raw SQL with two `LIKE`s.
+  A bare `--grep "Sentry POST failed"` is correct *today* (only `ci-deploy` emits it in
+  Better Stack — verified: `scripts/seccomp-unenforced-alert.sh` emits the same string but
+  via a CI `::warning::` echo, not `logger -t`, and is not in Source 4), but the
+  `ci-deploy` post-filter is the defense-in-depth that survives a future Source-4 addition.
+- **Mode-2 auto-handles the archive arm; raw SQL does not.** `betterstack-query.sh`
+  mode-2 (`--grep`) already UNION-ALLs the ~40-min hot window with the s3 archive, so a 7d
+  soak is complete. If you drop to mode-1 raw SQL, you MUST write the
+  `UNION ALL s3Cluster(primary, $BS_TABLE_S3)` yourself or the 7d window silently answers
+  with ~40 minutes of rows.
 
 ## Risks & Mitigations
 

--- a/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/session-state.md
@@ -1,0 +1,20 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md
+- Status: complete
+
+### Errors
+None. All four deepen-plan mandatory halts passed (4.6 User-Brand, 4.7 Observability, 4.8 PAT, 4.9 UI). All cited references live-verified (#6458 MERGED, #3053 OPEN, ADR-096/033 exist, hr-no-ssh-fallback-in-runbooks active).
+
+### Decisions
+- Mechanism is a Soak-shaped follow-through, not a new route. The eight ci-deploy.sh Sentry emitters already `|| logger -t "ci-deploy"` and ci-deploy is already in vector.toml Source-4 allowlist → those lines already ship to Better Stack. D-6 needs only a scheduled poller; the sweeper's exit-1 = comment + leave-open branch IS the fail-loud alarm. Zero on-host change, no new secret, no Terraform, no ADR/C4 change.
+- Query Better Stack, never Sentry (a failed Sentry POST never reaches Sentry, so a Sentry query would PASS vacuously — the #5934 lesson).
+- Deliberately keep the on-host POST fail-open (a deploy must not abort because Sentry is unreachable); "fail-loud" is about observing the failure, not blocking on it.
+- Enroll #6475 directly (Ref, not Closes; label + directive) since its only open item is D-6 (Item 1 done via #6458); soak PASS closes it.
+- Deepen correction: query approach switched to mode-2 `--grep "Sentry POST failed"` + ci-deploy post-filter with liveness gate + fail-safe TRANSIENT to prevent vacuous auto-close.
+
+### Components Invoked
+- Skill soleur:plan
+- Skill soleur:deepen-plan
+- Bash (git, gh, grep verification of ci-deploy.sh emitters, vector.toml, betterstack-query.sh, sweeper workflow, C4 model)

--- a/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/tasks.md
@@ -1,0 +1,41 @@
+# Tasks — Fail-loud on Sentry POST failures from ci-deploy.sh (D-6, #6475 Item 2)
+
+Plan: `knowledge-base/project/plans/2026-07-18-feat-ci-deploy-sentry-post-fail-followthrough-plan.md`
+Lane: single-domain (engineering / CI-infra observability)
+Branch: `feat-one-shot-6475-ci-deploy-sentry-fail-loud`
+
+## Phase 0 — Preconditions (verify, do not assume)
+
+- [ ] 0.1 `grep -n '|| logger -t "\$LOG_TAG"' apps/web-platform/infra/ci-deploy.sh` — expect 7 "Sentry POST failed" lines (437,517,541,609,635,666,1157); confirm `readonly LOG_TAG="ci-deploy"`.
+- [ ] 0.2 `grep -n '"ci-deploy"' apps/web-platform/infra/vector.toml` — expect it inside `host_scripts_journald` SYSLOG_IDENTIFIER allowlist (Source 4).
+- [ ] 0.3 `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 (HOST/USERNAME/PASSWORD already wired — no workflow edit).
+- [ ] 0.4 Read `scripts/betterstack-query.sh` mode-1 (raw SQL) branch + `$BS_TABLE`/`$BS_TABLE_S3` tokens (needed for AND-scoping; `--grep` is OR-only).
+- [ ] 0.5 Confirm `scripts/test-all.sh` discovers `scripts/followthroughs/*.test.sh`; confirm the `<NAME>_BQ` mock-override seam (per `hostname-mislabel-web1-6616.test.sh`).
+
+## Phase 1 — Write the probe (RED then GREEN)
+
+- [ ] 1.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` mirroring `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack query + liveness gate + fail-safe TRANSIENT).
+- [ ] 1.2 Query = AND-scoped raw-SQL (UNION-ALL hot+archive) for `raw LIKE '%…ci-deploy%' AND raw LIKE '%Sentry POST failed%'` over `CI_DEPLOY_SENTRY_SOAK_WINDOW` (default `7d`). Empirically confirm the `SYSLOG_IDENTIFIER` field spelling in one real `raw` row before freezing the LIKE; else fall back to `--grep "Sentry POST failed"` + post-filter `grep ci-deploy`.
+- [ ] 1.3 Liveness gate: separate count of ANY `ci-deploy` rows in window. Zero → `exit 2` (TRANSIENT), never PASS.
+- [ ] 1.4 Exit map: zero POST-failure + liveness≥1 → `exit 0`; ≥1 POST-failure → `exit 1` (fail-loud, print offending `dt`/`raw`); query/auth/creds/no-liveness → `exit 2`.
+- [ ] 1.5 Guards: `set -uo pipefail`; NO `: "${VAR:?}"` — use `if [[ -z "${VAR:-}" ]]; then echo TRANSIENT >&2; exit 2; fi`. Honor a `<NAME>_BQ` override for the query-script path (test seam). Validate window `^[0-9]+[hmd]$`.
+- [ ] 1.6 `chmod +x`.
+
+## Phase 2 — Probe unit tests
+
+- [ ] 2.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` (stub `betterstack-query.sh` via the `<NAME>_BQ` seam; JSONEachRow fixtures; no network/creds).
+- [ ] 2.2 Cases: POST-failure+liveness→1 (alarm, load-bearing); clean+liveness→0; zero-liveness→2; BQ non-zero→2; empty `BETTERSTACK_QUERY_*`→2 (never 1); invalid window→2.
+- [ ] 2.3 `bash scripts/test-all.sh` green (or the targeted `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exit 0).
+
+## Phase 3 — Enroll #6475 (automatable, no operator/SSH step)
+
+- [ ] 3.1 `gh issue edit 6475 --add-label follow-through`.
+- [ ] 3.2 Add directive to #6475 body (`gh issue edit 6475 --body …`, preserving existing body): `script=scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh earliest=<merge+7d UTC ISO> secrets=BETTERSTACK_QUERY_HOST,BETTERSTACK_QUERY_USERNAME,BETTERSTACK_QUERY_PASSWORD`.
+- [ ] 3.3 PR body uses **`Ref #6475`** (NOT `Closes`). Closure deferred to sweeper on soak PASS.
+
+## Phase 4 — Verify (post-merge, automatable)
+
+- [ ] 4.1 `gh workflow run scheduled-followthrough-sweeper.yml -f dry_run=true` — confirm #6475 directive parsed + probe executed (TRANSIENT before `earliest`).
+- [ ] 4.2 Discoverability (no SSH): `doppler run -p soleur -c prd_terraform -- scripts/betterstack-query.sh --since 7d --grep "Sentry POST failed"` returns rows-or-empty.
+
+## Acceptance Criteria — see plan §Acceptance Criteria (AC1–AC9, Pre-merge / Post-merge split)

--- a/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/tasks.md
@@ -15,8 +15,8 @@ Branch: `feat-one-shot-6475-ci-deploy-sentry-fail-loud`
 ## Phase 1 — Write the probe (RED then GREEN)
 
 - [ ] 1.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` mirroring `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack query + liveness gate + fail-safe TRANSIENT).
-- [ ] 1.2 Query = AND-scoped raw-SQL (UNION-ALL hot+archive) for `raw LIKE '%…ci-deploy%' AND raw LIKE '%Sentry POST failed%'` over `CI_DEPLOY_SENTRY_SOAK_WINDOW` (default `7d`). Empirically confirm the `SYSLOG_IDENTIFIER` field spelling in one real `raw` row before freezing the LIKE; else fall back to `--grep "Sentry POST failed"` + post-filter `grep ci-deploy`.
-- [ ] 1.3 Liveness gate: separate count of ANY `ci-deploy` rows in window. Zero → `exit 2` (TRANSIENT), never PASS.
+- [ ] 1.2 POST-failure query = mode-2 `betterstack-query.sh --since "$WINDOW" --grep "Sentry POST failed" --limit 1000` (auto-UNIONs hot+archive) THEN post-filter output `grep -c 'ci-deploy'` (precedent: `chardevice` `denied_count()`). Window = `CI_DEPLOY_SENTRY_SOAK_WINDOW` (default `7d`). Confirm the `ci-deploy` discriminator's substring form in one real Better Stack row before freezing the post-filter. (Raw-SQL mode-1 with two `LIKE`s is the documented alternative — if used, write the `s3Cluster` UNION yourself.)
+- [ ] 1.3 Liveness gate: separate `--grep "ci-deploy"` count of ANY ci-deploy rows in window. Zero → `exit 2` (TRANSIENT), never PASS.
 - [ ] 1.4 Exit map: zero POST-failure + liveness≥1 → `exit 0`; ≥1 POST-failure → `exit 1` (fail-loud, print offending `dt`/`raw`); query/auth/creds/no-liveness → `exit 2`.
 - [ ] 1.5 Guards: `set -uo pipefail`; NO `: "${VAR:?}"` — use `if [[ -z "${VAR:-}" ]]; then echo TRANSIENT >&2; exit 2; fi`. Honor a `<NAME>_BQ` override for the query-script path (test seam). Validate window `^[0-9]+[hmd]$`.
 - [ ] 1.6 `chmod +x`.

--- a/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6475-ci-deploy-sentry-fail-loud/tasks.md
@@ -6,31 +6,31 @@ Branch: `feat-one-shot-6475-ci-deploy-sentry-fail-loud`
 
 ## Phase 0 — Preconditions (verify, do not assume)
 
-- [ ] 0.1 `grep -n '|| logger -t "\$LOG_TAG"' apps/web-platform/infra/ci-deploy.sh` — expect 7 "Sentry POST failed" lines (437,517,541,609,635,666,1157); confirm `readonly LOG_TAG="ci-deploy"`.
-- [ ] 0.2 `grep -n '"ci-deploy"' apps/web-platform/infra/vector.toml` — expect it inside `host_scripts_journald` SYSLOG_IDENTIFIER allowlist (Source 4).
-- [ ] 0.3 `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 (HOST/USERNAME/PASSWORD already wired — no workflow edit).
-- [ ] 0.4 Read `scripts/betterstack-query.sh` mode-1 (raw SQL) branch + `$BS_TABLE`/`$BS_TABLE_S3` tokens (needed for AND-scoping; `--grep` is OR-only).
-- [ ] 0.5 Confirm `scripts/test-all.sh` discovers `scripts/followthroughs/*.test.sh`; confirm the `<NAME>_BQ` mock-override seam (per `hostname-mislabel-web1-6616.test.sh`).
+- [x] 0.1 `grep -n '|| logger -t "\$LOG_TAG"' apps/web-platform/infra/ci-deploy.sh` — expect 7 "Sentry POST failed" lines (437,517,541,609,635,666,1157); confirm `readonly LOG_TAG="ci-deploy"`.
+- [x] 0.2 `grep -n '"ci-deploy"' apps/web-platform/infra/vector.toml` — expect it inside `host_scripts_journald` SYSLOG_IDENTIFIER allowlist (Source 4).
+- [x] 0.3 `grep -c 'BETTERSTACK_QUERY_' .github/workflows/scheduled-followthrough-sweeper.yml` ≥ 3 (HOST/USERNAME/PASSWORD already wired — no workflow edit).
+- [x] 0.4 Read `scripts/betterstack-query.sh` mode-1 (raw SQL) branch + `$BS_TABLE`/`$BS_TABLE_S3` tokens (needed for AND-scoping; `--grep` is OR-only).
+- [x] 0.5 Confirm `scripts/test-all.sh` discovers `scripts/followthroughs/*.test.sh`; confirm the `<NAME>_BQ` mock-override seam (per `hostname-mislabel-web1-6616.test.sh`).
 
 ## Phase 1 — Write the probe (RED then GREEN)
 
-- [ ] 1.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` mirroring `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack query + liveness gate + fail-safe TRANSIENT).
-- [ ] 1.2 POST-failure query = mode-2 `betterstack-query.sh --since "$WINDOW" --grep "Sentry POST failed" --limit 1000` (auto-UNIONs hot+archive) THEN post-filter output `grep -c 'ci-deploy'` (precedent: `chardevice` `denied_count()`). Window = `CI_DEPLOY_SENTRY_SOAK_WINDOW` (default `7d`). Confirm the `ci-deploy` discriminator's substring form in one real Better Stack row before freezing the post-filter. (Raw-SQL mode-1 with two `LIKE`s is the documented alternative — if used, write the `s3Cluster` UNION yourself.)
-- [ ] 1.3 Liveness gate: separate `--grep "ci-deploy"` count of ANY ci-deploy rows in window. Zero → `exit 2` (TRANSIENT), never PASS.
-- [ ] 1.4 Exit map: zero POST-failure + liveness≥1 → `exit 0`; ≥1 POST-failure → `exit 1` (fail-loud, print offending `dt`/`raw`); query/auth/creds/no-liveness → `exit 2`.
-- [ ] 1.5 Guards: `set -uo pipefail`; NO `: "${VAR:?}"` — use `if [[ -z "${VAR:-}" ]]; then echo TRANSIENT >&2; exit 2; fi`. Honor a `<NAME>_BQ` override for the query-script path (test seam). Validate window `^[0-9]+[hmd]$`.
-- [ ] 1.6 `chmod +x`.
+- [x] 1.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` mirroring `chardevice-wedge-nonrecurrence-5934.sh` (Better Stack query + liveness gate + fail-safe TRANSIENT).
+- [x] 1.2 POST-failure query = mode-2 `betterstack-query.sh --since "$WINDOW" --grep "Sentry POST failed" --limit 1000` (auto-UNIONs hot+archive) THEN post-filter output `grep -c 'ci-deploy'` (precedent: `chardevice` `denied_count()`). Window = `CI_DEPLOY_SENTRY_SOAK_WINDOW` (default `7d`). Confirm the `ci-deploy` discriminator's substring form in one real Better Stack row before freezing the post-filter. (Raw-SQL mode-1 with two `LIKE`s is the documented alternative — if used, write the `s3Cluster` UNION yourself.)
+- [x] 1.3 Liveness gate: separate `--grep "ci-deploy"` count of ANY ci-deploy rows in window. Zero → `exit 2` (TRANSIENT), never PASS.
+- [x] 1.4 Exit map: zero POST-failure + liveness≥1 → `exit 0`; ≥1 POST-failure → `exit 1` (fail-loud, print offending `dt`/`raw`); query/auth/creds/no-liveness → `exit 2`.
+- [x] 1.5 Guards: `set -uo pipefail`; NO `: "${VAR:?}"` — use `if [[ -z "${VAR:-}" ]]; then echo TRANSIENT >&2; exit 2; fi`. Honor a `<NAME>_BQ` override for the query-script path (test seam). Validate window `^[0-9]+[hmd]$`.
+- [x] 1.6 `chmod +x`.
 
 ## Phase 2 — Probe unit tests
 
-- [ ] 2.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` (stub `betterstack-query.sh` via the `<NAME>_BQ` seam; JSONEachRow fixtures; no network/creds).
-- [ ] 2.2 Cases: POST-failure+liveness→1 (alarm, load-bearing); clean+liveness→0; zero-liveness→2; BQ non-zero→2; empty `BETTERSTACK_QUERY_*`→2 (never 1); invalid window→2.
-- [ ] 2.3 `bash scripts/test-all.sh` green (or the targeted `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exit 0).
+- [x] 2.1 Create `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` (stub `betterstack-query.sh` via the `<NAME>_BQ` seam; JSONEachRow fixtures; no network/creds).
+- [x] 2.2 Cases: POST-failure+liveness→1 (alarm, load-bearing); clean+liveness→0; zero-liveness→2; BQ non-zero→2; empty `BETTERSTACK_QUERY_*`→2 (never 1); invalid window→2.
+- [x] 2.3 `bash scripts/test-all.sh` green (or the targeted `bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh` exit 0).
 
 ## Phase 3 — Enroll #6475 (automatable, no operator/SSH step)
 
-- [ ] 3.1 `gh issue edit 6475 --add-label follow-through`.
-- [ ] 3.2 Add directive to #6475 body (`gh issue edit 6475 --body …`, preserving existing body): `script=scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh earliest=<merge+7d UTC ISO> secrets=BETTERSTACK_QUERY_HOST,BETTERSTACK_QUERY_USERNAME,BETTERSTACK_QUERY_PASSWORD`.
+- [x] 3.1 `gh issue edit 6475 --add-label follow-through`.
+- [x] 3.2 Add directive to #6475 body (`gh issue edit 6475 --body …`, preserving existing body): `script=scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh earliest=<merge+7d UTC ISO> secrets=BETTERSTACK_QUERY_HOST,BETTERSTACK_QUERY_USERNAME,BETTERSTACK_QUERY_PASSWORD`.
 - [ ] 3.3 PR body uses **`Ref #6475`** (NOT `Closes`). Closure deferred to sweeper on soak PASS.
 
 ## Phase 4 — Verify (post-merge, automatable)

--- a/scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh
+++ b/scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Follow-through soak for #6475 Item 2 (D-6): fail-loud on ci-deploy.sh Sentry
+# POST failures.
+#
+# WHAT IT PROVES. apps/web-platform/infra/ci-deploy.sh emits best-effort Sentry
+# events at seven fail-open sites (7 `logger … "Sentry POST failed"` lines across
+# the tags CRON_DRAIN, SANDBOX_CANARY, IMAGE_VERIFY, IMAGE_PULL [×2],
+# IMAGE_PULL_RECOVERY, ZOT_GATE). Each
+# POST is fail-OPEN — `curl … --max-time 10 || logger -t "$LOG_TAG" "<TAG>: Sentry
+# POST failed"` — which is CORRECT on-host behaviour (a deploy must never abort
+# because Sentry telemetry is unreachable). But it means the *failure of the alarm
+# path itself* is journald-only, and per hr-no-ssh-fallback-in-runbooks nobody
+# reads a host's journald — so a Sentry POST failure during a REAL fallback event
+# is silently unalarmed. D-6 closes that blind spot by making the signal LOUD:
+# actively queried on a schedule, surfaced onto #6475.
+#
+# The "Sentry POST failed" lines are tagged `logger -t "$LOG_TAG"` with
+# LOG_TAG="ci-deploy", and `ci-deploy` is already in vector.toml Source 4
+# (host_scripts_journald) SYSLOG_IDENTIFIER allowlist — so they already ship to
+# Better Stack Logs. What was missing is the active query + alarm; this probe is it.
+#
+# WHY Better Stack, not Sentry: a FAILED Sentry POST never arrives at Sentry, so a
+# Sentry *query* would PASS vacuously and auto-close #6475 blind (the exact #5934
+# trap). The only queryable sink for the POST-failure line is Better Stack
+# (journald → Vector). This probe queries Better Stack via
+# scripts/betterstack-query.sh and NEVER Sentry.
+#
+# SOUND signal = for the soak window: ci-deploy activity is observed
+# (liveness ≥ 1, proof the emit→Vector→Better Stack path is live and deploys ran)
+# AND zero "Sentry POST failed" lines from ci-deploy. Any such line in the window
+# is the fail-loud trigger.
+#
+# AND-scope to the ci-deploy SYSLOG_IDENTIFIER FIELD (load-bearing, not merely
+# defense-in-depth): a bare `ci-deploy` substring match is WRONG because inngest
+# ships GitHub-webhook processing logs to the same Better Stack source, and those
+# rows embed branch names ("…-ci-deploy-…") and issue/PR bodies that quote both
+# "Sentry POST failed" and "ci-deploy" verbatim (this tracker's own body does). Only
+# the journald SYSLOG_IDENTIFIER field (`SYSLOG_IDENTIFIER":"ci-deploy`) reliably
+# isolates real ci-deploy emissions from that webhook contamination — see the
+# CI_DEPLOY_*_MARKER constants below. (Aside: among host_scripts_journald tags only
+# ci-deploy emits "Sentry POST failed" via logger -t; the sibling
+# scripts/seccomp-unenforced-alert.sh emits the same string via a GitHub-Actions
+# `::warning::` echo, not logger -t, and is not in Source 4, so it never reaches
+# Better Stack.)
+#
+# FAIL-SAFE: any query/auth/config failure OR zero ci-deploy liveness → TRANSIENT
+# (exit 2), never PASS — the probe can only ever close #6475 on positive proof of
+# a live, clean window.
+#
+# Exit semantics (per sweep-followthroughs.sh contract):
+#   0 = PASS       (liveness ≥ 1 ci-deploy row AND zero POST-failure rows; sweeper closes #6475)
+#   1 = FAIL       (≥ 1 ci-deploy "Sentry POST failed" row; the D-6 alarm — sweeper comments #6475, leaves open)
+#   2 = TRANSIENT  (query unreachable/unauth, creds unset, OR zero ci-deploy liveness — inconclusive)
+#
+# Required env (read by betterstack-query.sh): BETTERSTACK_QUERY_HOST,
+#   BETTERSTACK_QUERY_USERNAME, BETTERSTACK_QUERY_PASSWORD (wired in
+#   scheduled-followthrough-sweeper.yml). Optional: CI_DEPLOY_SENTRY_SOAK_WINDOW
+#   (Nh/Nm/Nd, default 7d). Test seam: CI_DEPLOY_SENTRY_BQ overrides the
+#   betterstack-query.sh path.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BQ="${CI_DEPLOY_SENTRY_BQ:-$SCRIPT_DIR/../betterstack-query.sh}"
+
+WINDOW="${CI_DEPLOY_SENTRY_SOAK_WINDOW:-7d}"
+if ! [[ "$WINDOW" =~ ^[0-9]+[hmd]$ ]]; then
+  echo "TRANSIENT: invalid CI_DEPLOY_SENTRY_SOAK_WINDOW '$WINDOW' (expected Nh/Nm/Nd)" >&2
+  exit 2
+fi
+
+if [[ ! -x "$BQ" ]]; then
+  echo "TRANSIENT: betterstack-query.sh not found/executable at $BQ" >&2
+  exit 2
+fi
+
+# Creds-presence guard via an explicit empty-check, NOT a bash parameter-expansion
+# abort-gate — the abort form exits status 1 under the sweeper's non-interactive
+# shell (= FAIL = a loud alarm on a green codebase). Unset creds are inconclusive,
+# not a recurrence → TRANSIENT.
+if [[ -z "${BETTERSTACK_QUERY_HOST:-}" || -z "${BETTERSTACK_QUERY_USERNAME:-}" || -z "${BETTERSTACK_QUERY_PASSWORD:-}" ]]; then
+  echo "TRANSIENT: BETTERSTACK_QUERY_{HOST,USERNAME,PASSWORD} not all set — cannot query Better Stack; inconclusive" >&2
+  exit 2
+fi
+
+# The `ci-deploy` discriminator MUST isolate the journald SYSLOG_IDENTIFIER FIELD,
+# never a bare `ci-deploy` substring. Better Stack's `raw` column is the full
+# journald JSON, and inngest ships GitHub-webhook processing logs to the SAME source
+# — those embed branch names ("…-ci-deploy-…") and issue/PR bodies (which quote both
+# "Sentry POST failed" and "ci-deploy" verbatim, including THIS tracker's own body).
+# A bare-substring post-filter matched those and false-FAILed against live prod
+# (2 doppler-tagged webhook rows in a 14d window, SYSLOG_IDENTIFIER=doppler, zero
+# real ci-deploy emissions). Field isolation drops them. Two byte-forms are needed:
+#  - LIKE_MARKER: the SERVER-side --grep term. betterstack-query.sh runs it as
+#    `raw LIKE '%<term>%'` against the UNescaped ClickHouse column.
+#  - GREP_MARKER: the CLIENT-side grep over betterstack-query.sh's JSONEachRow STDOUT,
+#    where the inner quotes are backslash-escaped (`\"…\"`). Verified empirically
+#    against real rows: real emissions carry `SYSLOG_IDENTIFIER\":\"ci-deploy\"`;
+#    the webhook-contamination rows do not.
+readonly CI_DEPLOY_LIKE_MARKER='SYSLOG_IDENTIFIER":"ci-deploy'
+readonly CI_DEPLOY_GREP_MARKER='SYSLOG_IDENTIFIER\":\"ci-deploy\"'
+
+# fetch_rows <grep_term> — echo the raw JSONEachRow output for rows matching
+# <grep_term> in the window; return non-zero (caller → TRANSIENT) on any query
+# failure. Mode-2 `--grep` auto-UNION-ALLs the ~40-min hot window with the s3
+# archive, so a multi-day window is NOT silently truncated.
+fetch_rows() {
+  local term="$1" out rc
+  out="$("$BQ" --since "$WINDOW" --grep "$term" --limit 1000 2>/dev/null)"; rc=$?
+  [[ "$rc" -ne 0 ]] && return 1
+  printf '%s' "$out"
+  return 0
+}
+
+# POST-failure detection: fetch rows carrying the "Sentry POST failed" marker
+# (broad, server-side), then post-filter to the ci-deploy SYSLOG_IDENTIFIER FIELD.
+post_fail_rows="$(fetch_rows "Sentry POST failed")" || {
+  echo "TRANSIENT: Better Stack query failed (POST-failure marker) — auth/config/network" >&2; exit 2; }
+offending="$(printf '%s\n' "$post_fail_rows" | grep -F "$CI_DEPLOY_GREP_MARKER" || true)"
+post_fail_count="$(printf '%s\n' "$offending" | grep -c . || true)"
+
+# FAIL is evaluated BEFORE the liveness fetch so a real recurrence can never be
+# masked by a fault on the (separate) liveness query — a "Sentry POST failed" row
+# tagged ci-deploy is itself proof of activity, so FAIL is sound regardless of the
+# liveness count. This is the genuine "FAIL takes precedence" ordering.
+if [[ "$post_fail_count" -ge 1 ]]; then
+  echo "FAIL: ${post_fail_count} ci-deploy 'Sentry POST failed' event(s) in ${WINDOW} — a real fallback/degraded-state Sentry POST failed and the alarm path was silent on-host. The D-6 blind spot recurred; investigate the offending deploy(s):"
+  printf '%s\n' "$offending"
+  exit 1
+fi
+
+# Liveness: real ci-deploy rows (SYSLOG_IDENTIFIER field) in the window — proof the
+# emit→Vector→Better Stack path is live and deploys ran. Server-side --grep narrows
+# with the LIKE marker; the client count re-isolates on the escaped field marker so
+# a stray substring cannot inflate liveness. Zero → TRANSIENT, never PASS.
+liveness_rows="$(fetch_rows "$CI_DEPLOY_LIKE_MARKER")" || {
+  echo "TRANSIENT: Better Stack query failed (ci-deploy liveness) — auth/config/network" >&2; exit 2; }
+liveness_count="$(printf '%s\n' "$liveness_rows" | grep -cF "$CI_DEPLOY_GREP_MARKER" || true)"
+
+if [[ "$liveness_count" -eq 0 ]]; then
+  echo "TRANSIENT: no ci-deploy (SYSLOG_IDENTIFIER) rows in ${WINDOW} — the emit→Better Stack path is unobserved (no deploys in window, or delivery not live); inconclusive, never PASS" >&2
+  exit 2
+fi
+
+echo "PASS: ${liveness_count} ci-deploy row(s), zero 'Sentry POST failed' in ${WINDOW} — the ci-deploy Sentry-POST-failure rate holds at ~0 (D-6 #6475 soak clean)"
+exit 0

--- a/scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh
+++ b/scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Exit-code harness for ci-deploy-sentry-post-fail-6475.sh (#6475 Item 2 / D-6, AC5).
+#
+# The follow-through's exit code IS its authorization artifact (sweep-followthroughs.sh
+# closes #6475 on 0, comments+leaves-open on 1, retries on anything else). The cardinal
+# sin is a vacuous exit 0 that auto-closes #6475 while a Sentry POST failure is live, or
+# a spurious exit 1 that pages on a clean codebase. Every case here pins one arm of the
+# POST-failure / liveness / fail-safe decision tree.
+#
+# FIXTURE FIDELITY (load-bearing). Better Stack's `raw` column is the full journald
+# JSON, and betterstack-query.sh emits it via `FORMAT JSONEachRow`, so the inner quotes
+# arrive backslash-ESCAPED on stdout (`\"SYSLOG_IDENTIFIER\":\"ci-deploy\"`). The
+# fixtures below reproduce that exact escaped shape — an earlier bare-syslog fixture
+# (`<13>ci-deploy: …`) gave a false green while the SUT false-FAILed against live prod,
+# because inngest ships GitHub-webhook logs (SYSLOG_IDENTIFIER=doppler) to the same
+# source that embed both "Sentry POST failed" and "ci-deploy" (branch names / issue
+# bodies). Case 7 reproduces that contamination and pins the field-isolated fix.
+#
+# SEAM: the SUT reads its Better Stack rows from the query script named by
+# CI_DEPLOY_SENTRY_BQ. The mock below is FAITHFUL to betterstack-query.sh: server-side
+# it runs `raw LIKE '%term%'` against the UNescaped column, so the mock matches each
+# --grep term against a backslash-STRIPPED copy of the fixture line (approximating the
+# column) while emitting the ORIGINAL escaped line — exactly the real pipeline. It also
+# supports a per-term fault (3rd make_mock arg) to model one query faulting while the
+# other returns rows. No network, no creds.
+
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$HERE/ci-deploy-sentry-post-fail-6475.sh"
+fails=0
+pass() { printf '  PASS: %s\n' "$1"; }
+fail() { printf '  FAIL: %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+[[ -f "$SUT" ]] || { echo "FATAL: SUT not found at $SUT" >&2; exit 1; }
+[[ -x "$SUT" ]] || { echo "FATAL: SUT not executable at $SUT" >&2; exit 1; }
+
+# Creds present for every normal case (the SUT gates on their presence); the dedicated
+# "empty creds" case unsets them explicitly.
+export BETTERSTACK_QUERY_HOST=dummy-host
+export BETTERSTACK_QUERY_USERNAME=dummy-user
+export BETTERSTACK_QUERY_PASSWORD=dummy-pass
+
+WORK="$(mktemp -d)"
+trap 'rm -f "$MOCK" 2>/dev/null; rm -rf "$WORK" 2>/dev/null' EXIT
+MOCK="$WORK/mock-bq.sh"
+
+# make_mock <fixture-file> <exit-rc> [<fault-term>] — a betterstack-query.sh stand-in.
+# If <exit-rc> != 0 it faults for ALL calls (creds/query fault). Otherwise, if any
+# --grep term equals <fault-term> it exits 3 (per-term fault); else it emits the
+# fixture lines whose backslash-STRIPPED form contains ANY term (OR-combined, faithful
+# to `raw LIKE` on the unescaped column), verbatim (escaped).
+make_mock() {
+  local fixture="$1" rc="$2" fault_term="${3:-}"
+  cat > "$MOCK" <<MOCKEOF
+#!/usr/bin/env bash
+set -uo pipefail
+terms=()
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    --grep) terms+=("\$2"); shift 2 ;;
+    --since|--until|--limit|--table|--table-s3) shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ $rc -ne 0 ]]; then exit $rc; fi
+fault_term='$fault_term'
+if [[ -n "\$fault_term" ]]; then
+  for t in "\${terms[@]}"; do [[ "\$t" == "\$fault_term" ]] && exit 3; done
+fi
+if [[ \${#terms[@]} -eq 0 ]]; then cat "$fixture"; exit 0; fi
+while IFS= read -r line; do
+  probe="\${line//\\\\/}"   # strip backslashes -> approximates the unescaped column
+  for t in "\${terms[@]}"; do
+    if [[ "\$probe" == *"\$t"* ]]; then printf '%s\n' "\$line"; break; fi
+  done
+done < "$fixture"
+exit 0
+MOCKEOF
+  chmod 0755 "$MOCK"
+}
+
+# run_case <desc> <expected-rc> — assert the SUT exits expected-rc with the current MOCK.
+run_case() {
+  local desc="$1" expected="$2" rc=0 out
+  out="$(CI_DEPLOY_SENTRY_BQ="$MOCK" "$SUT" 2>&1)" || rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    pass "$desc (exit=$rc)"
+  else
+    fail "$desc — expected exit=$expected got exit=$rc :: ${out:0:220}"
+  fi
+}
+
+# Fixtures: synthesized JSONEachRow rows (cq-test-fixtures-synthesized-only) in the REAL
+# escaped `raw` shape betterstack-query.sh emits. A real ci-deploy emission carries the
+# top-level journald field `\"SYSLOG_IDENTIFIER\":\"ci-deploy\"`; webhook contamination
+# carries a different identifier (doppler) with the markers only in its message payload.
+
+# 1. FAIL (load-bearing alarm) — a real ci-deploy row (SYSLOG_IDENTIFIER field) carries
+#    "Sentry POST failed".
+cat > "$WORK/fx-fail.json" <<'EOF'
+{"dt":"2026-07-18T09:00:00Z","raw":"{\"SYSLOG_IDENTIFIER\":\"ci-deploy\",\"MESSAGE\":\"deploy start web-1\",\"host\":\"soleur-web-platform\"}"}
+{"dt":"2026-07-18T09:04:12Z","raw":"{\"SYSLOG_IDENTIFIER\":\"ci-deploy\",\"MESSAGE\":\"SANDBOX_CANARY: Sentry POST failed\",\"host\":\"soleur-web-platform\"}"}
+EOF
+make_mock "$WORK/fx-fail.json" 0
+run_case "real ci-deploy 'Sentry POST failed' + liveness -> FAIL (loud alarm)" 1
+
+# 2. PASS — real ci-deploy activity (field present), zero "Sentry POST failed".
+cat > "$WORK/fx-pass.json" <<'EOF'
+{"dt":"2026-07-18T09:00:00Z","raw":"{\"SYSLOG_IDENTIFIER\":\"ci-deploy\",\"MESSAGE\":\"deploy start web-1\",\"host\":\"soleur-web-platform\"}"}
+{"dt":"2026-07-18T09:05:00Z","raw":"{\"SYSLOG_IDENTIFIER\":\"ci-deploy\",\"MESSAGE\":\"deploy complete web-1\",\"host\":\"soleur-web-platform\"}"}
+EOF
+make_mock "$WORK/fx-pass.json" 0
+run_case "clean ci-deploy activity, no POST failure -> PASS" 0
+
+# 3. TRANSIENT — zero ci-deploy (field) rows entirely (source dark / no deploys).
+: > "$WORK/fx-zero.json"
+make_mock "$WORK/fx-zero.json" 0
+run_case "zero ci-deploy liveness (source dark) -> TRANSIENT (not vacuous PASS)" 2
+
+# 4. TRANSIENT — betterstack-query.sh non-zero (creds/query fault). Never PASS/FAIL.
+make_mock "$WORK/fx-pass.json" 3
+run_case "betterstack-query fault -> TRANSIENT" 2
+
+# 5. TRANSIENT — BETTERSTACK_QUERY_* unset. Must be exit 2, NEVER exit 1 (a `:?` gate
+#    would abort with status 1 = FAIL = false alarm on a green codebase).
+make_mock "$WORK/fx-pass.json" 0
+rc=0
+out="$(env -u BETTERSTACK_QUERY_HOST -u BETTERSTACK_QUERY_USERNAME -u BETTERSTACK_QUERY_PASSWORD \
+  CI_DEPLOY_SENTRY_BQ="$MOCK" "$SUT" 2>&1)" || rc=$?
+if [[ "$rc" -eq 2 ]]; then pass "unset BETTERSTACK_QUERY_* -> TRANSIENT (exit=$rc, never 1)"
+else fail "unset creds — expected exit=2 got exit=$rc :: ${out:0:200}"; fi
+
+# 6. TRANSIENT — invalid soak window (guard before any query).
+rc=0
+out="$(CI_DEPLOY_SENTRY_BQ="$MOCK" CI_DEPLOY_SENTRY_SOAK_WINDOW="bogus" "$SUT" 2>&1)" || rc=$?
+if [[ "$rc" -eq 2 ]]; then pass "invalid CI_DEPLOY_SENTRY_SOAK_WINDOW -> TRANSIENT (exit=$rc)"
+else fail "invalid window — expected exit=2 got exit=$rc :: ${out:0:200}"; fi
+
+# 7. PASS (contamination discriminator, LOAD-BEARING — reproduces the live false-FAIL).
+#    An inngest webhook row (SYSLOG_IDENTIFIER=doppler) embeds BOTH "Sentry POST failed"
+#    and "ci-deploy" (branch name + issue-body quote) in its message payload, but is NOT
+#    a real ci-deploy emission. The field-isolated post-filter drops it; ci-deploy
+#    liveness is otherwise clean -> PASS. Under the OLD bare-`grep ci-deploy` post-filter
+#    this arm FAILed (the defect this PR fixes).
+cat > "$WORK/fx-contamination.json" <<'EOF'
+{"dt":"2026-07-18T09:00:00Z","raw":"{\"SYSLOG_IDENTIFIER\":\"ci-deploy\",\"MESSAGE\":\"deploy complete web-1\",\"host\":\"soleur-web-platform\"}"}
+{"dt":"2026-07-18T09:10:00Z","raw":"{\"SYSLOG_IDENTIFIER\":\"doppler\",\"MESSAGE\":\"GitHub webhook push ref refs/heads/feat-one-shot-6475-ci-deploy-sentry-fail-loud quotes: logger -t ci-deploy <TAG>: Sentry POST failed\",\"host\":\"soleur-web-platform\"}"}
+EOF
+make_mock "$WORK/fx-contamination.json" 0
+run_case "webhook contamination (doppler tag embeds both markers) does NOT false-alarm -> PASS" 0
+
+# 8. TRANSIENT — the query script itself missing/non-executable.
+rc=0
+out="$(CI_DEPLOY_SENTRY_BQ="$WORK/does-not-exist.sh" "$SUT" 2>&1)" || rc=$?
+if [[ "$rc" -eq 2 ]]; then pass "missing/non-executable BQ -> TRANSIENT (exit=$rc)"
+else fail "missing BQ — expected exit=2 got exit=$rc :: ${out:0:200}"; fi
+
+# 9. FAIL-precedence (load-bearing) — a REAL POST-failure must fire exit 1 even when the
+#    (separate) liveness query would fault. The mock faults on the liveness term
+#    (SYSLOG_IDENTIFIER":"ci-deploy) but returns the fixture for "Sentry POST failed".
+#    Because the SUT evaluates FAIL BEFORE fetching liveness, a real recurrence is never
+#    masked into a TRANSIENT retry. A reorder (liveness fetch first) would exit 2 here.
+make_mock "$WORK/fx-fail.json" 0 'SYSLOG_IDENTIFIER":"ci-deploy'
+run_case "real FAIL not masked by a liveness-query fault -> FAIL (exit 1, not TRANSIENT)" 1
+
+if [[ "$fails" -gt 0 ]]; then
+  echo "FAILED: $fails case(s)" >&2
+  exit 1
+fi
+echo "OK: all ci-deploy-sentry-post-fail-6475 arms passed"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -151,6 +151,11 @@ if want_scripts; then
   # liveness, TRANSIENT-not-PASS). Registered explicitly (orphan-suite class above) — its exit code
   # gates whether the sweeper auto-closes #6616, so a vacuous PASS regression must redden CI.
   run_suite "scripts/hostname-mislabel-web1-6616" bash scripts/followthroughs/hostname-mislabel-web1-6616.test.sh
+  # #6475 (D-6): exit-code harness for the ci-deploy Sentry-POST-failure soak probe. Registered
+  # explicitly (orphan-suite class above) — its exit code gates whether the sweeper auto-closes
+  # #6475, and the probe's whole purpose is to be the fail-loud alarm, so a vacuous PASS (or a
+  # false FAIL that pages a green codebase) must redden CI here.
+  run_suite "scripts/ci-deploy-sentry-post-fail-6475" bash scripts/followthroughs/ci-deploy-sentry-post-fail-6475.test.sh
   # Inngest external-watchdog decision helpers (#6374/#6384/#6407). Registered here in #6407 —
   # these sourceable classifiers/gates were previously orphan suites (run only when invoked
   # manually), so a regression to the watchdog decision logic would have shipped with green CI.


### PR DESCRIPTION
## Summary

Implements item 2 (D-6) of #6475: make `ci-deploy.sh`'s fail-open Sentry POST failures **loud**. The eight fail-open emitters already `logger -t "ci-deploy" "<TAG>: Sentry POST failed"`, and `ci-deploy` is already in `vector.toml` Source 4 — so those lines already ship to Better Stack Logs. What was missing is the active query + alarm. This adds a Better Stack **soak follow-through** probe (`scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh`) enrolled on #6475, riding `scheduled-followthrough-sweeper.yml`:

- **FAIL (exit 1)** — a real ci-deploy `Sentry POST failed` row → the sweeper comments #6475 and leaves it open. This IS the D-6 alarm.
- **PASS (exit 0)** — ≥1 ci-deploy liveness row AND zero POST-failure rows → the sweeper resolves the tracker (item 1 already done, so a clean soak closes it out).
- **TRANSIENT (exit 2)** — any query/creds/liveness gap → retry, never a false close.

Queries **Better Stack, never Sentry** (a *failed* Sentry POST never reaches Sentry, so a Sentry query would PASS vacuously — the #5934 lesson). No on-host `ci-deploy.sh` change (the fail-open POST is deliberate), no new secret, no Terraform.

Ref #6475

Item 1 (schema-check the sibling cloud-init templates) was already completed and is checked off in the issue; this PR delivers the remaining D-6 item.

## Changelog

### Infra / observability
- Add `scripts/followthroughs/ci-deploy-sentry-post-fail-6475.sh` — a fail-loud Better Stack soak probe for ci-deploy Sentry POST failures, plus its exit-code test harness (9 arms).
- Register the harness in `scripts/test-all.sh` (orphan-suite class).
- Enroll #6475 as the follow-through tracker (`follow-through` label + `soleur:followthrough` directive; closure deferred to the sweeper on a clean soak PASS).
- Route a sharp-edge into `followthrough-convention.md` + a learning: Better Stack log-content probes must isolate the journald SYSLOG_IDENTIFIER field (not a bare substring) — the shared Vector source carries inngest webhook logs that quote arbitrary marker text.

## Test plan

- [x] 9-arm exit-code unit suite green (PASS / FAIL-alarm / TRANSIENT fail-safes / contamination-discriminator / FAIL-precedence).
- [x] `shellcheck` clean.
- [x] Both load-bearing arms (contamination post-filter, FAIL-precedence) mutation-proven non-vacuous.
- [x] Live end-to-end verification against prod Better Stack: probe returns **PASS** (569 real ci-deploy rows, 0 POST failures in 14d) — confirms the field-isolated discriminator drops webhook contamination and the sink is queryable with no SSH.
- [x] Enrollment verified: #6475 carries `follow-through` + a directive whose `script=` resolves on disk; the sweeper already exports the three `BETTERSTACK_QUERY_*` secrets.

Generated with [Claude Code](https://claude.com/claude-code)
