### PR TITLE
fix(infra): cert-reissue preflight must not block on unreadable always_use_https (#6657)

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
+++ b/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
@@ -194,7 +194,15 @@ export function checkReissuePreconditions(inputs: PreconditionInputs): {
     acmeWwwCarveout: inputs.acmeWwwStatus === 404,
     caaPermissive: inputs.caaCount === 0,
     challengeTxtPresent: inputs.challengeTxtPresent === true,
-    alwaysUseHttpsOff: inputs.alwaysUseHttps === "off",
+    // Block ONLY on an explicit "on" — NOT on "unknown". Reading always_use_https
+    // needs Zone.Zone Settings:Read, which the least-privilege DNS-edit-only token
+    // (CF_API_TOKEN_DNS_EDIT) intentionally lacks, so gatherPreconditions coalesces
+    // a 403 to "unknown". `acmeApexCarveout`/`acmeWwwCarveout` (the ACME path returns
+    // 404, not a 301 redirect) is the AUTHORITATIVE redirect-interception signal —
+    // always_use_https="on" would force those to 301 and fail the carve-out check
+    // anyway — so an unreadable setting must not block. #6657 live-run: the DNS-only
+    // token made this precondition false with `=== "off"` and blocked the remediation.
+    alwaysUseHttpsOff: inputs.alwaysUseHttps !== "on",
   };
   const failed = Object.entries(results)
     .filter(([, ok]) => !ok)

--- a/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
@@ -221,6 +221,19 @@ describe("checkReissuePreconditions", () => {
     expect(r.ok).toBe(false);
     expect(r.failed).toContain("acmeApexCarveout");
   });
+  it("always_use_https unreadable ('unknown', DNS-only token 403) → does NOT block (#6657)", () => {
+    // The least-privilege DNS-edit-only token cannot read the zone setting, so
+    // gatherPreconditions returns "unknown"; the ACME carve-out check is the
+    // authoritative signal, so an unreadable setting must not block.
+    const r = checkReissuePreconditions({ ...healthyPreconditions(), alwaysUseHttps: "unknown" });
+    expect(r.ok).toBe(true);
+    expect(r.results.alwaysUseHttpsOff).toBe(true);
+  });
+  it("always_use_https explicitly 'on' → blocks alwaysUseHttpsOff", () => {
+    const r = checkReissuePreconditions({ ...healthyPreconditions(), alwaysUseHttps: "on" });
+    expect(r.ok).toBe(false);
+    expect(r.failed).toContain("alwaysUseHttpsOff");
+  });
 });
 
 describe("setRecordsProxied — partial-toggle abort", () => {


### PR DESCRIPTION
## Summary

Live-incident hotfix for #6657 (found by actually running the reissue routine in prod). `gatherPreconditions` reads the `always_use_https` **zone setting**, which requires `Zone.Zone Settings:Read` — but the least-privilege DNS-edit-only token (`CF_API_TOKEN_DNS_EDIT`) intentionally lacks it, so the read 403s → `"unknown"` → `alwaysUseHttps === "off"` went false → `outcome=precondition_blocked` and the remediation never toggled.

**Fix:** block only on an explicit `"on"` (`!== "on"`), so an unreadable setting passes. The `acmeApexCarveout`/`acmeWwwCarveout` check (ACME path returns 404, not a 301 redirect) is the authoritative redirect-interception signal — `always_use_https="on"` would force those to 301 and fail the carve-out anyway — so this preserves the safety property while keeping the token least-privilege (`DNS:Edit` only).

## User-Brand Impact

- **Artifact:** the public `soleur.ai` marketing site TLS cert (no user PII).
- **Vector:** without this fix the auto-remediation can never run with a least-privilege token, so a stuck cert stays `bad_authz` and eventually 526s all visitors (the outage this routine exists to prevent).
- **Brand-survival threshold:** aggregate pattern

## Test plan

- [x] +2 unit tests: `always_use_https:"unknown"` → not blocked; `"on"` → blocked
- [x] 47 reissue unit tests green; `tsc --noEmit` clean

Ref #6657

Generated with [Claude Code](https://claude.com/claude-code)
