### PR TITLE
fix(infra): terraform-free bash-SSH bridge (server-ip input) for LUKS cutover/verify

### DIFF
--- a/.github/actions/cf-tunnel-ssh-bridge/action.yml
+++ b/.github/actions/cf-tunnel-ssh-bridge/action.yml
@@ -60,11 +60,13 @@
 #    post-apply). The pull/decode steps fail loud if either is missing/empty.
 #
 # ── OUTPUTS (to $GITHUB_ENV, job-scoped, visible to the caller's later steps) ─
-#  SERVER_IP, CLOUDFLARED_PID, TF_VAR_ci_ssh_private_key,
-#  TUNNEL_SERVICE_TOKEN_ID, TUNNEL_SERVICE_TOKEN_SECRET.
-#  When `server-ip` is set, ALSO: CI_SSH_KEYFILE (chmod 600 temp key),
-#  WEB_HOST_SSH + GIT_DATA_SSH (ready `ssh -i <keyfile> … -l root` invocations the
-#  bash-ssh cutover/verify scripts consume via `${WEB_HOST_SSH:-ssh}`).
+#  Always: SERVER_IP, CLOUDFLARED_PID, TUNNEL_SERVICE_TOKEN_ID,
+#  TUNNEL_SERVICE_TOKEN_SECRET.
+#  When `server-ip` is EMPTY (terraform callers): TF_VAR_ci_ssh_private_key.
+#  When `server-ip` is SET (bash-ssh callers): CI_SSH_KEYFILE (chmod 600 temp key)
+#  + WEB_HOST_SSH + GIT_DATA_SSH (ready `ssh -i <keyfile> … -l root` invocations the
+#  cutover/verify scripts consume via `${WEB_HOST_SSH}`). The key form is
+#  mutually exclusive per caller class — the key never lands on an unused surface.
 #
 # Composite actions cannot read the `secrets` context — every secret is an
 # explicit input referenced ONLY inside `env:` mappings (never a `run:` body or
@@ -79,7 +81,7 @@ inputs:
     description: 'Doppler service token (prd_terraform, read-only). Caller forwards the DOPPLER_TOKEN repo secret.'
     required: true
   infra-dir:
-    description: 'Path to the terraform root (reads `terraform output -raw server_ip`). e.g. apps/web-platform/infra.'
+    description: 'Path to the terraform root; `terraform output -raw server_ip` is read from it ONLY when `server-ip` is empty. e.g. apps/web-platform/infra.'
     required: true
   cloudflared-version:
     description: 'cloudflared release version to install (e.g. 2026.5.0).'
@@ -163,19 +165,14 @@ runs:
         while IFS= read -r line; do
           [[ -n "$line" ]] && printf '::add-mask::%s\n' "$line"
         done <<< "$KEY"
-        {
-          echo "TF_VAR_ci_ssh_private_key<<__SOLEUR_CI_SSH_KEY_EOF__"
-          printf '%s\n' "$KEY"
-          echo "__SOLEUR_CI_SSH_KEY_EOF__"
-        } >> "$GITHUB_ENV"
-
-        # For bash-ssh callers (server-ip set — the LUKS cutover/verify
-        # workflows pipe a script over `${WEB_HOST_SSH:-ssh} "$HOST"`), ALSO
-        # write the key to a chmod 600 temp keyfile and export the ready ssh
-        # invocation. This block is INERT (nothing written or exported) when
-        # server-ip is empty, so terraform callers (apply-web-platform-infra.yml,
-        # which uses only TF_VAR_ci_ssh_private_key above) are byte-unchanged.
+        # The two caller classes are mutually exclusive and each gets ONLY the key
+        # form it uses — the key never lands on a surface its caller does not need:
         if [[ -n "${SERVER_IP_INPUT:-}" ]]; then
+          # bash-ssh callers (LUKS cutover/verify pipe a script over
+          # `${WEB_HOST_SSH} "$HOST"`): write the key to a chmod 600 temp keyfile
+          # and export the ready ssh invocation. NO TF_VAR — these callers run no
+          # terraform, so the key stays OFF $GITHUB_ENV (only the keyfile holds
+          # it, and the caller's if:always() teardown shreds that).
           KEYFILE=$(mktemp)
           chmod 600 "$KEYFILE"
           # Export the path BEFORE writing key bytes so the caller's if:always()
@@ -185,6 +182,15 @@ runs:
           SSH_INVOCATION="ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root"
           printf 'WEB_HOST_SSH=%s\n' "$SSH_INVOCATION" >> "$GITHUB_ENV"
           printf 'GIT_DATA_SSH=%s\n' "$SSH_INVOCATION" >> "$GITHUB_ENV"
+        else
+          # terraform callers (apply-web-platform-infra.yml): the Go SSH client
+          # authenticates with var.ci_ssh_private_key. Byte-identical to the
+          # pre-server-ip behavior (this heredoc was previously unconditional).
+          {
+            echo "TF_VAR_ci_ssh_private_key<<__SOLEUR_CI_SSH_KEY_EOF__"
+            printf '%s\n' "$KEY"
+            echo "__SOLEUR_CI_SSH_KEY_EOF__"
+          } >> "$GITHUB_ENV"
         fi
 
     - name: Start cloudflared SSH bridge + iptables NAT redirect

--- a/.github/actions/cf-tunnel-ssh-bridge/action.yml
+++ b/.github/actions/cf-tunnel-ssh-bridge/action.yml
@@ -38,16 +38,23 @@
 #       if [[ -n "${CLOUDFLARED_PID:-}" ]]; then
 #         kill "$CLOUDFLARED_PID" 2>/dev/null || true
 #       fi
-#       [[ -f /tmp/cloudflared.log ]] && tail -n 200 /tmp/cloudflared.log || true
+#       if [[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]]; then
+#         shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true
+#       fi
+#       if [[ -f /tmp/cloudflared.log ]]; then tail -n 200 /tmp/cloudflared.log || true; fi
 #
-# The `-n` guards are mandatory: SERVER_IP / CLOUDFLARED_PID are unset if the
-# bridge failed before exporting them (SpecFlow 1a). A left-over OUTPUT NAT rule
-# or orphaned cloudflared would corrupt a later job on a persistent runner (moot
-# on GH-hosted ephemeral runners, but the discipline is required).
+# The `-n` guards are mandatory: SERVER_IP / CLOUDFLARED_PID / CI_SSH_KEYFILE are
+# unset if the bridge failed before exporting them (SpecFlow 1a). A left-over
+# OUTPUT NAT rule, orphaned cloudflared, or on-disk CI keyfile would corrupt/leak
+# into a later job on a persistent runner (moot on GH-hosted ephemeral runners,
+# but the discipline is required). The `CI_SSH_KEYFILE` shred applies only to
+# `server-ip` (bash-ssh) callers; it is unset for terraform callers.
 #
 # ── PREREQUISITES ──────────────────────────────────────────────────────────
-#  - `terraform init` must have run in `infra-dir` BEFORE this action (the bridge
-#    reads `terraform output -raw server_ip` from the R2 state).
+#  - `terraform init` must have run in `infra-dir` BEFORE this action ONLY when
+#    the `server-ip` input is EMPTY (the bridge then reads `terraform output -raw
+#    server_ip` from the R2 state). When `server-ip` is supplied, no terraform is
+#    needed — the caller passes the address directly.
 #  - The CF Access ci_ssh service token + DEPLOY_SSH_PRIVATE_KEY must be present
 #    in Doppler prd_terraform (apply-web-platform-infra.yml auto-syncs both
 #    post-apply). The pull/decode steps fail loud if either is missing/empty.
@@ -55,6 +62,9 @@
 # ── OUTPUTS (to $GITHUB_ENV, job-scoped, visible to the caller's later steps) ─
 #  SERVER_IP, CLOUDFLARED_PID, TF_VAR_ci_ssh_private_key,
 #  TUNNEL_SERVICE_TOKEN_ID, TUNNEL_SERVICE_TOKEN_SECRET.
+#  When `server-ip` is set, ALSO: CI_SSH_KEYFILE (chmod 600 temp key),
+#  WEB_HOST_SSH + GIT_DATA_SSH (ready `ssh -i <keyfile> … -l root` invocations the
+#  bash-ssh cutover/verify scripts consume via `${WEB_HOST_SSH:-ssh}`).
 #
 # Composite actions cannot read the `secrets` context — every secret is an
 # explicit input referenced ONLY inside `env:` mappings (never a `run:` body or
@@ -77,6 +87,16 @@ inputs:
   cloudflared-sha256:
     description: 'SHA-256 of the cloudflared-linux-amd64 binary at cloudflared-version (recompute against the real binary — see header).'
     required: true
+  server-ip:
+    description: >-
+      Optional. The address the redirect scopes to AND (for bash-ssh callers) the
+      keyfile+WEB_HOST_SSH/GIT_DATA_SSH export is enabled by. When set, the bridge
+      skips `terraform output -raw server_ip` (no terraform needed) and writes the
+      CI key to a temp file + exports the ready ssh invocation the cutover scripts
+      consume. When empty (default), behavior is byte-identical to the pre-input
+      terraform path (apply-web-platform-infra.yml relies on this).
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -119,12 +139,13 @@ runs:
         printf 'TUNNEL_SERVICE_TOKEN_ID=%s\n' "$TOKEN_ID" >> "$GITHUB_ENV"
         printf 'TUNNEL_SERVICE_TOKEN_SECRET=%s\n' "$TOKEN_SECRET" >> "$GITHUB_ENV"
 
-    - name: Decode CI SSH private key into TF_VAR_ci_ssh_private_key
+    - name: Decode CI SSH private key (TF_VAR + optional keyfile/WEB_HOST_SSH export)
       shell: bash
       env:
         DOPPLER_TOKEN: ${{ inputs.doppler-token }}
         DOPPLER_PROJECT: soleur
         DOPPLER_CONFIG: prd_terraform
+        SERVER_IP_INPUT: ${{ inputs.server-ip }}
       # The bridge connection authenticates with var.ci_ssh_private_key
       # (agent = false in CI). The secret name (DEPLOY_SSH_PRIVATE_KEY) does NOT
       # map to the var name (ci_ssh_private_key) via --name-transformer tf-var,
@@ -148,6 +169,24 @@ runs:
           echo "__SOLEUR_CI_SSH_KEY_EOF__"
         } >> "$GITHUB_ENV"
 
+        # For bash-ssh callers (server-ip set — the LUKS cutover/verify
+        # workflows pipe a script over `${WEB_HOST_SSH:-ssh} "$HOST"`), ALSO
+        # write the key to a chmod 600 temp keyfile and export the ready ssh
+        # invocation. This block is INERT (nothing written or exported) when
+        # server-ip is empty, so terraform callers (apply-web-platform-infra.yml,
+        # which uses only TF_VAR_ci_ssh_private_key above) are byte-unchanged.
+        if [[ -n "${SERVER_IP_INPUT:-}" ]]; then
+          KEYFILE=$(mktemp)
+          chmod 600 "$KEYFILE"
+          # Export the path BEFORE writing key bytes so the caller's if:always()
+          # teardown can shred the file even if the write below is interrupted.
+          echo "CI_SSH_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"
+          printf '%s\n' "$KEY" > "$KEYFILE"
+          SSH_INVOCATION="ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root"
+          printf 'WEB_HOST_SSH=%s\n' "$SSH_INVOCATION" >> "$GITHUB_ENV"
+          printf 'GIT_DATA_SSH=%s\n' "$SSH_INVOCATION" >> "$GITHUB_ENV"
+        fi
+
     - name: Start cloudflared SSH bridge + iptables NAT redirect
       shell: bash
       working-directory: ${{ inputs.infra-dir }}
@@ -155,6 +194,7 @@ runs:
         DOPPLER_TOKEN: ${{ inputs.doppler-token }}
         DOPPLER_PROJECT: soleur
         DOPPLER_CONFIG: prd_terraform
+        SERVER_IP_INPUT: ${{ inputs.server-ip }}
       run: |
         set -euo pipefail
         # APP_DOMAIN_BASE is NOT in the prd_terraform config — fall back to the
@@ -162,9 +202,17 @@ runs:
         # use the bare form: it exits non-zero under `set -e` and kills the step
         # before cloudflared starts; #4829 post-merge hotfix #4840).
         APP_DOMAIN_BASE=$(doppler secrets get APP_DOMAIN_BASE --plain 2>/dev/null || echo "soleur.ai")
-        SERVER_IP=$(terraform output -raw server_ip)
+        # When server-ip is supplied (bash-ssh callers: the LUKS cutover/verify
+        # workflows), scope the NAT redirect to it directly — no terraform needed.
+        # When empty (terraform callers: apply-web-platform-infra.yml), read the
+        # public IP from state exactly as before. The empty-check + export below
+        # are COMMON to both paths (teardown needs SERVER_IP either way).
+        SERVER_IP="${SERVER_IP_INPUT:-}"
         if [[ -z "$SERVER_IP" ]]; then
-          echo "::error::terraform output server_ip is empty — state not populated; cannot scope the NAT redirect to the prod host."
+          SERVER_IP=$(terraform output -raw server_ip)
+        fi
+        if [[ -z "$SERVER_IP" ]]; then
+          echo "::error::server-ip input empty AND terraform output server_ip empty — cannot scope the NAT redirect to the prod host."
           exit 1
         fi
         printf '::add-mask::%s\n' "$SERVER_IP"

--- a/.github/workflows/workspaces-luks-cutover.yml
+++ b/.github/workflows/workspaces-luks-cutover.yml
@@ -48,6 +48,10 @@ env:
   INFRA_DIR: apps/web-platform/infra
   CLOUDFLARED_VERSION: "2026.5.0"
   CLOUDFLARED_SHA256: "0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec"
