### PR TITLE
fix(db): wrap-tolerant verify/129 owner-binding assertion (unblocks deploy after #6663)

### DIFF
--- a/apps/web-platform/supabase/verify/129_rls_write_check_workspace_member.sql
+++ b/apps/web-platform/supabase/verify/129_rls_write_check_workspace_member.sql
@@ -14,11 +14,18 @@
 -- mechanism: a column-ACL denial and a WITH-CHECK denial are both SQLSTATE 42501,
 -- so the fuzz-green alone cannot attribute the denial to the WITH CHECK. Asserting
 -- `with_check ILIKE '%is_workspace_member%'` proves the mechanism directly. The
--- second clause asserts the literal `user_id = auth.uid()` owner-binding is
--- RETAINED (not replaced by the membership check) — it matches `%user_id =
--- auth.uid()%`, NOT a bare `%auth.uid()%` (which `is_workspace_member(workspace_id,
--- auth.uid())` would satisfy on its own, letting a dropped owner-binding false-green).
--- pg_policies.with_check deparses the predicate as `(user_id = auth.uid())`.
+-- second clause asserts the `user_id = <auth.uid()>` owner-binding is RETAINED
+-- (not replaced by the membership check) — it requires the `user_id = ` prefix,
+-- NOT a bare `%auth.uid()%` (which `is_workspace_member(workspace_id, …auth.uid()…)`
+-- would satisfy on its own, letting a dropped owner-binding false-green).
+--
+-- WRAP-TOLERANT (migration 134, auth_rls_initplan): migration 134 wrapped
+-- `auth.uid()` → `(select auth.uid())` for InitPlan hoisting, so pg_policies now
+-- deparses the owner-binding as `(user_id = ( SELECT auth.uid() AS uid))` instead
+-- of `(user_id = auth.uid())`. The regex `user_id = \(? *(select +)?auth.uid()`
+-- matches BOTH the wrapped and the pre-134 unwrapped form while still requiring the
+-- `user_id = ` owner-binding prefix (preserving the anti-false-green property). The
+-- `is_workspace_member` conjunct is verified live-present on prod post-134.
 
 -- (1) conversations UPDATE carries is_workspace_member + retains auth.uid()
 SELECT 'conversations_owner_update_with_check_member' AS check_name,
@@ -28,7 +35,7 @@ SELECT 'conversations_owner_update_with_check_member' AS check_name,
    AND policyname = 'conversations_owner_update'
    AND cmd = 'UPDATE'
    AND with_check ILIKE '%is_workspace_member%'
-   AND with_check ILIKE '%user_id = auth.uid()%'
+   AND with_check ~* 'user_id = \(? *(select +)?auth\.uid\(\)'
 UNION ALL
 -- (2) conversations INSERT carries is_workspace_member + retains auth.uid()
 SELECT 'conversations_owner_insert_with_check_member',
@@ -38,7 +45,7 @@ SELECT 'conversations_owner_insert_with_check_member',
    AND policyname = 'conversations_owner_insert'
    AND cmd = 'INSERT'
    AND with_check ILIKE '%is_workspace_member%'
-   AND with_check ILIKE '%user_id = auth.uid()%'
+   AND with_check ~* 'user_id = \(? *(select +)?auth\.uid\(\)'
 UNION ALL
 -- (3) kb_files UPDATE carries is_workspace_member + retains auth.uid()
 SELECT 'kb_files_owner_update_with_check_member',
@@ -48,4 +55,4 @@ SELECT 'kb_files_owner_update_with_check_member',
    AND policyname = 'kb_files_owner_update'
    AND cmd = 'UPDATE'
    AND with_check ILIKE '%is_workspace_member%'
-   AND with_check ILIKE '%user_id = auth.uid()%';
+   AND with_check ~* 'user_id = \(? *(select +)?auth\.uid\(\)';


### PR DESCRIPTION
## Why

PR #6663 (migration 134, auth_rls_initplan) wrapped `auth.uid()` → `(select auth.uid())` in the conversations/kb_files RLS `WITH CHECK` policies for InitPlan hoisting. `pg_policies` now deparses the owner-binding as `user_id = ( SELECT auth.uid() AS uid)`, so `verify/129`'s exact `ILIKE '%user_id = auth.uid()%'` no longer matched.

Post-merge, **`verify-migrations` FAILED** on the release run (migrate succeeded — 132/133/134 are live on prod — but `verify-migrations=failure` gated `deploy=skipped`). This blocks the deploy pipeline for **all** future releases until fixed.

The **`is_workspace_member` #6334 conjunct SURVIVED the wrap** — verified live-present on prod (`with_check` = `((user_id = ( SELECT auth.uid() AS uid)) AND is_workspace_member(workspace_id, ( SELECT auth.uid() AS uid)))`). Only the sentinel's spelling was stale.

## What

Replace the 3 owner-binding `ILIKE '%user_id = auth.uid()%'` assertions with a regex `user_id = \(? *(select +)?auth\.uid\(\)` that tolerates BOTH the wrapped and pre-134 unwrapped forms, while still requiring the `user_id = ` owner-binding prefix (anti-false-green property preserved — a dropped owner-binding still fails). The `is_workspace_member` clause is unchanged.

**Verified against live prod** (read-only): all 3 checks return `bad=0`.

## Test plan
- [x] Ran the full verify/129 query against live prod → 3/3 `bad=0`.
- [x] Regex matches wrapped (`user_id = ( SELECT auth.uid() AS uid)`) and unwrapped (`user_id = auth.uid()`) forms; requires the `user_id = ` prefix.

Ref #6663

🤖 Generated with [Claude Code](https://claude.com/claude-code)