+  # web-1 private IP — single source for BOTH the bridge `server-ip` (NAT redirect
+  # scope) and the Run step `WEB_HOST` (dial target). They MUST match or the
+  # redirect misses the SSH; defining once removes that drift foot-gun.
+  WEB_HOST_PRIVATE_IP: "10.0.1.10"
 
 jobs:
   cutover:
@@ -93,18 +97,19 @@ jobs:
           infra-dir: ${{ env.INFRA_DIR }}
           cloudflared-version: ${{ env.CLOUDFLARED_VERSION }}
           cloudflared-sha256: ${{ env.CLOUDFLARED_SHA256 }}
-          # server-ip == WEB_HOST (10.0.1.10, web-1 private IP): scopes the NAT
-          # redirect to the same address the Run step SSHes to, and enables the
-          # keyfile + WEB_HOST_SSH export the Run step consumes. No infra-state
-          # read here — the tunnel ingress (tunnel.tf) always lands on web-1.
-          server-ip: "10.0.1.10"
+          # server-ip == WEB_HOST (web-1 private IP, single-sourced from
+          # env.WEB_HOST_PRIVATE_IP): scopes the NAT redirect to the same address
+          # the Run step SSHes to, and enables the keyfile + WEB_HOST_SSH export
+          # the Run step consumes. No infra-state read here — the tunnel ingress
+          # (tunnel.tf) always lands on web-1.
+          server-ip: ${{ env.WEB_HOST_PRIVATE_IP }}
 
       - name: Run workspaces-luks cutover
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
           ROLLBACK: ${{ inputs.rollback && '1' || '0' }}
-          WEB_HOST: "10.0.1.10"
+          WEB_HOST: ${{ env.WEB_HOST_PRIVATE_IP }}
         # The cutover body runs ON web-1 (DP-6 host-side trap): copy it over the bridge and execute
         # it there so `trap cleanup EXIT` survives an SSH drop. The script reads the passphrase via
         # the host's pinned prd_workspaces_luks token path; no cloud-admin creds touch the host.
@@ -119,8 +124,10 @@ jobs:
           # auth-fail confusingly. The bridge sets WEB_HOST_SSH when server-ip
           # is passed (it is, above).
           [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::CF Tunnel SSH bridge did not export WEB_HOST_SSH — cannot reach web-1. Check the bridge step logs."; exit 1; }
+          # WEB_HOST_SSH is guaranteed set past the guard above (no :-ssh fallback —
+          # a keyless bare ssh is exactly what the guard exists to prevent).
           # shellcheck disable=SC2086
-          ${WEB_HOST_SSH:-ssh} "$WEB_HOST" "sudo DRY_RUN='${DRY_RUN}' ROLLBACK='${ROLLBACK}' bash -s" \
+          ${WEB_HOST_SSH} "$WEB_HOST" "sudo DRY_RUN='${DRY_RUN}' ROLLBACK='${ROLLBACK}' bash -s" \
             < "${INFRA_DIR}/workspaces-cutover.sh"
           rc=$?
           if [[ $rc -ne 0 ]]; then

--- a/.github/workflows/workspaces-luks-cutover.yml
+++ b/.github/workflows/workspaces-luks-cutover.yml
@@ -93,6 +93,11 @@ jobs:
           infra-dir: ${{ env.INFRA_DIR }}
           cloudflared-version: ${{ env.CLOUDFLARED_VERSION }}
           cloudflared-sha256: ${{ env.CLOUDFLARED_SHA256 }}
+          # server-ip == WEB_HOST (10.0.1.10, web-1 private IP): scopes the NAT
+          # redirect to the same address the Run step SSHes to, and enables the
+          # keyfile + WEB_HOST_SSH export the Run step consumes. No infra-state
+          # read here — the tunnel ingress (tunnel.tf) always lands on web-1.
+          server-ip: "10.0.1.10"
 
       - name: Run workspaces-luks cutover
         env:
@@ -109,6 +114,11 @@ jobs:
           # before the guidance prints.
           set +e
           set -uo pipefail
+          # Fail loud if the bridge did not export WEB_HOST_SSH — a bare `ssh`
+          # fallback would connect keyless as the runner user and time out /
+          # auth-fail confusingly. The bridge sets WEB_HOST_SSH when server-ip
+          # is passed (it is, above).
+          [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::CF Tunnel SSH bridge did not export WEB_HOST_SSH — cannot reach web-1. Check the bridge step logs."; exit 1; }
           # shellcheck disable=SC2086
           ${WEB_HOST_SSH:-ssh} "$WEB_HOST" "sudo DRY_RUN='${DRY_RUN}' ROLLBACK='${ROLLBACK}' bash -s" \
             < "${INFRA_DIR}/workspaces-cutover.sh"
@@ -117,6 +127,23 @@ jobs:
             echo "::error::workspaces-luks cutover exited $rc — the host-side EXIT trap auto-rolled-back to the plaintext mount (DP-6). See the emitted Sentry event (feature=workspaces-luks op=workspaces-luks-drift)."
             exit $rc
           fi
+
+      - name: Tear down cloudflared SSH bridge
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ -n "${SERVER_IP:-}" ]]; then
+            sudo iptables -t nat -D OUTPUT -d "$SERVER_IP" -p tcp --dport 22 \
+              -j REDIRECT --to-ports 2222 2>/dev/null || true
+          fi
+          if [[ -n "${CLOUDFLARED_PID:-}" ]]; then
+            kill "$CLOUDFLARED_PID" 2>/dev/null || true
+          fi
+          if [[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]]; then
+            shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true
+          fi
+          if [[ -f /tmp/cloudflared.log ]]; then tail -n 200 /tmp/cloudflared.log || true; fi
 
       - name: Cutover summary
         if: always()

--- a/.github/workflows/workspaces-luks-verify.yml
+++ b/.github/workflows/workspaces-luks-verify.yml
@@ -28,6 +28,9 @@ env:
   INFRA_DIR: apps/web-platform/infra
   CLOUDFLARED_VERSION: "2026.5.0"
   CLOUDFLARED_SHA256: "0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec"
+  # web-1 private IP — single source for BOTH the bridge `server-ip` (NAT redirect
+  # scope) and the probe `WEB_HOST` (dial target); they MUST match.
+  WEB_HOST_PRIVATE_IP: "10.0.1.10"
 
 jobs:
   verify:
@@ -55,15 +58,15 @@ jobs:
           cloudflared-sha256: ${{ env.CLOUDFLARED_SHA256 }}
           # server-ip == WEB_HOST (10.0.1.10): scopes the NAT redirect to the
           # address the probe SSHes to + enables the WEB_HOST_SSH export. No
-          # infra-state read here.
-          server-ip: "10.0.1.10"
+          # infra-state read here. Single-sourced from env.WEB_HOST_PRIVATE_IP.
+          server-ip: ${{ env.WEB_HOST_PRIVATE_IP }}
 
       - name: Re-assert /workspaces LUKS at-rest (read-only)
         env:
           # The bridge exports WEB_HOST_SSH as the exact ssh invocation (key -i <keyfile> + the
           # iptables NAT redirect scoped to server-ip; no ProxyCommand — the Go/bash client dials
           # 10.0.1.10:22 which the kernel redirects to the local cloudflared forward).
-          WEB_HOST: "10.0.1.10"
+          WEB_HOST: ${{ env.WEB_HOST_PRIVATE_IP }}
         run: |
           # set +e so a failing probe is captured in probe_rc (and reported) rather than exiting the
           # step at the ssh line under GitHub's inherited `-e` (which `set -uo pipefail` does not clear).
@@ -73,8 +76,9 @@ jobs:
           [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::CF Tunnel SSH bridge did not export WEB_HOST_SSH — cannot reach web-1. Check the bridge step logs."; exit 1; }
           # Run the baked daily probe read-only (it mutates nothing) — DP-11 reuse. It emits its
           # own discriminating Sentry event on any failed assert and exits non-zero.
+          # WEB_HOST_SSH is guaranteed set past the guard above (no :-ssh fallback).
           # shellcheck disable=SC2086
-          ${WEB_HOST_SSH:-ssh} "$WEB_HOST" 'sudo /usr/local/bin/luks-monitor'
+          ${WEB_HOST_SSH} "$WEB_HOST" 'sudo /usr/local/bin/luks-monitor'
           probe_rc=$?
           echo "luks-monitor probe rc=$probe_rc"
           # App-level workspace read + /api/health, exercising the full HTTPS path.

--- a/.github/workflows/workspaces-luks-verify.yml
+++ b/.github/workflows/workspaces-luks-verify.yml
@@ -53,18 +53,27 @@ jobs:
           infra-dir: ${{ env.INFRA_DIR }}
           cloudflared-version: ${{ env.CLOUDFLARED_VERSION }}
           cloudflared-sha256: ${{ env.CLOUDFLARED_SHA256 }}
+          # server-ip == WEB_HOST (10.0.1.10): scopes the NAT redirect to the
+          # address the probe SSHes to + enables the WEB_HOST_SSH export. No
+          # infra-state read here.
+          server-ip: "10.0.1.10"
 
       - name: Re-assert /workspaces LUKS at-rest (read-only)
         env:
-          # The bridge exports WEB_HOST_SSH as the exact ssh invocation (key + ProxyCommand).
+          # The bridge exports WEB_HOST_SSH as the exact ssh invocation (key -i <keyfile> + the
+          # iptables NAT redirect scoped to server-ip; no ProxyCommand — the Go/bash client dials
+          # 10.0.1.10:22 which the kernel redirects to the local cloudflared forward).
           WEB_HOST: "10.0.1.10"
         run: |
           # set +e so a failing probe is captured in probe_rc (and reported) rather than exiting the
           # step at the ssh line under GitHub's inherited `-e` (which `set -uo pipefail` does not clear).
           set +e
           set -uo pipefail
+          # Fail loud if the bridge did not export WEB_HOST_SSH (bare ssh would connect keyless).
+          [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::CF Tunnel SSH bridge did not export WEB_HOST_SSH — cannot reach web-1. Check the bridge step logs."; exit 1; }
           # Run the baked daily probe read-only (it mutates nothing) — DP-11 reuse. It emits its
           # own discriminating Sentry event on any failed assert and exits non-zero.
+          # shellcheck disable=SC2086
           ${WEB_HOST_SSH:-ssh} "$WEB_HOST" 'sudo /usr/local/bin/luks-monitor'
           probe_rc=$?
           echo "luks-monitor probe rc=$probe_rc"
@@ -80,6 +89,23 @@ jobs:
             exit 1
           fi
           echo "workspaces-luks at-rest re-assert PASSED (blkid=crypto_LUKS, mapper mount, escrow ok, /api/health 200)."
+
+      - name: Tear down cloudflared SSH bridge
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ -n "${SERVER_IP:-}" ]]; then
+            sudo iptables -t nat -D OUTPUT -d "$SERVER_IP" -p tcp --dport 22 \
+              -j REDIRECT --to-ports 2222 2>/dev/null || true
+          fi
+          if [[ -n "${CLOUDFLARED_PID:-}" ]]; then
+            kill "$CLOUDFLARED_PID" 2>/dev/null || true
+          fi
+          if [[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]]; then
+            shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true
+          fi
+          if [[ -f /tmp/cloudflared.log ]]; then tail -n 200 /tmp/cloudflared.log || true; fi
 
       - name: Verify summary
         if: always()

--- a/knowledge-base/project/learnings/2026-07-18-shared-action-false-export-contract-and-never-run-workflow-sequential-walls.md
+++ b/knowledge-base/project/learnings/2026-07-18-shared-action-false-export-contract-and-never-run-workflow-sequential-walls.md
@@ -1,0 +1,85 @@
+---
+title: "A shared action's contract comments claimed exports it never produced; a never-run workflow reveals bring-up walls one at a time"
+date: 2026-07-18
+category: integration-issues
+tags: [github-actions, composite-action, ssh, cf-tunnel, cutover, workspaces-luks, never-run-workflow, false-contract]
+module: Web Platform Infrastructure
+issue: 6649
+---
+
+# Shared-action false export-contract + never-run-workflow sequential walls
+
+## Problem
+
+Completing the #6649 LUKS-header escrow dry-run rehearsal meant bringing up the
+`workspaces-luks-cutover.yml` workflow, which had been **authored but never run
+end-to-end** (`Total runs 0`). Each fix revealed the next wall:
+
+1. **Wall 1** (prior PR #6679): the `CF Tunnel SSH bridge` step was skipped on
+   `dry_run=true` (an `if:` guard), so the SSH to web-1 timed out.
+2. **Wall 2**: the bridge called `terraform output -raw server_ip` but the
+   cutover workflow never installed terraform → `terraform: command not found`
+   (exit 127).
+3. **Wall 3**: the bridge action **never exported `WEB_HOST_SSH`** and never
+   wrote an SSH keyfile — yet **five comments** across `git-data-cutover.yml`,
+   `workspaces-luks-verify.yml`, and `git-data-cutover.sh` asserted "the bridge
+   exports WEB_HOST_SSH/GIT_DATA_SSH as the exact ssh invocation." The cutover
+   scripts consumed `${WEB_HOST_SSH:-ssh}`, so the unset var **silently degraded
+   to a keyless bare `ssh`** as the runner user — which would fail auth
+   confusingly rather than loudly.
+
+## Key insights
+
+### 1. A shared action's contract comments are aspirational until the code proves them.
+The `cf-tunnel-ssh-bridge` action was extracted (PR #4845) as **terraform-only**
+(exports `TF_VAR_ci_ssh_private_key` for terraform's Go SSH client). The
+bash-ssh callers were added later and their comments described a `WEB_HOST_SSH`
+export that the action **never actually made**. The `${WEB_HOST_SSH:-ssh}`
+fallback masked the gap: no error, just a wrong (keyless) connection. **When a
+caller reads `${X:-default}` for a value a shared action is *supposed* to
+export, grep the action for the actual `>> "$GITHUB_ENV"` write — a fallback is
+where a never-satisfied contract hides.** The fix here made the export real
+(gated on a new `server-ip` input) AND dropped the `:-ssh` fallback so a missing
+export fails loud.
+
+### 2. A never-run workflow reveals bring-up walls sequentially — budget for the chain, not the first error.
+`terraform: command not found` was only the *first observable* failure once the
+bridge ran. Behind it: no server_ip source without terraform, then no keyfile,
+then a public-vs-private-IP redirect mismatch. Fixing one exposes the next. For
+a workflow with `Total runs 0`, treat the first green-to-red transition as the
+start of a chain and trace the full path (here: read the working reference
+`apply-web-platform-infra.yml`'s entire bridge preamble) before estimating scope.
+
+### 3. Backward-compat for a shared action = a gated, default-inert new path.
+The fix added an optional `server-ip` input. When empty (the terraform callers,
+incl. the critical `apply-web-platform-infra.yml`), the terraform-output read +
+`TF_VAR` export run exactly as before (byte-equivalent diff on that file); when
+set, the terraform read is skipped and a keyfile + `WEB_HOST_SSH` export replace
+it. Gating BOTH the new key form AND the old one into a mutually-exclusive
+`if/else` keeps the private key off `$GITHUB_ENV` for the caller class that
+doesn't need it (security-sentinel P3).
+
+### 4. server-ip == the-host-the-script-dials is the load-bearing invariant.
+The iptables `-d "$SERVER_IP"` NAT redirect must scope to the SAME address the
+Run step SSHes to (both `10.0.1.10`), or the redirect misses the SSH. The tunnel
+ingress (`tunnel.tf`) always lands on web-1 regardless of the dialed IP, so the
+private IP works and needs no terraform. Single-source the literal (one env var)
+so the two sites can't drift (architecture P3).
+
+## Session errors (secondary)
+
+- **SC2015 in copied teardown.** `[[ -f log ]] && tail … || true` (A && B || C)
+  trips actionlint's shellcheck. Fixed to `if [[ -f log ]]; then tail … || true;
+  fi` in both workflows AND the action-header exemplar callers copy. **Prevention:**
+  when copying a teardown block from a contract comment, run actionlint on the
+  result; fix the exemplar too so the next caller copies the clean form.
+- **A bare-token AC grep (`grep -c terraform = 0`) tripped on my explanatory
+  comment** containing the word "terraform." Reworded the comments. **Prevention:**
+  a bare-token verification grep and prose that names the token collide — either
+  anchor the AC on the syntactic construct (`hashicorp/setup-terraform`,
+  `terraform output`) or keep the token out of comments (`cq-assert-anchor-not-bare-token`).
+
+## Related
+
+- Sequel to `2026-07-18-cutover-bridge-dryrun-guard-and-workflow-step-vs-in-script-ssh.md` (wall 1 + workflow-step-vs-in-script SSH).
+- git-data-cutover's second-host (10.0.1.20) reach is a separate tunnel-ingress gap: #6680.

--- a/knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
@@ -31,18 +31,27 @@ The three walls (all verified this session):
    `outputs.tf:3`), but the cutover Run step dials the **private** IP (`WEB_HOST: "10.0.1.10"`,
    cutover `:102`). The redirect never catches the SSH.
 3. **`WEB_HOST_SSH` never set.** The bridge never exports `WEB_HOST_SSH`/`GIT_DATA_SSH` and never
-   writes an SSH keyfile (five comments falsely claim it does — action header `:55-57`, verify `:59`,
-   git-data `:12-13`, `:109`). Bare `ssh "$WEB_HOST"` has no `-i` key and no `root@` user, so it
-   would fail even if the redirect caught it.
+   writes an SSH keyfile. Bare `ssh "$WEB_HOST"` has no `-i` key and no `root@` user, so it would
+   fail even if the redirect caught it. Several comments already *anticipate* the exports as if they
+   existed — the action header OUTPUTS block (`:55-57`) omits them, `verify.yml:59` wrongly says the
+   mechanism is "key + ProxyCommand" (it is key + NAT redirect), and `git-data-cutover.yml:12-13,109`
+   describe `GIT_DATA_SSH`/`WEB_HOST_SSH` exports that do not yet exist. This change makes the
+   git-data comments *true by code* (no edit to that out-of-scope file) and corrects the two genuinely
+   false statements (action header + verify `:59`) by text edit — see AC12.
 
 **Why the private-IP path works (design decision — see Research Reconciliation).** The iptables
 `-d` scope is only a *runner-side hijack filter*: whatever destination it matches is redirected
 pre-egress to `127.0.0.1:2222`, which cloudflared forwards over the tunnel to the ingress rule
 `ssh.${app_domain_base}` → `ssh://${web_hosts["web-1"].private_ip}:22` = `ssh://10.0.1.10:22`
 (`tunnel.tf:69-72`, `variables.tf:110`). So scoping `-d 10.0.1.10` catches the cutover's
-`ssh 10.0.1.10`, redirects it before egress (the private IP need not be routable from the runner),
-and the tunnel always lands on web-1. This makes `server-ip == WEB_HOST == 10.0.1.10` internally
-consistent and **eliminates terraform entirely** from the cutover/verify path.
+`ssh 10.0.1.10`: the kernel's output-route lookup on `10.0.1.10` resolves via the default route
+(`0.0.0.0/0`) present on GH-hosted `ubuntu-24.04` runners, a packet is produced, and the `nat OUTPUT`
+REDIRECT rewrites its destination to loopback **pre-egress** so it never reaches the private subnet.
+(Precise wording per Kieran review: the private IP needs a *resolvable* route — the default route
+suffices — not a route *to* the subnet; a `connect()` with no resolvable route would fail
+`ENETUNREACH` before REDIRECT runs.) The tunnel then always lands on web-1. This makes
+`server-ip == WEB_HOST == 10.0.1.10` internally consistent and **eliminates terraform entirely**
+from the cutover/verify path.
 
 ## Research Reconciliation — Spec vs. Codebase
 
@@ -50,7 +59,7 @@ consistent and **eliminates terraform entirely** from the cutover/verify path.
 | --- | --- | --- |
 | Bridge exits 127 (`terraform: command not found`) | Confirmed: cutover/verify install no terraform; action.yml:165 calls `terraform output` | Add optional `server-ip`; when set, skip `terraform output` verbatim |
 | Redirect scopes public IP; Run step dials private `10.0.1.10` | Confirmed: outputs.tf:3 = public `ipv4_address`; cutover:102 `WEB_HOST: "10.0.1.10"` | Pass `server-ip: "10.0.1.10"` = WEB_HOST → redirect scope matches the dialed IP |
-| Bridge never exports `WEB_HOST_SSH`, no keyfile; 5 false comments | Confirmed: action.yml exports only SERVER_IP/CLOUDFLARED_PID/TF_VAR_ci_ssh_private_key/TUNNEL_SERVICE_TOKEN_* (`:55-57`); verify:59 falsely says "key + ProxyCommand" | Write DEPLOY_SSH_PRIVATE_KEY to chmod-600 keyfile; export `WEB_HOST_SSH`/`GIT_DATA_SSH`/`CI_SSH_KEYFILE`; correct the comments |
+| Bridge never exports `WEB_HOST_SSH`, no keyfile; comments falsely/aspirationally claim it | Confirmed: action.yml exports only SERVER_IP/CLOUDFLARED_PID/TF_VAR_ci_ssh_private_key/TUNNEL_SERVICE_TOKEN_* (`:55-57`); verify:59 falsely says "key + ProxyCommand"; git-data:12-13,109 aspirationally reference the exports | On the gated `server-ip` path: write DEPLOY_SSH_PRIVATE_KEY to chmod-600 keyfile; export `WEB_HOST_SSH`/`GIT_DATA_SSH`/`CI_SSH_KEYFILE`. Correct action.yml + verify.yml comments by text edit; git-data comments become true by code (not edited — AC7) |
 | DEPLOY_SSH_PRIVATE_KEY authenticates as root@web-1 | Confirmed: ci-ssh-key.tf — DEPLOY_SSH_PRIVATE_KEY = `tls_private_key.ci_ssh`; public half appended to root's authorized_keys; server.tf connections use `user="root"` | `WEB_HOST_SSH = ssh -i <keyfile> … -l root` |
 | RECOMMENDED: use private IP `10.0.1.10` for both, avoid terraform | Confirmed against tunnel.tf:69-72 (origin-relative `ssh://10.0.1.10:22`, ADR-114 I2) + variables.tf:110 (`private_ip = "10.0.1.10"`) + model.c4:380 | **ADOPTED — private-10.0.1.10-consistent.** No public-IP-via-Doppler fallback needed |
 | Tunnel might need the **public** IP as redirect target | FALSE — tunnel.tf:66-68 ("the runner still dials the public SERVER_IP" is the *apply* path only); the tunnel host-side always delivers to web-1 private:22 regardless of the `-d` scope | Fallback (public-IP-via-Doppler) NOT needed; documented as rejected alternative |
@@ -70,10 +79,12 @@ LUKS-at-rest cutover remains un-rehearsed. `dry_run=true` performs **no freeze a
 (the escrow probe runs before the `DRY_RUN != 1` gate; workspaces-cutover.sh), so no sole-copy user
 data is touched by this change.
 **If this leaks, the user's data is exposed via:** the CI SSH private key. It is already in Doppler
-`prd_terraform` and already loaded into `$GITHUB_ENV` (`TF_VAR_ci_ssh_private_key`) by the action;
-this change additionally writes it to a **chmod-600** tempfile that the `if: always()` teardown
-**shreds**, and every key line is `::add-mask::`ed (existing decode step). No new exposure surface
-beyond the already-handled key.
+`prd_terraform` and already loaded into `$GITHUB_ENV` (`TF_VAR_ci_ssh_private_key`) by the action.
+On the `server-ip` path **only** (cutover + verify — the gated block), this change additionally
+writes it to a **chmod-600** tempfile; both of those workflows add an `if: always()` teardown that
+**shreds** it, so the keyfile is shredded on every path that creates it (the terraform callers never
+create it — gated off). Every key line is `::add-mask::`ed (existing decode step). No new exposure
+surface beyond the already-handled key; both runners are ephemeral `ubuntu-24.04`.
 **Brand-survival threshold:** none — reason: this change only brings up the SSH bridge for the
 non-mutating `dry_run=true` rehearsal + the read-only verify workflow; the destructive freeze is a
 separate, environment-gated dispatch that this PR does not run. (Scope-out bullet for the
@@ -85,46 +96,75 @@ mutation in this change`.)
 - `.github/actions/cf-tunnel-ssh-bridge/action.yml`
   - Add **optional** input `server-ip` (`required: false`, default `''`).
   - In the "Start cloudflared SSH bridge + iptables NAT redirect" step: add
-    `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to `env:`; replace the bare
-    `SERVER_IP=$(terraform output -raw server_ip)` with a guard — **use `$SERVER_IP_INPUT` when
-    non-empty, otherwise keep the `terraform output -raw server_ip` path verbatim** (including the
-    empty-check + `::error::`). The terraform branch must remain byte-identical for callers that do
-    not pass `server-ip`.
-  - In the "Decode CI SSH private key into TF_VAR_ci_ssh_private_key" step (where `$KEY` is in
-    scope): after the existing heredoc write, **also** write `$KEY` to a chmod-600 keyfile
-    (`KEYFILE=$(mktemp); chmod 600 "$KEYFILE"; printf '%s\n' "$KEY" > "$KEYFILE"`) and export to
-    `$GITHUB_ENV`: `CI_SSH_KEYFILE=$KEYFILE`, and both
-    `WEB_HOST_SSH` and `GIT_DATA_SSH` = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
-    These additions are **inert** for terraform callers (unused env + unused file). Broaden the
-    step name to reflect the added keyfile/export.
-  - Correct the five false comments (action header OUTPUTS/PREREQUISITES `:48-57`, and the caller
-    comments) to state reality: the bridge now writes an SSH keyfile and exports
-    `WEB_HOST_SSH`/`GIT_DATA_SSH`; the mechanism is **key + iptables NAT redirect (NOT a
-    ProxyCommand)**; `terraform init` is required **only** when `server-ip` is unset.
+    `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to `env:`; guard **only** the terraform-output
+    assignment — `SERVER_IP="${SERVER_IP_INPUT:-}"; if [[ -z "$SERVER_IP" ]]; then SERVER_IP=$(terraform output -raw server_ip); fi`.
+    **The empty-check + `::error::`, the `::add-mask::`, and the `SERVER_IP=… >> $GITHUB_ENV` export
+    stay COMMON to both branches** (spec-flow Gap6 / Kieran) — teardown's NAT-delete reads
+    `$SERVER_IP`, so it must be exported on the `server-ip` path too. The terraform branch remains
+    byte-identical for callers that do not pass `server-ip`.
+  - In the "Decode CI SSH private key…" step (where `$KEY` is in scope): **gate the entire keyfile +
+    export block on `[[ -n "$SERVER_IP_INPUT" ]]`** (add `SERVER_IP_INPUT: ${{ inputs.server-ip }}`
+    to this step's `env:`). Inside the guard, in this order (spec-flow Gap4 — export the path BEFORE
+    writing key bytes so a mid-step failure still lets teardown find it):
+    `KEYFILE=$(mktemp); chmod 600 "$KEYFILE"; echo "CI_SSH_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"; printf '%s\n' "$KEY" > "$KEYFILE"`,
+    then export both `WEB_HOST_SSH` and `GIT_DATA_SSH` = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
+    **Why gated (keystone decision — dissolves 5 review findings):** the presence of `server-ip` *is*
+    the "this caller bash-SSHes" signal. Gating means the terraform callers (apply / pipeline-fix /
+    git-data — none pass `server-ip`) get **no keyfile written at all** → genuinely inert (not merely
+    unused), the uniform-shred claim becomes true (only `server-ip` callers write it, and only they
+    add the shred teardown), AC6/AC7 preserved, and no runtime behavior of `git-data-cutover.yml`
+    changes. `GIT_DATA_SSH` is **kept** (task-directed AND actually consumed by
+    `git-data-cutover.sh:82-83,109` — the "drop it" review suggestion was refuted); it simply is not
+    materialized until #6680 gives git-data a `server-ip`. Broaden the step name to reflect the added
+    keyfile/export.
+  - Correct the genuinely-false comments (action header OUTPUTS/PREREQUISITES `:48-57`) to state
+    reality: on the `server-ip` path the bridge writes an SSH keyfile and exports
+    `WEB_HOST_SSH`/`GIT_DATA_SSH`/`CI_SSH_KEYFILE`; the mechanism is **key + iptables NAT redirect
+    (NOT a ProxyCommand)**; `terraform init` is required **only** when `server-ip` is unset. **Also
+    extend the CALLER-SIDE TEARDOWN CONTRACT block (`:23-46`)** (arch Finding A) to document that a
+    `server-ip` caller must additionally `shred -u "$CI_SSH_KEYFILE"` in its `if: always()` teardown,
+    so the shared contract matches the action's real outputs for future callers.
 - `.github/workflows/workspaces-luks-cutover.yml`
   - Pass `server-ip: "10.0.1.10"` to the `CF Tunnel SSH bridge` step (matches the Run step's
     `WEB_HOST: "10.0.1.10"`).
+  - In the "Run workspaces-luks cutover" step, replace the silent `${WEB_HOST_SSH:-ssh}` fallback
+    with a fail-loud guard before the ssh call (spec-flow Gap2 / `cq-silent-fallback`):
+    `[[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::bridge did not export WEB_HOST_SSH"; exit 1; }`
+    then dial `$WEB_HOST_SSH "$WEB_HOST" …`. Keep the existing `# shellcheck disable=SC2086` above
+    the unquoted expansion (word-splitting is intentional).
   - Add an `if: always()` teardown step **after** "Run workspaces-luks cutover": delete the NAT
     rule scoped to `$SERVER_IP`, kill `$CLOUDFLARED_PID`, **shred `$CI_SSH_KEYFILE`**, and dump
-    `/tmp/cloudflared.log` — all `-n`/`-f` guarded (modeled on `apply-web-platform-infra.yml:801-823`).
+    `/tmp/cloudflared.log`. Use **`set +e` only (NO `set -u`)** — modeled on
+    `apply-web-platform-infra.yml:801-823` — with the shred arm guarded
+    `[[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]] && shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true`
+    (spec-flow Gap5), and the NAT/PID arms `-n`-guarded on `${SERVER_IP:-}`/`${CLOUDFLARED_PID:-}`.
 - `.github/workflows/workspaces-luks-verify.yml`
   - Identical bridge treatment: pass `server-ip: "10.0.1.10"`; add the same `if: always()`
-    teardown (NAT delete + cloudflared kill + shred keyfile + log dump). Fix the `:59` comment
-    ("key + ProxyCommand" → "key + iptables NAT redirect").
+    teardown (`set +e` only, NAT delete + cloudflared kill + shred keyfile + log dump); add the same
+    `WEB_HOST_SSH` fail-loud guard before the probe ssh.
+  - **Add `# shellcheck disable=SC2086` above the `${WEB_HOST_SSH:-ssh}` line (`:68`)** — HIGH
+    (Kieran): unlike cutover `:112`, verify has no disable, so actionlint/shellcheck fires SC2086 on
+    the now-multi-word expansion and AC8 fails without it.
+  - Fix the `:59` comment ("key + ProxyCommand" → "key + iptables NAT redirect").
 
 ## Files NOT to edit (assert unchanged)
 
 - `.github/workflows/apply-web-platform-infra.yml` — critical path. It calls the bridge **without**
-  `server-ip` (`:649-656`), so the optional input defaults empty → the terraform path runs verbatim.
-  The keyfile-write + `WEB_HOST_SSH`/`GIT_DATA_SSH` export are inert (terraform's Go SSH client uses
-  `TF_VAR_ci_ssh_private_key` + the NAT redirect, not these env vars). **AC: `git diff origin/main`
-  on this file is empty.**
-- `.github/workflows/git-data-cutover.yml` — untouched (#6680). It also calls the bridge without
-  `server-ip` (terraform path) and dials `10.0.1.20`; the bridge additions newly export
-  `WEB_HOST_SSH`/`GIT_DATA_SSH` for it, but its 10.0.1.20 host has no tunnel ingress and no NAT
-  redirect, so #6680 remains exactly as-is — this change neither fixes nor breaks it.
+  `server-ip` (`:649-656`), so the optional input defaults empty → the terraform path runs verbatim
+  AND the keyfile/export block is **gated off** (nothing written, nothing exported — genuinely inert,
+  not merely unused). Terraform's Go SSH client uses `TF_VAR_ci_ssh_private_key` + the NAT redirect,
+  which are unchanged. **AC: `git diff origin/main` on this file is empty.**
+- `.github/workflows/git-data-cutover.yml` — untouched (#6680). It calls the bridge **without**
+  `server-ip`, so (a) the keyfile/export block is **gated off** (no `WEB_HOST_SSH`/`GIT_DATA_SSH`/
+  keyfile materialized → zero runtime behavior change to `git-data-cutover.sh`, which reads
+  `${GIT_DATA_SSH:-ssh}`/`${WEB_HOST_SSH:-ssh}` at `:82-83,109`), and (b) the bridge still hits
+  `terraform output` and **exits 127** (no terraform installed — `git-data-cutover.yml:21`) before
+  the "Run git-data cutover" step executes. So #6680 is neither fixed nor broken — its real blocker
+  is the missing terraform **plus** the missing 10.0.1.20 tunnel ingress (corrected per arch review;
+  the earlier "no tunnel ingress" single-reason framing was imprecise). When #6680 is worked, giving
+  git-data a `server-ip` lights up the gated `GIT_DATA_SSH` export automatically.
 - `.github/workflows/apply-deploy-pipeline-fix.yml` — calls the bridge without `server-ip`
-  (terraform path); additions inert.
+  (terraform path + keyfile/export gated off); genuinely inert.
 
 ## Implementation Phases
 
@@ -154,22 +194,37 @@ mutation in this change`.)
 ### Pre-merge (PR)
 1. `action.yml` declares `server-ip` with `required: false` — `grep -A3 'server-ip:' action.yml`
    shows `required: false`.
-2. The `terraform output -raw server_ip` line is guarded so it runs **only** when `server-ip` is
-   empty — `grep -B2 'terraform output -raw server_ip' action.yml` shows the `[[ -z "$SERVER_IP_INPUT" ]]` guard.
-3. The bridge writes a chmod-600 keyfile and exports `WEB_HOST_SSH`, `GIT_DATA_SSH`, `CI_SSH_KEYFILE`
-   to `$GITHUB_ENV`, with the value `ssh -i <keyfile> -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
+2. The `terraform output -raw server_ip` call is **reachable only when `server-ip` is empty**
+   (behavioral post-condition — do not pin a specific `-z`/`-n` form or line offset). The
+   `SERVER_IP` empty-check, `::add-mask::`, and `SERVER_IP=… >> $GITHUB_ENV` export run in **both**
+   branches (so teardown's NAT-delete works on the `server-ip` path).
+3. The keyfile-write + export block is **gated on `[[ -n "$SERVER_IP_INPUT" ]]`**; inside the gate
+   the bridge writes a chmod-600 keyfile (path exported to `$GITHUB_ENV` as `CI_SSH_KEYFILE`
+   **before** key bytes are written) and exports `WEB_HOST_SSH` + `GIT_DATA_SSH` =
+   `ssh -i <keyfile> -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
 4. `workspaces-luks-cutover.yml` and `workspaces-luks-verify.yml` each pass `server-ip: "10.0.1.10"`
    to the bridge, and the value equals each workflow's `WEB_HOST`.
-5. Both cutover and verify have an `if: always()` teardown that (a) `iptables -t nat -D OUTPUT -d "$SERVER_IP" …`,
-   (b) kills `$CLOUDFLARED_PID`, (c) shreds `$CI_SSH_KEYFILE` — each `-n`/`-f` guarded.
+5. Both cutover and verify have an `if: always()` teardown (`set +e` only, **no `set -u`**) that
+   (a) `iptables -t nat -D OUTPUT -d "$SERVER_IP" …` guarded on `${SERVER_IP:-}`, (b) kills
+   `${CLOUDFLARED_PID:-}`, (c) shreds the keyfile guarded
+   `[[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]] && shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true`.
 6. `git diff origin/main -- .github/workflows/apply-web-platform-infra.yml` is **empty** (byte-unchanged bridge invocation).
 7. `git diff origin/main -- .github/workflows/git-data-cutover.yml` is **empty**.
-8. `actionlint` is clean on `workspaces-luks-cutover.yml`, `workspaces-luks-verify.yml`, and (schema-permitting) the composite `action.yml` is validated by extracting each `run:` snippet through `bash -n`/`bash -c` (actionlint does NOT validate composite-action files — do not run it on `action.yml`; extract + shellcheck the shell instead).
+8. `actionlint` is clean on `workspaces-luks-cutover.yml` + `workspaces-luks-verify.yml` (with
+   `shellcheck` installed on the runner so SC2086 is actually evaluated — otherwise the shell check
+   is a silent no-op). Do NOT run `actionlint` on the composite `action.yml`; validate its `run:`
+   snippets via `bash -n`/`bash -c` + shellcheck (method — not part of the checkable AC).
 9. `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 stays green — no AWS creds appear in the edited cutover workflow).
 10. `bash apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh` passes (concurrency groups untouched).
 11. No `terraform`/`terraform output` token appears in the cutover/verify execution path — `grep -c 'terraform' .github/workflows/workspaces-luks-{cutover,verify}.yml` = 0.
-12. The five false comments (action `:55-57`, verify `:59`, and the OUTPUTS/PREREQUISITES header) are corrected to describe key+keyfile+NAT-redirect reality.
-13. PR body uses `Ref #6649` (NOT `Closes #6649`) — closure is soak/rehearsal-gated post-merge.
+12. The genuinely-false comments are corrected by **text edit to `action.yml` (OUTPUTS/PREREQUISITES
+    `:48-57`) + `workspaces-luks-verify.yml:59` only** (git-data-cutover.yml's comments become
+    accurate via the code change and are NOT edited — AC7 preserved) to describe
+    key+keyfile+NAT-redirect reality; `verify.yml:59` no longer says "ProxyCommand".
+13. `workspaces-luks-verify.yml` has `# shellcheck disable=SC2086` above its `${WEB_HOST_SSH:-ssh}`
+    line (mirrors cutover `:112`); both Run steps fail loud when `WEB_HOST_SSH` is unset.
+14. Standing inertness guard: `grep -E 'WEB_HOST_SSH|GIT_DATA_SSH|CI_SSH_KEYFILE' .github/workflows/apply-web-platform-infra.yml .github/workflows/apply-deploy-pipeline-fix.yml` returns nothing (the terraform callers never reference the gated vars).
+15. PR body uses `Ref #6649` (NOT `Closes #6649`) — closure is soak/rehearsal-gated post-merge.
 
 ### Post-merge (operator — dispatch automatable, approval is the sole human gate)
 - Dispatch the rehearsal: `gh workflow run workspaces-luks-cutover.yml -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS`
@@ -296,8 +351,19 @@ code-review scope-outs on these files).
   validates *workflows* (require `on:`/`jobs:`) and emits spurious "section missing" errors on the
   composite-action schema. Validate embedded `run:` shell via `bash -n`/`bash -c` + shellcheck
   instead (learning 2026-05-18-composite-action-extraction-inline-on-multi-file-rollout).
-- The keyfile-write + `WEB_HOST_SSH`/`GIT_DATA_SSH` export run for **every** bridge caller; assert
-  inertness for apply/pipeline-fix by confirming no caller consumes those env vars (grep returned
-  hits only in cutover/verify/git-data).
+- The keyfile-write + `WEB_HOST_SSH`/`GIT_DATA_SSH` export are **gated on `[[ -n "$SERVER_IP_INPUT" ]]`**,
+  so they run only for `server-ip` callers (cutover/verify) — genuinely inert (nothing written) for
+  the terraform callers, not merely unused. AC14 codifies the inertness as a standing grep guard.
+- `verify.yml:68` must carry `# shellcheck disable=SC2086` (cutover `:112` already does): once
+  `WEB_HOST_SSH` holds a multi-word value the unquoted expansion is required, and actionlint/shellcheck
+  fires SC2086 statically regardless of runtime value → AC8 fails without the disable.
+- The new teardown must use `set +e` only (never `set -euo pipefail`): an early-fail path leaves
+  `SERVER_IP`/`CLOUDFLARED_PID`/`CI_SSH_KEYFILE` unset, and `set -u` would abort the `if: always()`
+  teardown, defeating the clean-no-op contract. Guard each arm on `${VAR:-}`.
+- Export `CI_SSH_KEYFILE` to `$GITHUB_ENV` **before** writing the key bytes to the file, so a
+  mid-step failure between `mktemp` and content-write still leaves a shreddable path for teardown.
+- `${WEB_HOST_SSH:-ssh}` is a silent fallback (degrades to keyless bare `ssh` → confusing auth error,
+  not a clear "bridge didn't export"); both Run steps fail loud on unset `WEB_HOST_SSH` per
+  `cq-silent-fallback`.
 - Do NOT `Closes #6649` — use `Ref #6649`; closure is gated on the post-merge green `dry_run=true`
   rehearsal (which requires the environment reviewer's approval).

--- a/knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
@@ -1,0 +1,303 @@
+---
+title: "fix(infra): bring up the workspaces-luks cutover SSH bridge (Option C — bash-SSH, private-IP-consistent)"
+type: fix
+date: 2026-07-18
+branch: feat-one-shot-cutover-bridge-bringup
+lane: cross-domain
+brand_survival_threshold: none
+refs: ["#6649", "#6604", "#6680", "ADR-119", "ADR-114", "#4177", "#4844"]
+---
+
+# 🐛 fix(infra): bring up the workspaces-luks cutover SSH bridge (Option C)
+
+## Overview
+
+`workspaces-luks-cutover.yml -f dry_run=true` and `workspaces-luks-verify.yml` were authored
+but have never run end-to-end. A dry_run-guard fix (merged earlier today) got the cutover as
+far as the `CF Tunnel SSH bridge` step; the bridge then fails `terraform: command not found`
+(exit 127), and two further walls sit behind it. This plan implements **Option C** from a
+completed investigation: make the bridge a real bash-SSH bridge scoped to web-1, using the
+**private-IP-consistent** path (`10.0.1.10` for both the iptables redirect scope and the SSH
+target), so the #6649 dry-run escrow rehearsal can reach web-1 — while keeping the composite
+action **backward-compatible** with the critical-path `apply-web-platform-infra.yml`.
+
+The three walls (all verified this session):
+
+1. **`terraform: command not found` (exit 127).** `.github/actions/cf-tunnel-ssh-bridge/action.yml:165`
+   runs `terraform output -raw server_ip`, but neither `workspaces-luks-cutover.yml` nor
+   `workspaces-luks-verify.yml` installs terraform (`grep -c setup-terraform|terraform` = 0 in both).
+2. **SERVER_IP vs WEB_HOST mismatch.** The bridge scopes `iptables -t nat -A OUTPUT -d "$SERVER_IP"`
+   to web-1's **public** IP (`terraform output server_ip` = `hcloud_server.web["web-1"].ipv4_address`,
+   `outputs.tf:3`), but the cutover Run step dials the **private** IP (`WEB_HOST: "10.0.1.10"`,
+   cutover `:102`). The redirect never catches the SSH.
+3. **`WEB_HOST_SSH` never set.** The bridge never exports `WEB_HOST_SSH`/`GIT_DATA_SSH` and never
+   writes an SSH keyfile (five comments falsely claim it does — action header `:55-57`, verify `:59`,
+   git-data `:12-13`, `:109`). Bare `ssh "$WEB_HOST"` has no `-i` key and no `root@` user, so it
+   would fail even if the redirect caught it.
+
+**Why the private-IP path works (design decision — see Research Reconciliation).** The iptables
+`-d` scope is only a *runner-side hijack filter*: whatever destination it matches is redirected
+pre-egress to `127.0.0.1:2222`, which cloudflared forwards over the tunnel to the ingress rule
+`ssh.${app_domain_base}` → `ssh://${web_hosts["web-1"].private_ip}:22` = `ssh://10.0.1.10:22`
+(`tunnel.tf:69-72`, `variables.tf:110`). So scoping `-d 10.0.1.10` catches the cutover's
+`ssh 10.0.1.10`, redirects it before egress (the private IP need not be routable from the runner),
+and the tunnel always lands on web-1. This makes `server-ip == WEB_HOST == 10.0.1.10` internally
+consistent and **eliminates terraform entirely** from the cutover/verify path.
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (from task background) | Codebase reality (verified) | Plan response |
+| --- | --- | --- |
+| Bridge exits 127 (`terraform: command not found`) | Confirmed: cutover/verify install no terraform; action.yml:165 calls `terraform output` | Add optional `server-ip`; when set, skip `terraform output` verbatim |
+| Redirect scopes public IP; Run step dials private `10.0.1.10` | Confirmed: outputs.tf:3 = public `ipv4_address`; cutover:102 `WEB_HOST: "10.0.1.10"` | Pass `server-ip: "10.0.1.10"` = WEB_HOST → redirect scope matches the dialed IP |
+| Bridge never exports `WEB_HOST_SSH`, no keyfile; 5 false comments | Confirmed: action.yml exports only SERVER_IP/CLOUDFLARED_PID/TF_VAR_ci_ssh_private_key/TUNNEL_SERVICE_TOKEN_* (`:55-57`); verify:59 falsely says "key + ProxyCommand" | Write DEPLOY_SSH_PRIVATE_KEY to chmod-600 keyfile; export `WEB_HOST_SSH`/`GIT_DATA_SSH`/`CI_SSH_KEYFILE`; correct the comments |
+| DEPLOY_SSH_PRIVATE_KEY authenticates as root@web-1 | Confirmed: ci-ssh-key.tf — DEPLOY_SSH_PRIVATE_KEY = `tls_private_key.ci_ssh`; public half appended to root's authorized_keys; server.tf connections use `user="root"` | `WEB_HOST_SSH = ssh -i <keyfile> … -l root` |
+| RECOMMENDED: use private IP `10.0.1.10` for both, avoid terraform | Confirmed against tunnel.tf:69-72 (origin-relative `ssh://10.0.1.10:22`, ADR-114 I2) + variables.tf:110 (`private_ip = "10.0.1.10"`) + model.c4:380 | **ADOPTED — private-10.0.1.10-consistent.** No public-IP-via-Doppler fallback needed |
+| Tunnel might need the **public** IP as redirect target | FALSE — tunnel.tf:66-68 ("the runner still dials the public SERVER_IP" is the *apply* path only); the tunnel host-side always delivers to web-1 private:22 regardless of the `-d` scope | Fallback (public-IP-via-Doppler) NOT needed; documented as rejected alternative |
+
+**Premise Validation (Phase 0.6):** #6649 is OPEN (do NOT close — closure is gated on a
+post-merge green `dry_run=true` rehearsal). #6680 is OPEN (git-data 10.0.1.20 reach is a separate
+architectural gap — out of scope). Both recent cutover runs (29644526137, 29649845529) failed,
+confirming the workflow has never run end-to-end. Cited files (action.yml, tunnel.tf, outputs.tf,
+variables.tf, ci-ssh-key.tf, server.tf, the two `.test.sh`) all exist on the branch and match the
+task's descriptions.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing user-facing directly — a broken bridge
+means the `dry_run=true` escrow rehearsal cannot reach web-1, so #6649 stays open and the
+LUKS-at-rest cutover remains un-rehearsed. `dry_run=true` performs **no freeze and no repoint**
+(the escrow probe runs before the `DRY_RUN != 1` gate; workspaces-cutover.sh), so no sole-copy user
+data is touched by this change.
+**If this leaks, the user's data is exposed via:** the CI SSH private key. It is already in Doppler
+`prd_terraform` and already loaded into `$GITHUB_ENV` (`TF_VAR_ci_ssh_private_key`) by the action;
+this change additionally writes it to a **chmod-600** tempfile that the `if: always()` teardown
+**shreds**, and every key line is `::add-mask::`ed (existing decode step). No new exposure surface
+beyond the already-handled key.
+**Brand-survival threshold:** none — reason: this change only brings up the SSH bridge for the
+non-mutating `dry_run=true` rehearsal + the read-only verify workflow; the destructive freeze is a
+separate, environment-gated dispatch that this PR does not run. (Scope-out bullet for the
+`.github/**` sensitive-path gate: `threshold: none, reason: dry-run/verify only — no sole-copy data
+mutation in this change`.)
+
+## Files to Edit
+
+- `.github/actions/cf-tunnel-ssh-bridge/action.yml`
+  - Add **optional** input `server-ip` (`required: false`, default `''`).
+  - In the "Start cloudflared SSH bridge + iptables NAT redirect" step: add
+    `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to `env:`; replace the bare
+    `SERVER_IP=$(terraform output -raw server_ip)` with a guard — **use `$SERVER_IP_INPUT` when
+    non-empty, otherwise keep the `terraform output -raw server_ip` path verbatim** (including the
+    empty-check + `::error::`). The terraform branch must remain byte-identical for callers that do
+    not pass `server-ip`.
+  - In the "Decode CI SSH private key into TF_VAR_ci_ssh_private_key" step (where `$KEY` is in
+    scope): after the existing heredoc write, **also** write `$KEY` to a chmod-600 keyfile
+    (`KEYFILE=$(mktemp); chmod 600 "$KEYFILE"; printf '%s\n' "$KEY" > "$KEYFILE"`) and export to
+    `$GITHUB_ENV`: `CI_SSH_KEYFILE=$KEYFILE`, and both
+    `WEB_HOST_SSH` and `GIT_DATA_SSH` = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
+    These additions are **inert** for terraform callers (unused env + unused file). Broaden the
+    step name to reflect the added keyfile/export.
+  - Correct the five false comments (action header OUTPUTS/PREREQUISITES `:48-57`, and the caller
+    comments) to state reality: the bridge now writes an SSH keyfile and exports
+    `WEB_HOST_SSH`/`GIT_DATA_SSH`; the mechanism is **key + iptables NAT redirect (NOT a
+    ProxyCommand)**; `terraform init` is required **only** when `server-ip` is unset.
+- `.github/workflows/workspaces-luks-cutover.yml`
+  - Pass `server-ip: "10.0.1.10"` to the `CF Tunnel SSH bridge` step (matches the Run step's
+    `WEB_HOST: "10.0.1.10"`).
+  - Add an `if: always()` teardown step **after** "Run workspaces-luks cutover": delete the NAT
+    rule scoped to `$SERVER_IP`, kill `$CLOUDFLARED_PID`, **shred `$CI_SSH_KEYFILE`**, and dump
+    `/tmp/cloudflared.log` — all `-n`/`-f` guarded (modeled on `apply-web-platform-infra.yml:801-823`).
+- `.github/workflows/workspaces-luks-verify.yml`
+  - Identical bridge treatment: pass `server-ip: "10.0.1.10"`; add the same `if: always()`
+    teardown (NAT delete + cloudflared kill + shred keyfile + log dump). Fix the `:59` comment
+    ("key + ProxyCommand" → "key + iptables NAT redirect").
+
+## Files NOT to edit (assert unchanged)
+
+- `.github/workflows/apply-web-platform-infra.yml` — critical path. It calls the bridge **without**
+  `server-ip` (`:649-656`), so the optional input defaults empty → the terraform path runs verbatim.
+  The keyfile-write + `WEB_HOST_SSH`/`GIT_DATA_SSH` export are inert (terraform's Go SSH client uses
+  `TF_VAR_ci_ssh_private_key` + the NAT redirect, not these env vars). **AC: `git diff origin/main`
+  on this file is empty.**
+- `.github/workflows/git-data-cutover.yml` — untouched (#6680). It also calls the bridge without
+  `server-ip` (terraform path) and dials `10.0.1.20`; the bridge additions newly export
+  `WEB_HOST_SSH`/`GIT_DATA_SSH` for it, but its 10.0.1.20 host has no tunnel ingress and no NAT
+  redirect, so #6680 remains exactly as-is — this change neither fixes nor breaks it.
+- `.github/workflows/apply-deploy-pipeline-fix.yml` — calls the bridge without `server-ip`
+  (terraform path); additions inert.
+
+## Implementation Phases
+
+**Phase 0 — Preconditions (verify, do not code).**
+- Re-confirm `web_hosts["web-1"].private_ip == "10.0.1.10"` (`variables.tf:110`) and tunnel ingress
+  `ssh://…private_ip:22` (`tunnel.tf:69-72`).
+- Confirm `git diff origin/main --stat` touches only the three target files.
+
+**Phase 1 — Composite action: optional `server-ip` (removes wall #1 + #2).**
+- Add the input; guard the terraform output behind `[[ -z "$SERVER_IP_INPUT" ]]`.
+- Contract-first: this phase changes the SERVER_IP source; it must land before the callers pass the
+  new input (they already dial 10.0.1.10, so no dead code — but keep the action edit first).
+
+**Phase 2 — Composite action: keyfile + `WEB_HOST_SSH`/`GIT_DATA_SSH` export (removes wall #3).**
+- Extend the decode step; export the three env vars. Verify inertness for terraform callers by
+  reasoning (no consumer of these env vars in apply/pipeline-fix).
+
+**Phase 3 — Cutover + verify workflows: pass `server-ip` + add teardown.**
+- Add `server-ip: "10.0.1.10"` to both bridge invocations.
+- Add the `if: always()` teardown (shred keyfile + bridge teardown) to both.
+- Fix the verify `:59` comment.
+
+**Phase 4 — Verify (see Verification).**
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+1. `action.yml` declares `server-ip` with `required: false` — `grep -A3 'server-ip:' action.yml`
+   shows `required: false`.
+2. The `terraform output -raw server_ip` line is guarded so it runs **only** when `server-ip` is
+   empty — `grep -B2 'terraform output -raw server_ip' action.yml` shows the `[[ -z "$SERVER_IP_INPUT" ]]` guard.
+3. The bridge writes a chmod-600 keyfile and exports `WEB_HOST_SSH`, `GIT_DATA_SSH`, `CI_SSH_KEYFILE`
+   to `$GITHUB_ENV`, with the value `ssh -i <keyfile> -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
+4. `workspaces-luks-cutover.yml` and `workspaces-luks-verify.yml` each pass `server-ip: "10.0.1.10"`
+   to the bridge, and the value equals each workflow's `WEB_HOST`.
+5. Both cutover and verify have an `if: always()` teardown that (a) `iptables -t nat -D OUTPUT -d "$SERVER_IP" …`,
+   (b) kills `$CLOUDFLARED_PID`, (c) shreds `$CI_SSH_KEYFILE` — each `-n`/`-f` guarded.
+6. `git diff origin/main -- .github/workflows/apply-web-platform-infra.yml` is **empty** (byte-unchanged bridge invocation).
+7. `git diff origin/main -- .github/workflows/git-data-cutover.yml` is **empty**.
+8. `actionlint` is clean on `workspaces-luks-cutover.yml`, `workspaces-luks-verify.yml`, and (schema-permitting) the composite `action.yml` is validated by extracting each `run:` snippet through `bash -n`/`bash -c` (actionlint does NOT validate composite-action files — do not run it on `action.yml`; extract + shellcheck the shell instead).
+9. `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 stays green — no AWS creds appear in the edited cutover workflow).
+10. `bash apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh` passes (concurrency groups untouched).
+11. No `terraform`/`terraform output` token appears in the cutover/verify execution path — `grep -c 'terraform' .github/workflows/workspaces-luks-{cutover,verify}.yml` = 0.
+12. The five false comments (action `:55-57`, verify `:59`, and the OUTPUTS/PREREQUISITES header) are corrected to describe key+keyfile+NAT-redirect reality.
+13. PR body uses `Ref #6649` (NOT `Closes #6649`) — closure is soak/rehearsal-gated post-merge.
+
+### Post-merge (operator — dispatch automatable, approval is the sole human gate)
+- Dispatch the rehearsal: `gh workflow run workspaces-luks-cutover.yml -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS`
+  (automatable via `gh`; `/soleur:ship` can fire it). **Automation: not feasible past the
+  `environment: workspaces-luks-cutover` required-reviewer approval** — a named human authorization
+  gate on a sole-copy-data workflow (`playwright-attempt: N/A — GitHub environment approval is a
+  first-class human gate, not a dashboard form`).
+- After approval, read the run log (NO ssh): `gh run view <id> --log` — confirm the `CF Tunnel SSH
+  bridge` step is green (no exit 127) and the escrow probe emits its GREEN signal. This is the
+  #6649 closure evidence; close #6649 only after this passes.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: dry_run=true rehearsal reaches the escrow probe (GREEN escrow signal) before the DRY_RUN freeze gate
+  cadence: on workflow_dispatch (rehearsal), not scheduled
+  alert_target: GitHub Actions run status + step summary
+  configured_in: workspaces-luks-cutover.yml (Cutover summary step) + workspaces-cutover.sh escrow_probe
+error_reporting:
+  destination: GitHub Actions `::error::` annotations (bridge steps) + /tmp/cloudflared.log dump (teardown) + Sentry (feature=workspaces-luks op=workspaces-luks-drift) for script-side failures
+  fail_loud: yes — every bridge step exits non-zero with an `::error::`; the Run step surfaces the ssh rc
+failure_modes:
+  - mode: cloudflared TCP forward does not open on 127.0.0.1:2222
+    detection: `::error::` "cloudflared TCP forward did not open …" + log dump
+    alert_route: run failure + teardown log
+  - mode: SSH auth/connect fails (wrong key/user/redirect scope)
+    detection: Run step ssh rc != 0 → `::error::` (cutover) / probe_rc (verify)
+    alert_route: run failure
+  - mode: iptables NAT redirect insertion fails
+    detection: `::error::` "iptables NAT redirect … failed"
+    alert_route: run failure
+logs:
+  where: GitHub Actions run log + /tmp/cloudflared.log (dumped by teardown)
+  retention: GitHub Actions default (90d)
+discoverability_test:
+  command: gh run view <run-id> --log   # NO ssh
+  expected_output: "CF Tunnel SSH bridge" step green (no exit 127) AND escrow probe GREEN
+```
+
+## Hypotheses (Phase 1.4 — SSH/firewall/terraform; L3→L7 order)
+
+Per `hr-ssh-diagnosis-verify-firewall`, verify L3 (firewall/routing) before L7 (sshd/service):
+
+- **L3 firewall/egress:** the GH runner egress IP is NOT in `var.admin_ips` (by design — 5000+
+  rotating IPs) and cannot be. This is the reason the tunnel bridge exists. The private `10.0.1.10`
+  need not be routable from the runner because the iptables OUTPUT REDIRECT rewrites the destination
+  **before egress**. ✔ verified against tunnel.tf + the action's existing NAT rule.
+- **L3/L4 NAT redirect:** `-d 10.0.1.10 --dport 22 → 127.0.0.1:2222` catches the cutover's
+  `ssh 10.0.1.10`. ✔ this is precisely what wall #2 fixes (scope was the public IP).
+- **L4/L7 tunnel:** cloudflared `127.0.0.1:2222` → CF Access (ci_ssh service token) → ingress
+  `ssh.${app_domain_base}` → `ssh://10.0.1.10:22`. ✔ tunnel.tf:69-72 (origin-relative, ADR-114 I2).
+- **L7 sshd auth:** `-i <keyfile with DEPLOY_SSH_PRIVATE_KEY> -l root` — public half is in web-1
+  root's `authorized_keys` (ci-ssh-key.tf). ✔ this is what wall #3 fixes.
+
+The three walls are exactly the L3→L7 failure chain, addressed in order: terraform 127 (removed by
+`server-ip`), redirect-scope mismatch (fixed by `server-ip == WEB_HOST == 10.0.1.10`), missing
+key/user (fixed by the keyfile + `WEB_HOST_SSH` export).
+
+## Domain Review
+
+**Domains relevant:** Engineering (infra/CI/security). Product: none (no UI surface — Files to Edit
+are `.github/**` only; no `components/**`, `app/**/page.tsx`, or `app/**/layout.tsx`).
+
+### Engineering / Security
+**Status:** reviewed (inline)
+**Assessment:** The one security-relevant addition is writing the CI SSH private key to disk. It is
+mitigated: the key is already in `$GITHUB_ENV`; the keyfile is chmod-600 (mktemp default), every
+line is `::add-mask::`ed by the existing decode step, and the `if: always()` teardown shreds it.
+`server-ip` is a static literal (`"10.0.1.10"`), not attacker-controlled. No new secret, vendor, or
+host is introduced. `StrictHostKeyChecking=accept-new` + `UserKnownHostsFile=/dev/null` is the
+established CI pattern for an ephemeral runner reaching a host over a CF-Access-gated tunnel (the
+edge already authenticates via the service token; TOFU on the inner hop adds no meaningful risk on a
+one-shot ephemeral runner).
+
+### Product/UX Gate
+**Tier:** none — no user-facing surface.
+
+## Infrastructure (IaC)
+
+**Skip — no new infrastructure.** This plan edits a composite action + two workflows and consumes
+**existing** provisioned infrastructure: the Cloudflare Tunnel + CF Access ci_ssh service token
+(tunnel.tf), the CI SSH keypair + Doppler `DEPLOY_SSH_PRIVATE_KEY` (ci-ssh-key.tf), and web-1's
+root authorized_keys. No `*.tf` file changes; no server/service/secret/vendor is created. The
+entire point of Option C is to **remove** the terraform dependency from the cutover/verify path.
+
+## Architecture Decision (ADR/C4)
+
+**No new ADR; no C4 change.** This implements "Option C" within the existing bridge architecture
+(#4177/#4844 composite action) under ADR-119 (workspaces-luks cutover) and ADR-114 (origin-relative
+tunnel ingress, I2). No ADR is reversed or extended: the tunnel topology is unchanged and is
+exactly what makes the private-IP path correct.
+
+**C4 completeness check (all three `.c4` files read):** the relevant elements are already modeled —
+`model.c4:386 github -> tunnel` ("CI … reaches web-1's shell … via CF Access service tokens"),
+`model.c4:380 tunnel -> hetzner` ("ssh. → ssh://10.0.1.10:22 — ORIGIN-RELATIVE"), and the tunnel
+container itself (`model.c4:176-178`); `views.c4:32` includes the tunnel. **External actors**
+(GitHub Actions runner = `github`), **external/edge systems** (Cloudflare tunnel = `tunnel`),
+**containers/data-stores** (web-1 = `hetzner`, workspacesVolume), and the **access relationship**
+(CI → tunnel → web-1 SSH) are all present. Option C adds only another *caller* (the cutover/verify
+workflows) of the already-modeled `github -> tunnel` SSH edge — no new actor, system, store, or
+access relationship. Therefore **no C4 impact**.
+
+## Alternative Approaches Considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| **Public-IP-via-Doppler** (source web-1 public IP from a Doppler secret, set `server-ip` = public IP, match `WEB_HOST` = public IP) | Rejected. tunnel.tf:66-68's "runner still dials the public SERVER_IP" describes only the *apply* path; the tunnel host-side always delivers to web-1 private:22 regardless of the `-d` scope, so the public IP buys nothing and adds a Doppler read + a routable-IP assumption. The private-IP path is simpler and terraform-free. |
+| **Install terraform in cutover/verify** (`setup-terraform` + `terraform init`) | Rejected. Re-introduces the R2-backend init + credentials into a workflow whose whole design (creds in GitHub secrets, nothing on the host) is meant to avoid it; `server-ip` removes the need. |
+| **Modify git-data-cutover.yml to reach 10.0.1.20** | Out of scope — separate architectural gap tracked as #6680 (no tunnel ingress for the git-data host). |
+
+## Open Code-Review Overlap
+
+None — sweep of open `code-review`-labelled issues against the three Files-to-Edit returned no
+matches (infra CI/action files; the open LUKS issues #6649/#6680 are feature/gap issues, not
+code-review scope-outs on these files).
+
+## Sharp Edges
+
+- A plan whose `## User-Brand Impact` section is empty, contains only `TBD`/placeholder text, or
+  omits the threshold will fail `deepen-plan` Phase 4.6. (This plan's threshold is `none` with a
+  reason bullet.)
+- `actionlint` MUST NOT be run against `.github/actions/cf-tunnel-ssh-bridge/action.yml` — it
+  validates *workflows* (require `on:`/`jobs:`) and emits spurious "section missing" errors on the
+  composite-action schema. Validate embedded `run:` shell via `bash -n`/`bash -c` + shellcheck
+  instead (learning 2026-05-18-composite-action-extraction-inline-on-multi-file-rollout).
+- The keyfile-write + `WEB_HOST_SSH`/`GIT_DATA_SSH` export run for **every** bridge caller; assert
+  inertness for apply/pipeline-fix by confirming no caller consumes those env vars (grep returned
+  hits only in cutover/verify/git-data).
+- Do NOT `Closes #6649` — use `Ref #6649`; closure is gated on the post-merge green `dry_run=true`
+  rehearsal (which requires the environment reviewer's approval).

--- a/knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
@@ -10,6 +10,22 @@ refs: ["#6649", "#6604", "#6680", "ADR-119", "ADR-114", "#4177", "#4844"]
 
 # 🐛 fix(infra): bring up the workspaces-luks cutover SSH bridge (Option C)
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-18 (plan-review 5-agent panel + deepen-plan gates + verify-the-negative grep pass)
+
+### Key improvements from review + deepen
+1. **Keystone: gate the keyfile-write + `WEB_HOST_SSH`/`GIT_DATA_SSH` export on `[[ -n "$SERVER_IP_INPUT" ]]`.** Converges 5 independent findings (code-simplicity #1, spec-flow Gap1, arch Finding A/B, Kieran scope) — makes the additions *genuinely inert* (not merely unused) for the terraform callers, makes the uniform-shred claim true, and preserves AC6/AC7.
+2. **`GIT_DATA_SSH` kept, not dropped** — the DHH/code-simplicity "drop it" finding was **refuted** by grep: `git-data-cutover.sh:82-83` defines `gd_ssh()`/`web_ssh()` consuming `${GIT_DATA_SSH:-ssh}`/`${WEB_HOST_SSH:-ssh}`, and the task directs the export.
+3. **HIGH (Kieran): `verify.yml:68` needs `# shellcheck disable=SC2086`** or AC8 fails (unlike cutover `:112`).
+4. Six mechanical hardening fixes: SERVER_IP export shared across both branches; keyfile-path exported before key bytes; teardown `set +e` only; fail-loud `WEB_HOST_SSH` guard; corrected git-data inertness rationale (no-terraform→exit-127, not "no ingress"); routability wording precision.
+
+### Deepen gates cleared
+- Phase 4.5 Network-Outage Deep-Dive (SSH/firewall triggers) — subsection below; telemetry emitted.
+- Phase 4.6 User-Brand Impact — threshold `none`, no sensitive-path match (grep-confirmed).
+- Phase 4.7 Observability — 5 fields present, `discoverability_test.command` ssh-free.
+- Phase 4.8 PAT-shape — clean. Phase 4.9 UI-wireframe — N/A (no UI surface). Phase 4.55 Downtime — no trigger (dry_run performs no freeze/repoint; action edit inert for the serving path).
+
 ## Overview
 
 `workspaces-luks-cutover.yml -f dry_run=true` and `workspaces-luks-verify.yml` were authored
@@ -261,7 +277,7 @@ logs:
   where: GitHub Actions run log + /tmp/cloudflared.log (dumped by teardown)
   retention: GitHub Actions default (90d)
 discoverability_test:
-  command: gh run view <run-id> --log   # NO ssh
+  command: gh run view <run-id> --log   # run-log only, never the host shell
   expected_output: "CF Tunnel SSH bridge" step green (no exit 127) AND escrow probe GREEN
 ```
 
@@ -283,6 +299,25 @@ Per `hr-ssh-diagnosis-verify-firewall`, verify L3 (firewall/routing) before L7 (
 The three walls are exactly the L3→L7 failure chain, addressed in order: terraform 127 (removed by
 `server-ip`), redirect-scope mismatch (fixed by `server-ip == WEB_HOST == 10.0.1.10`), missing
 key/user (fixed by the keyfile + `WEB_HOST_SSH` export).
+
+### Network-Outage Deep-Dive (deepen-plan Phase 4.5)
+
+Per `hr-ssh-diagnosis-verify-firewall`, L3 is verified before any L7 fix. Each layer cites a concrete
+artifact (verify-the-negative grep pass, this session):
+
+| Layer | Verification artifact | Status |
+| --- | --- | --- |
+| **L3 firewall / egress allow-list** | Runner egress IP is intentionally NOT in `var.admin_ips` (design — 5000+ rotating IPs); the tunnel bridge is the sanctioned path. This is a *by-design* non-allowlist, not a drifted one, so no firewall fix is warranted — the fix is the tunnel, which already exists. | ✔ verified (design intent) |
+| **L3 routing / redirect** | `nat OUTPUT REDIRECT -d 10.0.1.10 --dport 22 → 127.0.0.1:2222`; `10.0.1.10` resolves via the runner's default route (`0.0.0.0/0`) then REDIRECTs to loopback pre-egress. `server-ip == WEB_HOST == 10.0.1.10` (grep: cutover:102 / verify:60). | ✔ verified |
+| **L4/L7 tunnel** | `tunnel.tf:69-72` ingress `ssh.${app_domain_base}` → `ssh://10.0.1.10:22` (origin-relative, ADR-114 I2); CF Access ci_ssh service-token gate (`CI_SSH_ACCESS_TOKEN_ID/_SECRET` present in Doppler prd_terraform). | ✔ verified |
+| **L7 sshd auth** | `ci-ssh-key.tf` appends `tls_private_key.ci_ssh` public half to web-1 root's authorized_keys; `server.tf:299` connections `user="root"`. `WEB_HOST_SSH = ssh -i <keyfile> … -l root`. | ✔ verified |
+| **Wall #1 (terraform 127)** | `grep -cE 'setup-terraform\|terraform (init\|output\|apply\|plan)'` on cutover + verify = **0** — confirms the exit-127 root cause; `server-ip` removes the dependency. | ✔ verified |
+
+**Verify-the-negative pass (Phase 4.45), grep-confirmed this session:**
+- Inertness — `grep -E 'WEB_HOST_SSH\|GIT_DATA_SSH\|CI_SSH_KEYFILE'` on `apply-web-platform-infra.yml` + `apply-deploy-pipeline-fix.yml` → **zero hits** (terraform callers never consume the gated vars; with gating they are not even exported). **CONFIRMS** the inertness claim (AC14 codifies it).
+- H7 — `grep -E 'AWS_ACCESS_KEY_ID\|…\|WORKSPACES_HEADER_BUCKET'` on cutover workflow → **zero hits**. **CONFIRMS** `workspaces-luks-header.test.sh` H7 stays green.
+- `GIT_DATA_SSH` liveness — `git-data-cutover.sh:82-83` `gd_ssh()`/`web_ssh()` consume it. **CONFIRMS** keeping the export (refutes "drop it").
+- git-data no-terraform — `grep -c setup-terraform git-data-cutover.yml` = **0**. **CONFIRMS** the corrected rationale: the bridge exits 127 before git-data's script runs.
 
 ## Domain Review
 

--- a/knowledge-base/project/specs/feat-one-shot-cutover-bridge-bringup/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-cutover-bridge-bringup/tasks.md
@@ -1,0 +1,42 @@
+---
+title: "Tasks — workspaces-luks cutover SSH bridge bring-up (Option C)"
+plan: knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
+branch: feat-one-shot-cutover-bridge-bringup
+lane: cross-domain
+---
+
+# Tasks
+
+## Phase 0 — Preconditions (verify, no code)
+- [ ] 0.1 Confirm `web_hosts["web-1"].private_ip == "10.0.1.10"` (variables.tf:110) and tunnel ingress `ssh://…private_ip:22` (tunnel.tf:69-72).
+- [ ] 0.2 `git diff origin/main --stat` shows only the three target files will change.
+
+## Phase 1 — Composite action: optional `server-ip` (walls #1 + #2)
+- [ ] 1.1 Add input `server-ip` (`required: false`, default `''`) to `.github/actions/cf-tunnel-ssh-bridge/action.yml`.
+- [ ] 1.2 Add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to the "Start cloudflared SSH bridge…" step `env:`.
+- [ ] 1.3 Guard the terraform read: `SERVER_IP="$SERVER_IP_INPUT"; [[ -z "$SERVER_IP" ]] && SERVER_IP=$(terraform output -raw server_ip)` — keep the empty-check + `::error::` for the terraform branch byte-for-byte.
+
+## Phase 2 — Composite action: keyfile + WEB_HOST_SSH/GIT_DATA_SSH export (wall #3)
+- [ ] 2.1 In the "Decode CI SSH private key…" step, after the existing heredoc write, write `$KEY` to `KEYFILE=$(mktemp)`; `chmod 600 "$KEYFILE"`.
+- [ ] 2.2 Export `CI_SSH_KEYFILE`, `WEB_HOST_SSH`, `GIT_DATA_SSH` to `$GITHUB_ENV`; the ssh vars = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
+- [ ] 2.3 Broaden the step name to reflect the added keyfile/export.
+- [ ] 2.4 Correct the five false comments (header OUTPUTS/PREREQUISITES :48-57; the ProxyCommand claims) → key + keyfile + iptables NAT redirect; terraform-init only required when `server-ip` unset.
+
+## Phase 3 — Cutover + verify workflows
+- [ ] 3.1 `workspaces-luks-cutover.yml`: pass `server-ip: "10.0.1.10"` to the bridge step.
+- [ ] 3.2 `workspaces-luks-cutover.yml`: add `if: always()` teardown after "Run workspaces-luks cutover" — NAT delete (`-d "$SERVER_IP"`), kill `$CLOUDFLARED_PID`, shred `$CI_SSH_KEYFILE`, dump `/tmp/cloudflared.log` (all `-n`/`-f` guarded; model on apply:801-823).
+- [ ] 3.3 `workspaces-luks-verify.yml`: pass `server-ip: "10.0.1.10"`; add the same `if: always()` teardown.
+- [ ] 3.4 `workspaces-luks-verify.yml`: fix the `:59` comment ("key + ProxyCommand" → "key + iptables NAT redirect").
+
+## Phase 4 — Verify
+- [ ] 4.1 `actionlint` clean on `workspaces-luks-cutover.yml` + `workspaces-luks-verify.yml` (NOT on `action.yml` — extract `run:` snippets → `bash -n`/shellcheck).
+- [ ] 4.2 `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 green — no AWS creds in cutover workflow).
+- [ ] 4.3 `bash apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh` passes.
+- [ ] 4.4 `git diff origin/main -- .github/workflows/apply-web-platform-infra.yml` empty; same for `git-data-cutover.yml`.
+- [ ] 4.5 `grep -c terraform .github/workflows/workspaces-luks-{cutover,verify}.yml` = 0.
+- [ ] 4.6 PR body uses `Ref #6649` (not `Closes`).
+
+## Phase 5 — Post-merge (ship / operator)
+- [ ] 5.1 `/soleur:ship` (or operator) dispatches `gh workflow run workspaces-luks-cutover.yml -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS`.
+- [ ] 5.2 Approve the `workspaces-luks-cutover` environment gate (sole human authorization — not automatable past approval).
+- [ ] 5.3 `gh run view <id> --log` (NO ssh): confirm bridge step green (no exit 127) + escrow probe GREEN; then close #6649.

--- a/knowledge-base/project/specs/feat-one-shot-cutover-bridge-bringup/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-cutover-bridge-bringup/tasks.md
@@ -8,36 +8,36 @@ lane: cross-domain
 # Tasks
 
 ## Phase 0 — Preconditions (verify, no code)
-- [ ] 0.1 Confirm `web_hosts["web-1"].private_ip == "10.0.1.10"` (variables.tf:110) and tunnel ingress `ssh://…private_ip:22` (tunnel.tf:69-72).
-- [ ] 0.2 `git diff origin/main --stat` will touch only: action.yml + workspaces-luks-cutover.yml + workspaces-luks-verify.yml.
+- [x] 0.1 Confirm `web_hosts["web-1"].private_ip == "10.0.1.10"` (variables.tf:110) and tunnel ingress `ssh://…private_ip:22` (tunnel.tf:69-72).
+- [x] 0.2 `git diff origin/main --stat` will touch only: action.yml + workspaces-luks-cutover.yml + workspaces-luks-verify.yml.
 
 ## Phase 1 — Composite action: optional `server-ip` (walls #1 + #2)
-- [ ] 1.1 Add input `server-ip` (`required: false`, default `''`) to `.github/actions/cf-tunnel-ssh-bridge/action.yml`.
-- [ ] 1.2 Add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to the "Start cloudflared SSH bridge…" step `env:`.
-- [ ] 1.3 Guard ONLY the terraform read: `SERVER_IP="${SERVER_IP_INPUT:-}"; if [[ -z "$SERVER_IP" ]]; then SERVER_IP=$(terraform output -raw server_ip); fi`. Keep the empty-check + `::error::`, the `::add-mask::`, and the `SERVER_IP=… >> $GITHUB_ENV` export COMMON to both branches (teardown needs SERVER_IP on the server-ip path).
+- [x] 1.1 Add input `server-ip` (`required: false`, default `''`) to `.github/actions/cf-tunnel-ssh-bridge/action.yml`.
+- [x] 1.2 Add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to the "Start cloudflared SSH bridge…" step `env:`.
+- [x] 1.3 Guard ONLY the terraform read: `SERVER_IP="${SERVER_IP_INPUT:-}"; if [[ -z "$SERVER_IP" ]]; then SERVER_IP=$(terraform output -raw server_ip); fi`. Keep the empty-check + `::error::`, the `::add-mask::`, and the `SERVER_IP=… >> $GITHUB_ENV` export COMMON to both branches (teardown needs SERVER_IP on the server-ip path).
 
 ## Phase 2 — Composite action: gated keyfile + WEB_HOST_SSH/GIT_DATA_SSH export (wall #3)
-- [ ] 2.1 In the "Decode CI SSH private key…" step, add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to `env:` and wrap the new block in `if [[ -n "$SERVER_IP_INPUT" ]]; then … fi`.
-- [ ] 2.2 Inside the gate, IN ORDER: `KEYFILE=$(mktemp); chmod 600 "$KEYFILE"; echo "CI_SSH_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"; printf '%s\n' "$KEY" > "$KEYFILE"` (path exported BEFORE key bytes — spec-flow Gap4).
-- [ ] 2.3 Export `WEB_HOST_SSH` and `GIT_DATA_SSH` = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root` to `$GITHUB_ENV`. Keep GIT_DATA_SSH (consumed by git-data-cutover.sh:82-83,109; refuted "drop" finding).
-- [ ] 2.4 Broaden the step name to reflect the keyfile/export.
-- [ ] 2.5 Correct action.yml OUTPUTS/PREREQUISITES header (:48-57) → key+keyfile+NAT-redirect reality; terraform-init only when `server-ip` unset. Extend the CALLER-SIDE TEARDOWN CONTRACT block (:23-46) to document the keyfile shred for server-ip callers.
+- [x] 2.1 In the "Decode CI SSH private key…" step, add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to `env:` and wrap the new block in `if [[ -n "$SERVER_IP_INPUT" ]]; then … fi`.
+- [x] 2.2 Inside the gate, IN ORDER: `KEYFILE=$(mktemp); chmod 600 "$KEYFILE"; echo "CI_SSH_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"; printf '%s\n' "$KEY" > "$KEYFILE"` (path exported BEFORE key bytes — spec-flow Gap4).
+- [x] 2.3 Export `WEB_HOST_SSH` and `GIT_DATA_SSH` = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root` to `$GITHUB_ENV`. Keep GIT_DATA_SSH (consumed by git-data-cutover.sh:82-83,109; refuted "drop" finding).
+- [x] 2.4 Broaden the step name to reflect the keyfile/export.
+- [x] 2.5 Correct action.yml OUTPUTS/PREREQUISITES header (:48-57) → key+keyfile+NAT-redirect reality; terraform-init only when `server-ip` unset. Extend the CALLER-SIDE TEARDOWN CONTRACT block (:23-46) to document the keyfile shred for server-ip callers.
 
 ## Phase 3 — Cutover + verify workflows
-- [ ] 3.1 `workspaces-luks-cutover.yml`: pass `server-ip: "10.0.1.10"` to the bridge step.
-- [ ] 3.2 `workspaces-luks-cutover.yml` Run step: add fail-loud guard `[[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::bridge did not export WEB_HOST_SSH"; exit 1; }` before the ssh; keep the `# shellcheck disable=SC2086`.
-- [ ] 3.3 `workspaces-luks-cutover.yml`: add `if: always()` teardown after "Run workspaces-luks cutover" — `set +e` only (no set -u); NAT delete guarded `${SERVER_IP:-}`; kill `${CLOUDFLARED_PID:-}`; shred `[[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]] && shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true`; dump /tmp/cloudflared.log (model apply:801-823).
-- [ ] 3.4 `workspaces-luks-verify.yml`: pass `server-ip: "10.0.1.10"`; add the same fail-loud guard + `if: always()` teardown.
-- [ ] 3.5 `workspaces-luks-verify.yml`: add `# shellcheck disable=SC2086` above the `${WEB_HOST_SSH:-ssh}` line (:68) — HIGH (mirrors cutover:112); fix the `:59` comment ("key + ProxyCommand" → "key + iptables NAT redirect").
+- [x] 3.1 `workspaces-luks-cutover.yml`: pass `server-ip: "10.0.1.10"` to the bridge step.
+- [x] 3.2 `workspaces-luks-cutover.yml` Run step: add fail-loud guard `[[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::bridge did not export WEB_HOST_SSH"; exit 1; }` before the ssh; keep the `# shellcheck disable=SC2086`.
+- [x] 3.3 `workspaces-luks-cutover.yml`: add `if: always()` teardown after "Run workspaces-luks cutover" — `set +e` only (no set -u); NAT delete guarded `${SERVER_IP:-}`; kill `${CLOUDFLARED_PID:-}`; shred `[[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]] && shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true`; dump /tmp/cloudflared.log (model apply:801-823).
+- [x] 3.4 `workspaces-luks-verify.yml`: pass `server-ip: "10.0.1.10"`; add the same fail-loud guard + `if: always()` teardown.
+- [x] 3.5 `workspaces-luks-verify.yml`: add `# shellcheck disable=SC2086` above the `${WEB_HOST_SSH:-ssh}` line (:68) — HIGH (mirrors cutover:112); fix the `:59` comment ("key + ProxyCommand" → "key + iptables NAT redirect").
 
 ## Phase 4 — Verify
-- [ ] 4.1 `actionlint` clean on cutover + verify (shellcheck installed so SC2086 is evaluated). Do NOT actionlint action.yml — extract `run:` → `bash -n`/shellcheck.
-- [ ] 4.2 `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 green).
-- [ ] 4.3 `bash apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh` passes.
-- [ ] 4.4 `git diff origin/main -- .github/workflows/apply-web-platform-infra.yml` empty; same for `git-data-cutover.yml`.
-- [ ] 4.5 `grep -c terraform .github/workflows/workspaces-luks-{cutover,verify}.yml` = 0.
-- [ ] 4.6 Standing guard: `grep -E 'WEB_HOST_SSH|GIT_DATA_SSH|CI_SSH_KEYFILE' apply-web-platform-infra.yml apply-deploy-pipeline-fix.yml` → nothing.
-- [ ] 4.7 PR body uses `Ref #6649` (not `Closes`).
+- [x] 4.1 `actionlint` clean on cutover + verify (shellcheck installed so SC2086 is evaluated). Do NOT actionlint action.yml — extract `run:` → `bash -n`/shellcheck.
+- [x] 4.2 `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 green).
+- [x] 4.3 `bash apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh` passes.
+- [x] 4.4 `git diff origin/main -- .github/workflows/apply-web-platform-infra.yml` empty; same for `git-data-cutover.yml`.
+- [x] 4.5 `grep -c terraform .github/workflows/workspaces-luks-{cutover,verify}.yml` = 0.
+- [x] 4.6 Standing guard: `grep -E 'WEB_HOST_SSH|GIT_DATA_SSH|CI_SSH_KEYFILE' apply-web-platform-infra.yml apply-deploy-pipeline-fix.yml` → nothing.
+- [x] 4.7 PR body uses `Ref #6649` (not `Closes`).
 
 ## Phase 5 — Post-merge (ship / operator)
 - [ ] 5.1 `/soleur:ship` (or operator) dispatches `gh workflow run workspaces-luks-cutover.yml -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS`.

--- a/knowledge-base/project/specs/feat-one-shot-cutover-bridge-bringup/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-cutover-bridge-bringup/tasks.md
@@ -1,5 +1,5 @@
 ---
-title: "Tasks — workspaces-luks cutover SSH bridge bring-up (Option C)"
+title: "Tasks — workspaces-luks cutover SSH bridge bring-up (Option C, gated)"
 plan: knowledge-base/project/plans/2026-07-18-fix-workspaces-luks-cutover-ssh-bridge-bringup-plan.md
 branch: feat-one-shot-cutover-bridge-bringup
 lane: cross-domain
@@ -9,32 +9,35 @@ lane: cross-domain
 
 ## Phase 0 — Preconditions (verify, no code)
 - [ ] 0.1 Confirm `web_hosts["web-1"].private_ip == "10.0.1.10"` (variables.tf:110) and tunnel ingress `ssh://…private_ip:22` (tunnel.tf:69-72).
-- [ ] 0.2 `git diff origin/main --stat` shows only the three target files will change.
+- [ ] 0.2 `git diff origin/main --stat` will touch only: action.yml + workspaces-luks-cutover.yml + workspaces-luks-verify.yml.
 
 ## Phase 1 — Composite action: optional `server-ip` (walls #1 + #2)
 - [ ] 1.1 Add input `server-ip` (`required: false`, default `''`) to `.github/actions/cf-tunnel-ssh-bridge/action.yml`.
 - [ ] 1.2 Add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to the "Start cloudflared SSH bridge…" step `env:`.
-- [ ] 1.3 Guard the terraform read: `SERVER_IP="$SERVER_IP_INPUT"; [[ -z "$SERVER_IP" ]] && SERVER_IP=$(terraform output -raw server_ip)` — keep the empty-check + `::error::` for the terraform branch byte-for-byte.
+- [ ] 1.3 Guard ONLY the terraform read: `SERVER_IP="${SERVER_IP_INPUT:-}"; if [[ -z "$SERVER_IP" ]]; then SERVER_IP=$(terraform output -raw server_ip); fi`. Keep the empty-check + `::error::`, the `::add-mask::`, and the `SERVER_IP=… >> $GITHUB_ENV` export COMMON to both branches (teardown needs SERVER_IP on the server-ip path).
 
-## Phase 2 — Composite action: keyfile + WEB_HOST_SSH/GIT_DATA_SSH export (wall #3)
-- [ ] 2.1 In the "Decode CI SSH private key…" step, after the existing heredoc write, write `$KEY` to `KEYFILE=$(mktemp)`; `chmod 600 "$KEYFILE"`.
-- [ ] 2.2 Export `CI_SSH_KEYFILE`, `WEB_HOST_SSH`, `GIT_DATA_SSH` to `$GITHUB_ENV`; the ssh vars = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root`.
-- [ ] 2.3 Broaden the step name to reflect the added keyfile/export.
-- [ ] 2.4 Correct the five false comments (header OUTPUTS/PREREQUISITES :48-57; the ProxyCommand claims) → key + keyfile + iptables NAT redirect; terraform-init only required when `server-ip` unset.
+## Phase 2 — Composite action: gated keyfile + WEB_HOST_SSH/GIT_DATA_SSH export (wall #3)
+- [ ] 2.1 In the "Decode CI SSH private key…" step, add `SERVER_IP_INPUT: ${{ inputs.server-ip }}` to `env:` and wrap the new block in `if [[ -n "$SERVER_IP_INPUT" ]]; then … fi`.
+- [ ] 2.2 Inside the gate, IN ORDER: `KEYFILE=$(mktemp); chmod 600 "$KEYFILE"; echo "CI_SSH_KEYFILE=$KEYFILE" >> "$GITHUB_ENV"; printf '%s\n' "$KEY" > "$KEYFILE"` (path exported BEFORE key bytes — spec-flow Gap4).
+- [ ] 2.3 Export `WEB_HOST_SSH` and `GIT_DATA_SSH` = `ssh -i $KEYFILE -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root` to `$GITHUB_ENV`. Keep GIT_DATA_SSH (consumed by git-data-cutover.sh:82-83,109; refuted "drop" finding).
+- [ ] 2.4 Broaden the step name to reflect the keyfile/export.
+- [ ] 2.5 Correct action.yml OUTPUTS/PREREQUISITES header (:48-57) → key+keyfile+NAT-redirect reality; terraform-init only when `server-ip` unset. Extend the CALLER-SIDE TEARDOWN CONTRACT block (:23-46) to document the keyfile shred for server-ip callers.
 
 ## Phase 3 — Cutover + verify workflows
 - [ ] 3.1 `workspaces-luks-cutover.yml`: pass `server-ip: "10.0.1.10"` to the bridge step.
-- [ ] 3.2 `workspaces-luks-cutover.yml`: add `if: always()` teardown after "Run workspaces-luks cutover" — NAT delete (`-d "$SERVER_IP"`), kill `$CLOUDFLARED_PID`, shred `$CI_SSH_KEYFILE`, dump `/tmp/cloudflared.log` (all `-n`/`-f` guarded; model on apply:801-823).
-- [ ] 3.3 `workspaces-luks-verify.yml`: pass `server-ip: "10.0.1.10"`; add the same `if: always()` teardown.
-- [ ] 3.4 `workspaces-luks-verify.yml`: fix the `:59` comment ("key + ProxyCommand" → "key + iptables NAT redirect").
+- [ ] 3.2 `workspaces-luks-cutover.yml` Run step: add fail-loud guard `[[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::bridge did not export WEB_HOST_SSH"; exit 1; }` before the ssh; keep the `# shellcheck disable=SC2086`.
+- [ ] 3.3 `workspaces-luks-cutover.yml`: add `if: always()` teardown after "Run workspaces-luks cutover" — `set +e` only (no set -u); NAT delete guarded `${SERVER_IP:-}`; kill `${CLOUDFLARED_PID:-}`; shred `[[ -n "${CI_SSH_KEYFILE:-}" && -f "$CI_SSH_KEYFILE" ]] && shred -u "$CI_SSH_KEYFILE" 2>/dev/null || true`; dump /tmp/cloudflared.log (model apply:801-823).
+- [ ] 3.4 `workspaces-luks-verify.yml`: pass `server-ip: "10.0.1.10"`; add the same fail-loud guard + `if: always()` teardown.
+- [ ] 3.5 `workspaces-luks-verify.yml`: add `# shellcheck disable=SC2086` above the `${WEB_HOST_SSH:-ssh}` line (:68) — HIGH (mirrors cutover:112); fix the `:59` comment ("key + ProxyCommand" → "key + iptables NAT redirect").
 
 ## Phase 4 — Verify
-- [ ] 4.1 `actionlint` clean on `workspaces-luks-cutover.yml` + `workspaces-luks-verify.yml` (NOT on `action.yml` — extract `run:` snippets → `bash -n`/shellcheck).
-- [ ] 4.2 `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 green — no AWS creds in cutover workflow).
+- [ ] 4.1 `actionlint` clean on cutover + verify (shellcheck installed so SC2086 is evaluated). Do NOT actionlint action.yml — extract `run:` → `bash -n`/shellcheck.
+- [ ] 4.2 `bash apps/web-platform/infra/workspaces-luks-header.test.sh` passes (H7 green).
 - [ ] 4.3 `bash apps/web-platform/infra/web-1-swap-concurrency-parity.test.sh` passes.
 - [ ] 4.4 `git diff origin/main -- .github/workflows/apply-web-platform-infra.yml` empty; same for `git-data-cutover.yml`.
 - [ ] 4.5 `grep -c terraform .github/workflows/workspaces-luks-{cutover,verify}.yml` = 0.
-- [ ] 4.6 PR body uses `Ref #6649` (not `Closes`).
+- [ ] 4.6 Standing guard: `grep -E 'WEB_HOST_SSH|GIT_DATA_SSH|CI_SSH_KEYFILE' apply-web-platform-infra.yml apply-deploy-pipeline-fix.yml` → nothing.
+- [ ] 4.7 PR body uses `Ref #6649` (not `Closes`).
 
 ## Phase 5 — Post-merge (ship / operator)
 - [ ] 5.1 `/soleur:ship` (or operator) dispatches `gh workflow run workspaces-luks-cutover.yml -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS`.


### PR DESCRIPTION
## Summary
- Makes `cf-tunnel-ssh-bridge` a terraform-free bash-SSH bridge via an optional `server-ip` input. When set, it scopes the iptables NAT redirect to that address (skipping `terraform output -raw server_ip`), writes the CI SSH key to a `chmod 600` temp keyfile, and exports `WEB_HOST_SSH`/`GIT_DATA_SSH` — the ready `ssh -i <keyfile> … -l root` invocation the LUKS cutover/verify scripts consume.
- `workspaces-luks-cutover.yml` + `workspaces-luks-verify.yml` pass `server-ip` (== `WEB_HOST`, single-sourced from `env.WEB_HOST_PRIVATE_IP`), add a fail-loud `WEB_HOST_SSH` guard, and an `if: always()` teardown (NAT delete + cloudflared kill + keyfile `shred -u`).
- **Backward-compatible:** when `server-ip` is empty (the terraform caller `apply-web-platform-infra.yml`), the `terraform output` path + `TF_VAR_ci_ssh_private_key` export are byte-unchanged (verified: empty diff on that file). The key form is mutually exclusive per caller class, so the private key stays off `$GITHUB_ENV` for the bash-SSH callers (only the shredded keyfile holds it).
- Unblocks the #6649 dry-run escrow rehearsal, which reached the bridge (after the earlier dry-run-guard fix) but hit `terraform: command not found` (exit 127).

Ref #6649 — closure is gated on a post-merge green `dry_run=true` escrow rehearsal (run this session), hence `Ref`, not `Closes`. The git-data-cutover second-host (10.0.1.20) tunnel-ingress gap is tracked separately in #6680.

## Changelog
- fix(infra): `cf-tunnel-ssh-bridge` gains an optional `server-ip` input enabling a terraform-free bash-SSH bridge for the LUKS cutover/verify workflows; the terraform apply path is unchanged.

## User-Brand Impact
- **Brand-survival threshold:** none, reason: workflow_dispatch-only rehearsal-gate change; the new path only enables the already-authorized (typed-confirm + environment-reviewer) dry-run to reach web-1 over the existing CF tunnel. No user data or credentials are exposed — the CI SSH key is written to a `chmod 600` temp keyfile kept off `$GITHUB_ENV` for this caller class and shredded in an `if: always()` teardown; freeze/repoint/wipe stay `DRY_RUN`-gated.

## Test plan
- [x] `actionlint` clean (both workflows); action run-blocks `shellcheck` + `bash -n` OK
- [x] `workspaces-luks-header.test.sh` 40/0; `web-1-swap-concurrency-parity.test.sh` 17/0; `terraform-target-parity.test.ts` 52/0
- [x] `apply-web-platform-infra.yml` + `git-data-cutover.yml` byte-unchanged; bridge exports absent from apply/deploy-fix
- [x] `TEST_GROUP=scripts scripts/test-all.sh` 184/184

Generated with [Claude Code](https://claude.com/claude-code)
