### PR TITLE
fix(infra): autonomous workspaces-luks escrow rehearsal (#6649)

### DIFF
--- a/.github/workflows/apply-web-platform-infra.yml
+++ b/.github/workflows/apply-web-platform-infra.yml
@@ -362,6 +362,8 @@ jobs:
               -target=cloudflare_r2_bucket.workspaces_luks_header \
               -target=doppler_secret.workspaces_luks_header_bucket \
               -target=doppler_secret.workspaces_luks_header_r2_endpoint \
+              -target=doppler_service_token.workspaces_luks \
+              -target=github_actions_secret.workspaces_luks_boot_token \
               -target=github_actions_secret.doppler_token_inngest_arm \
               -target=tls_private_key.ci_ssh \
               -target=doppler_secret.deploy_ssh_private_key \

--- a/.github/workflows/workspaces-luks-cutover.yml
+++ b/.github/workflows/workspaces-luks-cutover.yml
@@ -14,6 +14,15 @@
 # here: the environment is not a second reviewer on an already-reviewed PR, it is the sole gate on an
 # irreversible freeze. The environment MUST have a NON-EMPTY required-reviewer set (a zero-reviewer
 # environment auto-approves — DP-11 F8). The typed `confirm` token is a typo-guard, NOT the authorization.
+#
+# #6649 — the gate is applied to the REAL freeze arm ONLY (`dry_run=false`). A `dry_run=true` rehearsal
+# performs NO irreversible operation (freeze/repoint are behind `DRY_RUN != 1` in workspaces-cutover.sh;
+# the wipe is a separate CONFIRM_WIPE dispatch), so gating it behind a human made every escrow rehearsal
+# wait on an approval — defeating autonomy for a reversible probe. The job `environment:` expression below
+# resolves to the gated environment when `dry_run` is false and to an empty string (ungated) when true.
+# This is FAIL-CLOSED: the same `!inputs.dry_run` operand drives the gate, so any freeze-reachable run is
+# gated. The C19/AC20b human authorization on the irreversible operation is fully preserved; only the
+# reversible rehearsal is ungated. The reviewer set MUST stay non-empty for the freeze arm.
 
 name: workspaces-luks cutover freeze (#6604 / ADR-119)
 
@@ -57,9 +66,14 @@ jobs:
   cutover:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    # The sole human authorization on a sole-copy-data freeze (C19). MUST carry a non-empty
-    # required-reviewer set in repo settings (DP-11 F8 — a zero-reviewer environment auto-approves).
-    environment: workspaces-luks-cutover
+    # The sole human authorization on a sole-copy-data freeze (C19). Applied to the REAL freeze arm
+    # ONLY (`dry_run=false`) — a reversible dry-run rehearsal runs ungated for autonomy (#6649). The
+    # expression is FAIL-CLOSED: `!inputs.dry_run && 'workspaces-luks-cutover'` yields the gated env
+    # whenever dry_run is false (the freeze-reachable case), and the empty-string branch (ungated)
+    # ONLY when dry_run is exactly true. The environment MUST carry a non-empty required-reviewer set
+    # in repo settings (DP-11 F8 — a zero-reviewer environment auto-approves). Never invert the
+    # operands: `inputs.dry_run && '' || 'X'` gates ALWAYS ('' is falsy), the opposite of intent.
+    environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}
     steps:
       - name: Validate confirm token
         env:
@@ -106,13 +120,20 @@ jobs:
 
       - name: Run workspaces-luks cutover
         env:
+          # prd_terraform-scoped runner token — reads HCLOUD_TOKEN (volume-id lookup) on the RUNNER.
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          # prd_workspaces_luks-scoped boot token — the ONLY credential that can read
+          # WORKSPACES_LUKS_KEY + the R2 escrow creds host-side. Delivered to web-1 via a 0600 stdin
+          # .env (never argv). Published by the DEFAULT apply of apply-web-platform-infra.yml (#6649).
+          WORKSPACES_LUKS_BOOT_TOKEN: ${{ secrets.WORKSPACES_LUKS_BOOT_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
           ROLLBACK: ${{ inputs.rollback && '1' || '0' }}
           WEB_HOST: ${{ env.WEB_HOST_PRIVATE_IP }}
-        # The cutover body runs ON web-1 (DP-6 host-side trap): copy it over the bridge and execute
-        # it there so `trap cleanup EXIT` survives an SSH drop. The script reads the passphrase via
-        # the host's pinned prd_workspaces_luks token path; no cloud-admin creds touch the host.
+        # The cutover body runs ON web-1 (DP-6 host-side trap): ship the script + its siblings over the
+        # bridge and execute it there AS A FILE so `trap cleanup EXIT` survives an SSH drop AND the
+        # emit sibling is sourced (${BASH_SOURCE[0]} resolves — the pre-#6649 stdin-pipe darkened it).
+        # The script reads the passphrase via the host's pinned prd_workspaces_luks token path
+        # (delivered as $DOPPLER_TOKEN in the 0600 .env); no cloud-admin creds touch the host.
         run: |
           # set +e so the `rc=$?` + ::error:: diagnostic runs — GitHub's inherited `-e` (which
           # `set -uo pipefail` does not clear) would otherwise exit the step on the ssh failure
@@ -124,15 +145,69 @@ jobs:
           # auth-fail confusingly. The bridge sets WEB_HOST_SSH when server-ip
           # is passed (it is, above).
           [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::CF Tunnel SSH bridge did not export WEB_HOST_SSH — cannot reach web-1. Check the bridge step logs."; exit 1; }
-          # WEB_HOST_SSH is guaranteed set past the guard above (no :-ssh fallback —
-          # a keyless bare ssh is exactly what the guard exists to prevent).
+          # The host cannot read prd_workspaces_luks without the boot token — fail loud here rather
+          # than let read_key/load_escrow_creds die mid-run with a confusing empty-secret error.
+          [[ -n "${WORKSPACES_LUKS_BOOT_TOKEN:-}" ]] || { echo "::error::WORKSPACES_LUKS_BOOT_TOKEN not configured — run the DEFAULT apply of apply-web-platform-infra.yml to publish it (#6649)."; exit 1; }
+
+          # BLOCKER 5 — resolve the fresh LUKS volume's stable by-id device path. DOPPLER_TOKEN is
+          # prd_terraform-scoped, so it reads HCLOUD_TOKEN here on the runner (never on the host).
+          HCLOUD_TOKEN="$(doppler secrets get HCLOUD_TOKEN --plain -p soleur -c prd_terraform)"
+          VOL_JSON="$(curl -fsS --max-time 15 -H "Authorization: Bearer $HCLOUD_TOKEN" \
+            'https://api.hetzner.cloud/v1/volumes?name=soleur-web-platform-data-luks')"
+          # Assert EXACTLY ONE volume matched before taking [0] — an ambiguous/zero match must NOT
+          # silently pick a wrong device (the real arm luksFormats WORKSPACES_LUKS_DEV; a wrong id is
+          # data-destructive on that device). Belt for the blkid-signature backstop in prepare_luks_target.
+          VCOUNT="$(jq -r '.volumes | length' <<<"$VOL_JSON")"
+          [[ "$VCOUNT" == "1" ]] || { echo "::error::expected exactly 1 soleur-web-platform-data-luks volume from the Hetzner API, got ${VCOUNT:-<none>} — refusing to guess the fresh device"; exit 1; }
+          VID="$(jq -r '.volumes[0].id' <<<"$VOL_JSON")"
+          [[ "$VID" =~ ^[0-9]+$ ]] || { echo "::error::could not resolve the soleur-web-platform-data-luks volume id from the Hetzner API (got: '${VID:-<empty>}')"; exit 1; }
+          LUKS_DEV="/dev/disk/by-id/scsi-0HC_Volume_${VID}"
+
+          # BLOCKER 3 — content-carrier: ship the script + siblings to a temp dir on the PERSISTENT
+          # STATE_DIR (NOT tmpfs /tmp — a tmpfs .env makes the boot-token shred a no-op against the raw
+          # device, the F7 anti-pattern the header backup already fixes) and run it AS A FILE. No sudo:
+          # WEB_HOST_SSH lands `-l root`, and sudo's env_reset would scrub HOME + the sourced .env.
           # shellcheck disable=SC2086
-          ${WEB_HOST_SSH} "$WEB_HOST" "sudo DRY_RUN='${DRY_RUN}' ROLLBACK='${ROLLBACK}' bash -s" \
-            < "${INFRA_DIR}/workspaces-cutover.sh"
+          REMOTE_DIR="$(${WEB_HOST_SSH} "$WEB_HOST" 'mkdir -p /var/lib/workspaces-luks && chmod 700 /var/lib/workspaces-luks && mktemp -d /var/lib/workspaces-luks/wl-cutover.XXXXXX')"
+          [[ -n "$REMOTE_DIR" ]] || { echo "::error::failed to create the remote bundle dir on web-1"; exit 1; }
+          echo "REMOTE_DIR=$REMOTE_DIR" >> "$GITHUB_ENV"
+          # shellcheck disable=SC2086
+          tar czf - -C "$INFRA_DIR" workspaces-cutover.sh workspaces-luks-emit.sh luks-monitor.sh luks-monitor.service luks-monitor.timer \
+            | ${WEB_HOST_SSH} "$WEB_HOST" "tar xzf - -C '$REMOTE_DIR'"
+
+          # BLOCKER 4 — deliver the boot token (+ device + flags) via a mode-0600 root .env written
+          # over STDIN (never `sudo VAR=val` argv — that leaks the full-prd-capable token into the host
+          # process list). Write .env, arm the host-local shred trap, source it, and run the script AS A
+          # FILE — ALL in ONE remote bash -c so the trap covers the .env's entire lifetime (no
+          # un-trapped window). Fields are metacharacter-free (dp.st token / by-id path / 0|1) so
+          # `set -a; . .env` is injection-safe.
+          # shellcheck disable=SC2086
+          printf 'DOPPLER_TOKEN=%s\nWORKSPACES_LUKS_DEV=%s\nDRY_RUN=%s\nROLLBACK=%s\n' \
+            "$WORKSPACES_LUKS_BOOT_TOKEN" "$LUKS_DEV" "$DRY_RUN" "$ROLLBACK" \
+            | ${WEB_HOST_SSH} "$WEB_HOST" "bash -c 'install -m600 /dev/stdin \"$REMOTE_DIR/.env\"; trap \"shred -u \\\"$REMOTE_DIR/.env\\\" 2>/dev/null || rm -f \\\"$REMOTE_DIR/.env\\\"\" EXIT; set -a; . \"$REMOTE_DIR/.env\"; set +a; bash \"$REMOTE_DIR/workspaces-cutover.sh\"'"
           rc=$?
           if [[ $rc -ne 0 ]]; then
-            echo "::error::workspaces-luks cutover exited $rc — the host-side EXIT trap auto-rolled-back to the plaintext mount (DP-6). See the emitted Sentry event (feature=workspaces-luks op=workspaces-luks-drift)."
+            # The DP-6 EXIT trap rolls back to the plaintext mount ONLY for a PRE-canary failure; a
+            # failure AFTER the host canary (e.g. monitor-timer arm) leaves the LUKS mount LIVE and
+            # retained (cleanup() no-ops once CANARY_OK=1). Not every failure emits a Sentry event —
+            # the at-rest asserts do; the timer-arm die now does too. Read the streamed die() message
+            # in this run log first, then the Sentry channel (feature=workspaces-luks op=workspaces-luks-drift).
+            echo "::error::workspaces-luks cutover exited $rc — see the streamed die() message above. Pre-canary failures auto-rolled-back to the plaintext mount (DP-6); a post-canary failure left the LUKS mount live. Check the run log + any emitted Sentry event (feature=workspaces-luks op=workspaces-luks-drift)."
             exit $rc
+          fi
+
+      - name: Remove remote cutover bundle
+        if: always()
+        env:
+          WEB_HOST: ${{ env.WEB_HOST_PRIVATE_IP }}
+        # Belt-and-suspenders: the .env is shredded by the host-local EXIT trap even on an SSH drop;
+        # this removes the (script-only, non-secret) bundle dir. REMOTE_DIR is exported to GITHUB_ENV
+        # by the Run step; empty if that step never created it.
+        run: |
+          set +e
+          if [[ -n "${WEB_HOST_SSH:-}" && -n "${REMOTE_DIR:-}" ]]; then
+            # shellcheck disable=SC2086
+            ${WEB_HOST_SSH} "$WEB_HOST" "rm -rf '$REMOTE_DIR'" 2>/dev/null || true
           fi
 
       - name: Tear down cloudflared SSH bridge

--- a/.github/workflows/workspaces-luks-verify.yml
+++ b/.github/workflows/workspaces-luks-verify.yml
@@ -67,6 +67,10 @@ jobs:
           # iptables NAT redirect scoped to server-ip; no ProxyCommand — the Go/bash client dials
           # 10.0.1.10:22 which the kernel redirects to the local cloudflared forward).
           WEB_HOST: ${{ env.WEB_HOST_PRIVATE_IP }}
+          # prd_workspaces_luks-scoped boot token — luks-monitor.sh reads WORKSPACES_LUKS_KEY via
+          # `doppler … --config prd_workspaces_luks`, so it needs this token. Delivered via a 0600
+          # stdin .env (same discipline as the cutover), NEVER argv. Published by the DEFAULT apply.
+          WORKSPACES_LUKS_BOOT_TOKEN: ${{ secrets.WORKSPACES_LUKS_BOOT_TOKEN }}
         run: |
           # set +e so a failing probe is captured in probe_rc (and reported) rather than exiting the
           # step at the ssh line under GitHub's inherited `-e` (which `set -uo pipefail` does not clear).
@@ -74,11 +78,25 @@ jobs:
           set -uo pipefail
           # Fail loud if the bridge did not export WEB_HOST_SSH (bare ssh would connect keyless).
           [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "::error::CF Tunnel SSH bridge did not export WEB_HOST_SSH — cannot reach web-1. Check the bridge step logs."; exit 1; }
-          # Run the baked daily probe read-only (it mutates nothing) — DP-11 reuse. It emits its
-          # own discriminating Sentry event on any failed assert and exits non-zero.
+          [[ -n "${WORKSPACES_LUKS_BOOT_TOKEN:-}" ]] || { echo "::error::WORKSPACES_LUKS_BOOT_TOKEN not configured — run the DEFAULT apply of apply-web-platform-infra.yml to publish it (#6649)."; exit 1; }
+          # Ship luks-monitor.sh + its emit sibling to a temp dir on the PERSISTENT STATE_DIR and run
+          # it AS A FILE (read-only; MUTATES NOTHING — it opens no device). This removes the
+          # dependency on a prior cutover having installed /usr/local/bin/luks-monitor AND, unlike the
+          # old `sudo /usr/local/bin/luks-monitor`, delivers the boot token the probe needs (the
+          # installed binary has no EnvironmentFile in this SSH session). No sudo: WEB_HOST_SSH lands
+          # `-l root` (sudo's env_reset would scrub HOME + the sourced .env). Boot token via 0600
+          # stdin .env, shredded on a host-local EXIT trap — same discipline as the cutover.
+          # shellcheck disable=SC2086
+          REMOTE_DIR="$(${WEB_HOST_SSH} "$WEB_HOST" 'mkdir -p /var/lib/workspaces-luks && chmod 700 /var/lib/workspaces-luks && mktemp -d /var/lib/workspaces-luks/wl-verify.XXXXXX')"
+          [[ -n "$REMOTE_DIR" ]] || { echo "::error::failed to create the remote bundle dir on web-1"; exit 1; }
+          echo "REMOTE_DIR=$REMOTE_DIR" >> "$GITHUB_ENV"
+          # shellcheck disable=SC2086
+          tar czf - -C "$INFRA_DIR" luks-monitor.sh workspaces-luks-emit.sh \
+            | ${WEB_HOST_SSH} "$WEB_HOST" "tar xzf - -C '$REMOTE_DIR'"
           # WEB_HOST_SSH is guaranteed set past the guard above (no :-ssh fallback).
           # shellcheck disable=SC2086
-          ${WEB_HOST_SSH} "$WEB_HOST" 'sudo /usr/local/bin/luks-monitor'
+          printf 'DOPPLER_TOKEN=%s\n' "$WORKSPACES_LUKS_BOOT_TOKEN" \
+            | ${WEB_HOST_SSH} "$WEB_HOST" "bash -c 'install -m600 /dev/stdin \"$REMOTE_DIR/.env\"; trap \"shred -u \\\"$REMOTE_DIR/.env\\\" 2>/dev/null || rm -f \\\"$REMOTE_DIR/.env\\\"\" EXIT; set -a; . \"$REMOTE_DIR/.env\"; set +a; bash \"$REMOTE_DIR/luks-monitor.sh\"'"
           probe_rc=$?
           echo "luks-monitor probe rc=$probe_rc"
           # App-level workspace read + /api/health, exercising the full HTTPS path.
@@ -93,6 +111,20 @@ jobs:
             exit 1
           fi
           echo "workspaces-luks at-rest re-assert PASSED (blkid=crypto_LUKS, mapper mount, escrow ok, /api/health 200)."
+
+      - name: Remove remote verify bundle
+        if: always()
+        env:
+          WEB_HOST: ${{ env.WEB_HOST_PRIVATE_IP }}
+        # Belt-and-suspenders: the .env is shredded by the host-local EXIT trap even on an SSH drop;
+        # this removes the (script-only, non-secret) bundle dir. REMOTE_DIR is exported to GITHUB_ENV
+        # by the Re-assert step; empty if that step never created it.
+        run: |
+          set +e
+          if [[ -n "${WEB_HOST_SSH:-}" && -n "${REMOTE_DIR:-}" ]]; then
+            # shellcheck disable=SC2086
+            ${WEB_HOST_SSH} "$WEB_HOST" "rm -rf '$REMOTE_DIR'" 2>/dev/null || true
+          fi
 
       - name: Tear down cloudflared SSH bridge
         if: always()

--- a/apps/web-platform/infra/luks-monitor.service
+++ b/apps/web-platform/infra/luks-monitor.service
@@ -15,6 +15,10 @@ SyslogIdentifier=luks-monitor
 # DOPPLER_TOKEN (scoped workspaces-luks-boot) + SOLEUR_SENTRY_DSN (baked). Written via the cutover
 # channel (ADR-119 §(e)); the DSN half is baked by cloud-init so a Doppler outage still pages.
 EnvironmentFile=-/etc/default/luks-monitor
+# HOME must be set for the root doppler CLI (it writes/reads its config dir under $HOME); a root
+# systemd unit has no HOME by default, so `doppler secrets get` dies "$HOME is not defined" and the
+# probe emits doppler_unreachable every run. Every sibling root-doppler unit sets this (#6649).
+Environment=HOME=/root
 ExecStart=/usr/local/bin/luks-monitor
 # A failed probe already emitted its discriminating Sentry event; do not let systemd retry-storm.
 Nice=10

--- a/apps/web-platform/infra/workspaces-cutover.sh
+++ b/apps/web-platform/infra/workspaces-cutover.sh
@@ -59,8 +59,14 @@ DRY_RUN="${DRY_RUN:-1}"
 ROLLBACK="${ROLLBACK:-0}"
 CONFIRM_WIPE="${CONFIRM_WIPE:-0}"
 
+# Locate sibling scripts relative to THIS file. The workflow ships this script + its siblings
+# (workspaces-luks-emit.sh, luks-monitor.{sh,service,timer}) as a tar bundle and runs THIS file as a
+# file (#6649 content-carrier model), so the self-path is the on-host file path. The `:-$0` fallback
+# keeps it defined under `set -u` even if the body ever arrives on stdin (`bash -s`), where
+# BASH_SOURCE is empty — the pre-#6649 failure that darkened the emit channel + killed the run.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 EMIT="/usr/local/bin/workspaces-luks-emit.sh"
-[ -f "$EMIT" ] || EMIT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/workspaces-luks-emit.sh"
+[ -f "$EMIT" ] || EMIT="${SELF_DIR}/workspaces-luks-emit.sh"
 # shellcheck source=apps/web-platform/infra/workspaces-luks-emit.sh
 [ -f "$EMIT" ] && . "$EMIT"
 
@@ -472,14 +478,33 @@ if [ "$DRY_RUN" != "1" ]; then
   health="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 https://app.soleur.ai/api/health || echo 000)"
   [ "$health" = "200" ] || die "app /api/health=$health (expected 200) after restart"
   # Deliver the standing observability to the LIVE host via THIS channel (ADR-119 §(e)).
-  install -D -m 0755 "$(dirname "${BASH_SOURCE[0]}")/luks-monitor.sh" /usr/local/bin/luks-monitor 2>/dev/null || true
+  install -D -m 0755 "${SELF_DIR}/luks-monitor.sh" /usr/local/bin/luks-monitor 2>/dev/null || true
   install -D -m 0755 "$EMIT" /usr/local/bin/workspaces-luks-emit.sh 2>/dev/null || true
-  install -D -m 0644 "$(dirname "${BASH_SOURCE[0]}")/luks-monitor.service" /etc/systemd/system/luks-monitor.service 2>/dev/null || true
-  install -D -m 0644 "$(dirname "${BASH_SOURCE[0]}")/luks-monitor.timer" /etc/systemd/system/luks-monitor.timer 2>/dev/null || true
+  install -D -m 0644 "${SELF_DIR}/luks-monitor.service" /etc/systemd/system/luks-monitor.service 2>/dev/null || true
+  install -D -m 0644 "${SELF_DIR}/luks-monitor.timer" /etc/systemd/system/luks-monitor.timer 2>/dev/null || true
+  # #6649 — persist the prd_workspaces_luks boot token into the luks-monitor EnvironmentFile so the
+  # DAILY timer probe (luks-monitor.service) can `doppler secrets get WORKSPACES_LUKS_KEY … --config
+  # prd_workspaces_luks` unattended. cloud-init bakes ONLY SOLEUR_SENTRY_DSN here (no token), and the
+  # cutover carries the token in $DOPPLER_TOKEN (injected via the 0600 stdin .env). Preserve the baked
+  # DSN line; write 0600 root. Absent this, the daily probe would emit doppler_unreachable every day.
+  if [ -n "${DOPPLER_TOKEN:-}" ]; then
+    ENVF="/etc/default/luks-monitor"; touch "$ENVF"; chmod 600 "$ENVF"
+    # Drop any prior DOPPLER_TOKEN line, keep the baked DSN + everything else, append the current token.
+    # `umask 077` so the `.tmp` is BORN 0600 — a `chmod 600 "$ENVF"` AFTER the `mv` cannot protect the
+    # window, because `mv` replaces the inode with the tmp's (0644-under-default-umask) perms, briefly
+    # exposing the full-prd token world-readable (security review P3). The final chmod is belt-and-suspenders.
+    ( umask 077; { grep -v '^DOPPLER_TOKEN=' "$ENVF" 2>/dev/null || true; printf 'DOPPLER_TOKEN=%s\n' "$DOPPLER_TOKEN"; } > "${ENVF}.tmp" ) \
+      && mv "${ENVF}.tmp" "$ENVF" && chmod 600 "$ENVF"
+  else
+    log "WARN: DOPPLER_TOKEN not in env at unit-install time — the daily luks-monitor probe will lack a prd_workspaces_luks token"
+  fi
   # Structural fail-closed gate: chattr +i the root-disk mountpoint is unreachable now (mapper is
   # mounted), so it is delivered on the next unmount path; arm the daily probe timer now.
   systemctl daemon-reload 2>/dev/null || true
   systemctl enable --now luks-monitor.timer 2>/dev/null || true
+  # Fail loud if the timer did not arm (a silently-missing unit would leave the daily probe dark; the
+  # `install … || true` above swallows delivery errors deliberately, so assert the end state here).
+  systemctl is-enabled luks-monitor.timer >/dev/null 2>&1 || { emit_drift luks_monitor_timer_enable_failed; die "luks-monitor.timer failed to enable — the daily at-rest probe would not run (C15/ADR-119 §(e))"; }
   # Reboot-once re-canary (C15): the realistic failure is the boot path (the structural gate + the
   # --restart resurrection). This script does NOT auto-reboot — a reboot drops the CF-Tunnel SSH
   # session mid-run. The run-keyed CANARY_OK is persisted to $STATE_FILE with the header UUID (above)

--- a/apps/web-platform/infra/workspaces-luks-header.test.sh
+++ b/apps/web-platform/infra/workspaces-luks-header.test.sh
@@ -35,8 +35,12 @@ REPO="$(cd "$DIR/../../.." && pwd)"
 TF="$DIR/workspaces-luks-header.tf"
 SH="$DIR/workspaces-cutover.sh"
 YML="$REPO/.github/workflows/workspaces-luks-cutover.yml"
+# #6649 — the escrow rehearsal autonomy + content-carrier delivery spans more files:
+YML_VERIFY="$REPO/.github/workflows/workspaces-luks-verify.yml"
+TF_MAIN="$DIR/workspaces-luks.tf"
+SVC="$DIR/luks-monitor.service"
 
-for f in "$TF" "$SH" "$YML"; do
+for f in "$TF" "$SH" "$YML" "$YML_VERIFY" "$TF_MAIN" "$SVC"; do
   [ -f "$f" ] || { echo "FAIL: required file not found: $f" >&2; exit 1; }
 done
 
@@ -472,6 +476,148 @@ else
     fail "S9[ok]: clean probe did not reach the end (rc=$rc out=$o)"
   fi
 fi
+
+# ==============================================================================
+# #6649 — escrow rehearsal autonomy + content-carrier delivery (BLOCKER 3/4/5 + gate).
+# Every predicate anchors on the syntactic construct (cq-assert-anchor-not-bare-token) and is
+# mutation-tested below. strip_comments FIRST so a form surviving only in a COMMENT cannot satisfy
+# a check vacuously (and a forbidden form in a comment cannot false-fail a negative check).
+# ==============================================================================
+
+# H13 — the cutover runs workspaces-cutover.sh AS A FILE from a tar-shipped bundle (content-carrier),
+# with NO stdin pipe of the script body (the pre-#6649 model that left ${BASH_SOURCE[0]} unbound).
+# The positive anchor requires `bash` to INVOKE the file by path (execution, not a stray `rm` mention),
+# closing the bare-`bash`-reads-stdin evasion (a piped script to `bash` never names the file by path).
+# The negative uses a word boundary so `bash -s` (stdin) is forbidden without false-failing an
+# unrelated flag token that merely starts with `-s`.
+p_file_execution() {
+  local f="$1" body
+  body="$(strip_comments "$f")"
+  grep -q 'tar xzf - -C' <<<"$body" || { echo 0; return; }
+  grep -Eq 'bash .{0,3}REMOTE_DIR/workspaces-cutover\.sh' <<<"$body" || { echo 0; return; }
+  grep -Eq 'bash -s([[:space:]"'"'"']|$)' <<<"$body" && { echo 0; return; }   # forbid the stdin-pipe re-introduction
+  echo 1
+}
+
+# H14 — the boot token (+ device + flags) is delivered via a mode-0600 stdin env file, NEVER as a
+# `VAR=val` command-line assignment (the full-prd-capable token must not enter the host process list).
+# Asserts the GOOD form EXCLUSIVELY, sudo-INDEPENDENT: the session lands `-l root` so the realistic
+# next regression is a sudo-LESS `DOPPLER_TOKEN=$x bash …` argv leak, which a `sudo …`-anchored regex
+# misses entirely. The ONLY permitted `<sensitive>=` occurrence is the printf placeholder `=%s` (the
+# stdin .env payload); any `=` NOT immediately followed by `%` is an argv/expansion leak, with or
+# without sudo, with or without an intervening `-E`/`--preserve-env`/`FOO=bar`.
+p_token_via_stdin() {
+  local f="$1" body
+  body="$(strip_comments "$f")"
+  grep -q 'install -m600 /dev/stdin' <<<"$body" || { echo 0; return; }
+  grep -Eq '(DOPPLER_TOKEN|WORKSPACES_LUKS_BOOT_TOKEN)=([^%]|$)' <<<"$body" && { echo 0; return; }
+  echo 1
+}
+
+# H15 — the 0600 .env is shredded on a host-local EXIT trap (covers an SSH drop; F7 discipline).
+# Herestring (not a pipe): under `set -o pipefail`, `strip_comments | grep -q` SIGPIPEs the sed on an
+# early match and false-reports 0 (this suite's own SIGPIPE learning).
+p_env_shred_trap() {
+  local body; body="$(strip_comments "$1")"
+  grep -Eq 'trap .*shred -u.*EXIT' <<<"$body" && echo 1 || echo 0
+}
+
+# H16 — WORKSPACES_LUKS_DEV (the by-id device) is derived + passed to the host (BLOCKER 5).
+p_luks_dev_passed() {
+  local f="$1" body
+  body="$(strip_comments "$f")"
+  grep -q 'WORKSPACES_LUKS_DEV=%s' <<<"$body" || { echo 0; return; }
+  grep -q 'scsi-0HC_Volume_' <<<"$body" || { echo 0; return; }
+  echo 1
+}
+
+# H17 — the environment gate is FAIL-CLOSED (gated unless dry_run is exactly true). RED on the
+# inverted `inputs.dry_run && '' || 'X'` form (which gates ALWAYS / ungates the freeze).
+p_env_gate_failclosed() {
+  local body; body="$(strip_comments "$1")"   # herestring below — avoid the pipefail+grep -q SIGPIPE flake
+  grep -qF "environment: \${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}" <<<"$body" && echo 1 || echo 0
+}
+
+# H18 — luks-monitor.service carries HOME=/root (root doppler unit) + the EnvironmentFile that
+# supplies the boot token to the daily probe.
+p_service_env() {
+  local f="$1" body
+  body="$(strip_comments "$f")"
+  grep -qE '^Environment=HOME=/root[[:space:]]*$' <<<"$body" || { echo 0; return; }
+  grep -qE '^EnvironmentFile=-?/etc/default/luks-monitor[[:space:]]*$' <<<"$body" || { echo 0; return; }
+  echo 1
+}
+
+# H19 — the freeze-arm reviewer set stays NON-EMPTY (a zero-reviewer environment auto-approves,
+# DP-11 F8; learning 2026-07-17-workflow-env-gate-references-unprovisioned-environment-auto-approves).
+# BLOCK-SCOPED to the github_repository_environment.workspaces_luks_cutover resource (a decoy
+# `users = [1]` elsewhere in the file must NOT satisfy it), and newline-flattened so a `terraform fmt`
+# that wraps the list (`users = [\n  54279,\n]`) does not false-RED the line-oriented grep.
+p_reviewers_nonempty() {
+  local body; body="$(block_of "$1" github_repository_environment workspaces_luks_cutover | tr '\n' ' ')"
+  grep -Eq 'users[[:space:]]*=[[:space:]]*\[[[:space:]]*[0-9]' <<<"$body" && echo 1 || echo 0
+}
+
+# H20 — verify.yml ALSO uses file-execution of luks-monitor.sh + stdin-token delivery (BOTH
+# workflows must not regress the discipline); the old `sudo /usr/local/bin/luks-monitor` is gone.
+p_verify_file_execution() {
+  local f="$1" body
+  body="$(strip_comments "$f")"
+  grep -q 'REMOTE_DIR/luks-monitor.sh' <<<"$body" || { echo 0; return; }
+  grep -q 'install -m600 /dev/stdin' <<<"$body" || { echo 0; return; }
+  # Forbid running the PRE-INSTALLED binary regardless of sudo — the session is `-l root`, so the
+  # realistic regression is a sudo-LESS `/usr/local/bin/luks-monitor` call that skips the shipped
+  # file (+ the boot-token .env the probe needs). Anchor on the path, not the old `sudo …` prefix.
+  grep -q '/usr/local/bin/luks-monitor' <<<"$body" && { echo 0; return; }
+  echo 1
+}
+
+# --- #6649 assertions (mutation-tested) ---------------------------------------
+
+assert_holds "H13 cutover runs the script as a FILE from a tar bundle (no bash -s pipe)" p_file_execution "$YML"
+assert_mutation_append "H13 (bash -s stdin pipe re-introduced)" p_file_execution "$YML" \
+  '          ${WEB_HOST_SSH} "$WEB_HOST" "bash -s" < "${INFRA_DIR}/workspaces-cutover.sh"'
+# Prove the POSITIVE execution anchor is load-bearing: if `bash <file>` no longer invokes the script
+# by path (e.g. it is piped to a bare `bash` instead), the guard must go RED.
+assert_mutation "H13 (file no longer executed by path — bare-bash-stdin evasion)" p_file_execution "$YML" \
+  's~bash (.{0,3}REMOTE_DIR/workspaces-cutover)~source \1~'
+
+assert_holds "H14 boot token via install -m600 /dev/stdin, never a VAR=val argv (sudo-independent)" p_token_via_stdin "$YML"
+assert_mutation "H14 (install -m600 /dev/stdin removed)" p_token_via_stdin "$YML" \
+  's~install -m600 /dev/stdin~install /dev/stdin~'
+assert_mutation_append "H14 (token leaked onto a SUDO argv)" p_token_via_stdin "$YML" \
+  '          ${WEB_HOST_SSH} "$WEB_HOST" "sudo DOPPLER_TOKEN=$WORKSPACES_LUKS_BOOT_TOKEN bash x.sh"'
+# The sudo-LESS argv leak is the realistic next regression (the -l root session dropped sudo):
+assert_mutation_append "H14 (token leaked onto a sudo-LESS argv)" p_token_via_stdin "$YML" \
+  '          ${WEB_HOST_SSH} "$WEB_HOST" "DOPPLER_TOKEN=$WORKSPACES_LUKS_BOOT_TOKEN bash x.sh"'
+assert_mutation_append "H14 (token leaked via sudo --preserve-env argv)" p_token_via_stdin "$YML" \
+  '          ${WEB_HOST_SSH} "$WEB_HOST" "sudo --preserve-env DOPPLER_TOKEN=$WORKSPACES_LUKS_BOOT_TOKEN bash x.sh"'
+
+assert_holds "H15 .env shredded on a host-local EXIT trap (cutover)" p_env_shred_trap "$YML"
+assert_mutation "H15 (shred removed from the cutover trap)" p_env_shred_trap "$YML" 's~shred -u~rm -f~g'
+# H15b — verify.yml's .env ALSO carries the boot token, so its shred trap must be guarded too (the
+# quality review found H20 asserted only file-execution + install, never the shred trap for verify).
+assert_holds "H15b .env shredded on a host-local EXIT trap (verify)" p_env_shred_trap "$YML_VERIFY"
+assert_mutation "H15b (shred removed from the verify trap)" p_env_shred_trap "$YML_VERIFY" 's~shred -u~rm -f~g'
+
+assert_holds "H16 WORKSPACES_LUKS_DEV (by-id device) derived + passed" p_luks_dev_passed "$YML"
+assert_mutation "H16 (WORKSPACES_LUKS_DEV no longer passed)" p_luks_dev_passed "$YML" \
+  's~WORKSPACES_LUKS_DEV=%s~WORKSPACES_LUKS_UNPASSED=%s~'
+
+assert_holds "H17 environment gate is fail-closed (real freeze arm only)" p_env_gate_failclosed "$YML"
+assert_mutation "H17 (gate expression inverted to always-gated/ungated-freeze)" p_env_gate_failclosed "$YML" \
+  's~!inputs\.dry_run~inputs.dry_run~'
+
+assert_holds "H18 luks-monitor.service has HOME=/root + EnvironmentFile" p_service_env "$SVC"
+assert_mutation "H18 (HOME=/root removed)" p_service_env "$SVC" 's~^Environment=HOME=/root~Environment=FOO=bar~'
+
+assert_holds "H19 freeze-arm reviewer set stays non-empty" p_reviewers_nonempty "$TF_MAIN"
+assert_mutation "H19 (reviewers emptied → auto-approve)" p_reviewers_nonempty "$TF_MAIN" \
+  's~users[[:space:]]*=[[:space:]]*\[[0-9]+\]~users = []~'
+
+assert_holds "H20 verify.yml uses file-execution + stdin token (no sudo binary)" p_verify_file_execution "$YML_VERIFY"
+assert_mutation_append "H20 (old sudo /usr/local/bin/luks-monitor re-introduced)" p_verify_file_execution "$YML_VERIFY" \
+  '          ${WEB_HOST_SSH} "$WEB_HOST" "sudo /usr/local/bin/luks-monitor"'
 
 # --- Summary ------------------------------------------------------------------
 echo "workspaces-luks-header.test.sh: $passes passed, $fails failed"

--- a/apps/web-platform/infra/workspaces-luks.tf
+++ b/apps/web-platform/infra/workspaces-luks.tf
@@ -122,6 +122,25 @@ resource "doppler_service_token" "workspaces_luks" {
   access  = "read"
 }
 
+# #6649 — publish the boot token to a repo-level GitHub Actions secret so the cutover/verify
+# workflows can deliver it host-side (the ONLY credential that reads prd_workspaces_luks; web-1's
+# baked DOPPLER_TOKEN is prd-root-scoped and cannot). Mirrors github_actions_secret.doppler_token_inngest_arm
+# (inngest-arm-write-token.tf) exactly: a repo secret, no lifecycle.ignore_changes — a `-replace`
+# rotation of the token propagates the new key here in the same apply.
+#
+# This reclassifies the token from operator-applied-host-token to CI-PUBLISHED token, so
+# apply-web-platform-infra.yml's DEFAULT allow-list explicitly targets BOTH this resource AND
+# doppler_service_token.workspaces_luks, and terraform-target-parity.test.ts REMOVES the token from
+# OPERATOR_APPLIED_TOKEN_EXCLUSIONS (the #5566 "a token feeding a github_actions_secret MUST be
+# targeted, never excluded" rule). It rides the DEFAULT apply, NOT the scoped
+# apply_target=workspaces-luks-cutover job (whose gate asserts EXACTLY the five volume/attachment/
+# passphrase/secret/token creates and would abort on a sixth resource).
+resource "github_actions_secret" "workspaces_luks_boot_token" {
+  repository      = "soleur"
+  secret_name     = "WORKSPACES_LUKS_BOOT_TOKEN"
+  plaintext_value = doppler_service_token.workspaces_luks.key
+}
+
 # --- The encrypted volume -----------------------------------------------------
 # DELIBERATELY NO `format` ATTRIBUTE. This is the single most important line in the
 # file — and it is a line that is NOT here.
@@ -189,12 +208,15 @@ resource "hcloud_volume_attachment" "workspaces_luks" {
 
 # GitHub Environment with a required-reviewer protection rule — the SOLE human
 # authorization on the irreversible /workspaces LUKS freeze (C19 / AC20b; DP-11 F8).
-# The freeze job in .github/workflows/workspaces-luks-cutover.yml declares
-# `environment: workspaces-luks-cutover`, so the run is held in "Waiting" for reviewer
-# approval BEFORE any step executes — that approval IS the human ack. A zero-reviewer
-# environment auto-approves, so reviewers.users MUST stay non-empty. reviewers.users
-# takes numeric GitHub user IDs — 54279 = @deruelle (the operator/founder). Mirrors
-# github_repository_environment.inngest_cutover (inngest-arm-write-token.tf).
+# The cutover job in .github/workflows/workspaces-luks-cutover.yml declares
+# `environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (#6649), so the
+# REAL freeze arm (`dry_run=false`) is held in "Waiting" for reviewer approval BEFORE any
+# step executes — that approval IS the human ack — while a reversible `dry_run=true` rehearsal
+# resolves to an empty (ungated) environment and runs unattended (autonomy). The expression is
+# fail-closed: the same `!inputs.dry_run` operand gates the freeze, so any freeze-reachable run
+# is gated. A zero-reviewer environment auto-approves, so reviewers.users MUST stay non-empty for
+# the freeze arm. reviewers.users takes numeric GitHub user IDs — 54279 = @deruelle (the
+# operator/founder). Mirrors github_repository_environment.inngest_cutover (inngest-arm-write-token.tf).
 #
 # Provisioned by the DEFAULT allow-list apply (apply-web-platform-infra.yml push /
 # apply_target=manual-rerun), NOT the scoped apply_target=workspaces-luks-cutover job:

--- a/knowledge-base/engineering/architecture/decisions/ADR-119-luks-at-rest-for-the-live-workspaces-volume.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-119-luks-at-rest-for-the-live-workspaces-volume.md
@@ -315,6 +315,56 @@ architectural axis, so no new ADR):
   radius" property — that distinctness lives only at runtime (the `load_escrow_creds` name-compare +
   negative probe) + the `workspaces-luks-header.test.sh` reference-not-literal guard, not in the picture.
 
+## Addendum (2026-07-18): the escrow-rehearsal authorization model (#6649)
+
+The escrow rehearsal (`workspaces-luks-cutover.yml -f dry_run=true`) must run FULLY AUTONOMOUSLY — the
+operator is non-technical and never approves gates or runs terraform. Three host-provisioning/
+execution gaps (content-carrier, boot-token delivery, `WORKSPACES_LUKS_DEV`) blocked the probe; a
+fourth — the human gate — blocked autonomy. This addendum records the authorization-model change only;
+the mechanics live in the plan.
+
+**The gate moves onto the irreversible arm.** The cutover job previously declared a static
+`environment: workspaces-luks-cutover` at job level, so EVERY dispatch — including a `dry_run=true`
+rehearsal — waited on a required-reviewer (`[54279]`) approval. But a dry-run performs NO irreversible
+operation: the freeze/repoint are behind `DRY_RUN != 1` in `workspaces-cutover.sh`, and the plaintext
+wipe is a separate `CONFIRM_WIPE` dispatch. Gating a reversible probe behind a human is the actual
+misconfiguration. The job now declares:
+
+```yaml
+environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}
+```
+
+**Reversibility proof (what the dry-run actually touches on web-1).** The dry-run is NOT
+host-side-effect-free, but every effect is reversible/benign: `ensure_aws` installs a SHA-pinned
+aws-cli (additive, no service restart); `escrow_probe` does a PUT→read-back→delete of a namespaced
+`.probe/<run-id>` R2 key (self-cleaning); `prepare_luks_target` selects, `luksFormat`s-if-raw, and
+opens the FRESH device (never the live plaintext volume — selected by by-id + a single-match assertion,
+guarded by the `blkid` discriminator §(g) that refuses to format a device carrying a filesystem
+signature) under the DP-6 `trap cleanup EXIT` host-local rollback. The `luksFormat` is destructive only
+on the disposable fresh volume; the live plaintext `/mnt/data` is never a candidate. None of these is the irreversible act the C19/AC20b
+gate exists to authorize (the freeze + plaintext wipe), all of which stay behind `DRY_RUN != 1`.
+
+**Truth table (why the expression is fail-closed).**
+
+| `inputs.dry_run` | `!inputs.dry_run` | `&& 'workspaces-luks-cutover'` | `\|\| ''` | environment | gated? |
+|---|---|---|---|---|---|
+| `true` (rehearsal) | `false` | `false` | `''` | none (empty) | NO — autonomous |
+| `false` (real freeze) | `true` | `'workspaces-luks-cutover'` | (short-circuits) | `workspaces-luks-cutover` | YES — human ack |
+
+The expression reads the **typed** `inputs.dry_run` boolean context (declared `type: boolean, default: true`), so `!inputs.dry_run` coerces on a real boolean — never the string-typed `github.event.inputs.dry_run`, where `!'false'` is `false` and the freeze would run **ungated**. Drift guards `workspaces-luks-header.test.sh` H17 (exact fail-closed byte-form) + H19 (non-empty reviewers) pin this; they go RED on the inversion. **Sequencing:** the boot-token secret rides the DEFAULT apply, not the scoped `apply_target=workspaces-luks-cutover` first-provision — between a scoped first-provision and the next default apply the secret is unpublished, so both workflows fail loud (`[[ -n "$WORKSPACES_LUKS_BOOT_TOKEN" ]] || exit 1`) rather than proceeding tokenless.
+
+The gate and `DRY_RUN` derive from the SAME `inputs.dry_run` operand, so "freeze-reachable" ⟺ "gated"
+is a tautology — there is no input that reaches the freeze arm ungated. The empty-string branch changes
+ONLY autonomy, never the safety property. **Never invert the operands:** `inputs.dry_run && '' || 'X'`
+gates ALWAYS (`''` is falsy, so it falls through to `'X'` in both arms) — the opposite of intent, and it
+would leave the freeze ungated in exactly the case that matters. A drift guard
+(`workspaces-luks-header.test.sh` H17) asserts the exact fail-closed form and goes RED on the inversion.
+
+The reviewer set MUST stay non-empty (a zero-reviewer environment auto-approves — DP-11 F8); H19 asserts
+it. Split-job (a `rehearse` job with no environment + a `freeze` job with a static `environment:`) is the
+auditability-preferred fallback if GitHub's empty-string-environment semantics ever change; the
+conditional form is the primary because it keeps the two arms in one job (no duplicated bridge/teardown).
+
 ## References
 
 - Issue #6588 — the P1 that mandated CTO routing before terraform.

--- a/knowledge-base/project/learnings/2026-07-18-forbiddance-drift-guard-encodes-pre-refactor-threat-model.md
+++ b/knowledge-base/project/learnings/2026-07-18-forbiddance-drift-guard-encodes-pre-refactor-threat-model.md
@@ -1,0 +1,74 @@
+---
+title: "A forbiddance drift-guard written during a refactor tends to guard the OLD mechanism, not the new one"
+date: 2026-07-18
+category: test-failures
+tags: [drift-guard, test-design, refactor, security, review]
+issue: 6649
+pr: 6686
+---
+
+# A forbiddance drift-guard written during a refactor tends to guard the OLD mechanism, not the new one
+
+## Problem
+
+#6649 removed `sudo` from the workspaces-luks host-execution path (the CF-tunnel SSH bridge
+lands `-l root`, so `sudo` was redundant AND its `env_reset` scrubbed `HOME`/the sourced `.env`).
+Alongside the refactor I wrote two negative drift guards to protect the "boot token never enters
+the host process list" invariant:
+
+- H14: `grep -Eq 'sudo[[:space:]]+([A-Za-z_]+[[:space:]]+)*(DOPPLER_TOKEN|…)='` → forbid a
+  `sudo VAR=val` argv leak.
+- H20: `grep -q 'sudo /usr/local/bin/luks-monitor'` → forbid the old pre-installed-binary call.
+
+Both passed, were mutation-tested, and read as solid. A test-design review agent (prompted with
+"find the vacuity the battery MISSED — do not re-run its mutations") found both guard the
+**pre-refactor** threat shape: the refactor itself removed `sudo`, so the realistic *next*
+regression is the SAME leak via the NEW mechanism — a **sudo-less** `DOPPLER_TOKEN=$x bash …`
+argv assignment, or a bare `/usr/local/bin/luks-monitor` call. Both evade a `sudo`-anchored
+regex entirely (confirmed against sandbox copies: the predicates returned "holds" while leaking).
+
+## Root cause
+
+When you author a forbiddance guard *during* a refactor that removes mechanism M, the bad-form
+you have front-of-mind is "M plus the leak" (`sudo VAR=val`) — because that is what you just
+deleted. But M is gone; the code can no longer take that path. The guard therefore protects a
+shape the code can no longer produce, while the shape it CAN now produce (the leak without M)
+sails through green. A forbiddance predicate that enumerates a specific bad form is only as good
+as the author's imagination of bad forms, and a just-completed refactor actively biases that
+imagination toward the retired one.
+
+## Solution
+
+**Assert the GOOD form exclusively, mechanism-independently — don't blacklist the specific old bad form.**
+
+- H14 became: the only permitted `(DOPPLER_TOKEN|WORKSPACES_LUKS_BOOT_TOKEN)=` occurrence is the
+  printf placeholder `=%s` (the stdin `.env` payload); any `=` NOT immediately followed by `%` is a
+  leak — `grep -Eq '(DOPPLER_TOKEN|WORKSPACES_LUKS_BOOT_TOKEN)=([^%]|$)'` — with or without `sudo`,
+  `-E`, `--preserve-env`, or an intervening `FOO=bar`.
+- H20 became: forbid the `/usr/local/bin/luks-monitor` path regardless of `sudo`.
+- Added mutations for the sudo-LESS forms so the guard's own battery proves it catches them.
+
+## Key insight
+
+The litmus (from the review skill's own catalogue): *can you name an implementation a reasonable
+engineer might write NEXT that satisfies the assertion while violating the property?* During a
+refactor, the highest-probability "next implementation" is the one that reaches the same bad end
+via the mechanism you just introduced — so a forbiddance guard anchored on the mechanism you just
+removed is vacuous by construction. Prefer whitelisting the good form (verb/prefix/mechanism-blind)
+over blacklisting a bad form. This is the refactor-time corollary of "assert the property, not the
+shape the code happens to have."
+
+## Session Errors
+
+- **Forbiddance guards H14/H20 encoded the pre-refactor `sudo` threat model** — Recovery: rewrote
+  to assert the good form exclusively (sudo-independent) + added sudo-less mutations. **Prevention:**
+  this learning; when writing a negative guard during a mechanism-removing refactor, whitelist the
+  good form rather than blacklist the removed mechanism.
+- **H17 predicate SIGPIPE-flaked** (`strip_comments | grep -q` under `pipefail`, early match →
+  SIGPIPE → false 0) — Recovery: herestring form. **Prevention:** already documented in
+  [[2026-07-18-pipefail-grep-q-early-match-sigpipe-flakes-drift-guards]]; reused that fix.
+- **Over-deferred automatable operator/terraform steps** at the investigate-then-plan boundary —
+  Recovery: user corrected; ran the apply-trigger + rehearsal + issue-close autonomously.
+  **Prevention:** already enforced by `hr-never-label-any-step-as-manual-without` +
+  `hr-exhaust-all-automated-options-before`; an "investigate and return a scoped plan" framing does
+  NOT license enumerating automatable steps as terminal operator actions.

--- a/knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md
@@ -1,0 +1,278 @@
+---
+title: "fix(infra): make the workspaces-luks escrow rehearsal fully autonomous + get the escrow probe GREEN (#6649)"
+issue: 6649
+type: fix
+lane: cross-domain
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+adr: ADR-119 (addendum)
+created: 2026-07-18
+branch: feat-one-shot-6649-luks-escrow-autonomy
+---
+
+# fix(infra): workspaces-luks escrow rehearsal — fully autonomous + escrow probe GREEN (#6649)
+
+## Enhancement Summary
+
+**Deepened:** 2026-07-18 · **Agents:** security-sentinel, architecture-strategist, spec-flow-analyzer, code-simplicity-reviewer, observability/verify-negative Explore · **Hard gates:** 4.6 (user-brand) PASS, 4.7 (observability) PASS, 4.8 (PAT-shaped) pass-with-benign-Hetzner-token-false-positive, 4.9 (UI-wireframe) N/A.
+
+**Key improvements from the review:**
+1. **P1 — token classification corrected:** explicit `-target=doppler_service_token.workspaces_luks` + REMOVE it from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS` (mirror inngest; #5566 silent-un-applied rule) — was "reconcile a comment."
+2. **P1 — `.env` on tmpfs would defeat the shred:** relocate to `STATE_DIR` (F7) + consolidate write→trap→run into one `bash -c` (closes the un-trapped-file window).
+3. Autonomy gate CONFIRMED sound (freeze-reachable ⟺ gated; empty-string-env affects only autonomy, never safety); split-job recorded as the auditability-preferred fallback.
+4. Reachability preconditions (A–F) enumerated — the probe is reached only if the volume is attached, aws-cli installs, and 4 header secrets exist (all post-merge-verified).
+5. Two latent P1 host bugs confirmed + fixed (`HOME=/root` on the service unit; `DOPPLER_TOKEN` bake for the daily probe).
+
+See `## Deepen-Plan Review Synthesis` for the full verdict list; taste/scope dissents in `knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/decision-challenges.md`.
+
+## Overview
+
+The `/workspaces` LUKS cutover (ADR-119, epic #6588) has a working escrow *design* — `workspaces-cutover.sh` already carries `load_escrow_creds` + `escrow_probe` (the DRY_RUN-safe probe-PUT + negative over-scope probe) and the R2 escrow S3 token is minted with its akid/secret in Doppler `prd_workspaces_luks`. But the rehearsal cannot reach the probe, and every rehearsal blocks on a human. Four host-provisioning + execution-model gaps remain (all verified against the current worktree, not paraphrased):
+
+1. **BLOCKER 3 — content-carrier execution.** The cutover workflow pipes the whole script via `${WEB_HOST_SSH} "$WEB_HOST" "sudo … bash -s" < workspaces-cutover.sh` (`workspaces-luks-cutover.yml:130-131`). Under `set -uo pipefail`, `${BASH_SOURCE[0]}` (`workspaces-cutover.sh:63`, `:475`, `:477-478`) is unbound when the body arrives on stdin — so the emit sibling is never sourced (`emit_drift` degrades to log-only, the Sentry `feature=workspaces-luks op=workspaces-luks-drift` channel goes dark) and the real arm cannot install the luks-monitor units. On a host without `/usr/local/bin/workspaces-luks-emit.sh` already installed (the pre-cutover state), line 63's `||` branch dereferences the unbound `${BASH_SOURCE[0]}` and the script dies immediately — the observed `rc=1` at "Run workspaces-luks cutover".
+2. **BLOCKER 4 — the prd_workspaces_luks token never reaches the host script.** `read_key` (`:68/:247`) and the `read_header_*`/`load_escrow_creds` reads (`:74-121`) all run host-side as `doppler secrets get … --config prd_workspaces_luks`, but the workflow's SSH invocation passes only `DRY_RUN`/`ROLLBACK` into the `sudo` env (`:130`) — no Doppler credential reaches the host, and the workflow's own `DOPPLER_TOKEN` is `prd_terraform`-scoped (cannot read `prd_workspaces_luks`). The ONLY credential that can is `doppler_service_token.workspaces_luks` (`workspaces-luks.tf:118-123`, scoped to `prd_workspaces_luks`), which is created but **published nowhere** — no `github_actions_secret`, no bake.
+3. **BLOCKER 5 — `WORKSPACES_LUKS_DEV` unset.** `prepare_luks_target` (`:252-253`) dies `WORKSPACES_LUKS_DEV unset or absent` — it runs in BOTH arms and BEFORE `escrow_probe` (`:280`), so fixing blocker 4 alone still never reaches the probe.
+4. **AUTONOMY — the human gate sits on the rehearsal.** The cutover job declares `environment: workspaces-luks-cutover` at job level (`workspaces-luks-cutover.yml:62`), whose reviewer set is `[54279]` (`workspaces-luks.tf:207-209`). Every dry-run rehearsal waits on a human approval, even though the dry-run performs NO irreversible operation (freeze/flip are behind `DRY_RUN != 1`; the wipe is a separate `CONFIRM_WIPE` dispatch). We move the gate onto the real freeze arm only, keeping the C19/AC20b human authorization on the irreversible operation.
+
+This is a `single-user incident` brand-survival plan: the surface is sole-copy user source code, and the escrow proof this rehearsal exercises is the ONLY defense against the ADR-119 terminal failure (passphrase/header loss ⇒ unreadable forever). The autonomy change touches the authorization boundary on that irreversible path, so security-sentinel + architecture-strategist review is a hard gate (see `## Architecture Decision`).
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Task-prescribed claim | Codebase reality (verified) | Plan response |
+|---|---|---|
+| "tar-pipe … then run `sudo bash /path/workspaces-cutover.sh`" for BOTH cutover.yml AND verify.yml | `verify.yml:81` runs `sudo /usr/local/bin/luks-monitor` (read-only), and its header contract is "MUTATES NOTHING". Running `workspaces-cutover.sh` there would open the real device (`prepare_luks_target`) — breaking the read-only invariant. `WEB_HOST_SSH` already lands as **root** (`-l root`). | Ship the SAME bundle to both hosts, but each runs its correct entrypoint: cutover.yml → `bash <dir>/workspaces-cutover.sh`; verify.yml → `bash <dir>/luks-monitor` (read-only, preserving the MUTATES-NOTHING contract). `sudo` is dropped — `WEB_HOST_SSH` is `ssh … -l root`, so `sudo` is redundant AND its `env_reset` scrubs `HOME`/the sourced env; running the file directly as root preserves `HOME=/root` (needed for `doppler`). This is a deliberate, security-preserving deviation from the literal wording. **Security review must confirm verify.yml stays read-only.** |
+| "add a `github_actions_secret WORKSPACES_LUKS_BOOT_TOKEN` in workspaces-luks.tf … provisioned by the DEFAULT allow-list apply" | Confirmed viable. `apply-web-platform-infra.yml:361` already targets `github_repository_environment.workspaces_luks_cutover` in the DEFAULT allow-list. `workspaces-luks.test.sh` A11 counts only `doppler_secret`/`doppler_service_token`/`random_password`/`hcloud_volume` cardinality + forbids `config = "prd"`; a `github_actions_secret` matches none, and `github_repository_environment` already coexists → **A11 stays green.** | Add `github_actions_secret.workspaces_luks_boot_token` to `workspaces-luks.tf`; add `-target=github_actions_secret.workspaces_luks_boot_token` to the DEFAULT allow-list (NOT the scoped cutover `-target` set at `:2660-2664`). |
+| (task did not mention) parity-test invariant on the token — **[CORRECTED by deepen-plan architecture review, P1]** | `terraform-target-parity.test.ts:686-688` rule: "Do NOT grow `OPERATOR_APPLIED_TOKEN_EXCLUSIONS` for a token that feeds a github_actions_secret — that is the #5566 silent-un-applied class and MUST be targeted." The `inngest_arm_write` precedent targets BOTH `doppler_service_token.inngest_arm_write` AND `github_actions_secret.doppler_token_inngest_arm` explicitly, and does NOT exclude the token. Publishing `doppler_service_token.workspaces_luks.key` reclassifies it from operator-applied-host-token to **CI-published token**. | **Mirror inngest exactly:** add an EXPLICIT `-target=doppler_service_token.workspaces_luks` to the DEFAULT allow-list (alongside the `github_actions_secret` target) AND **REMOVE** `doppler_service_token.workspaces_luks` from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS`. Do NOT rely on `-target` transitivity + a self-contradicting exclusion (a comment reconciliation alone is insufficient — the classification changed). /work: verify the interaction with the general 5-resource `OPERATOR_APPLIED_EXCLUSIONS` and the scoped cutover gate (the gate asserts only `vc/ac/sc` creates, not a token create, so a pre-created token is fine; the scoped `-target` set at `:2660-2664` still lists the token — idempotent). |
+| BLOCKER 4c: "persist the token to /etc/default/luks-monitor … so the daily probe works" | cloud-init bakes `/etc/default/luks-monitor` with ONLY `SOLEUR_SENTRY_DSN` (`cloud-init.yml:422-424`) — NO `DOPPLER_TOKEN`. AND `luks-monitor.service` has NO `Environment=HOME=/root`; a root systemd unit running `doppler` dies `$HOME is not defined` (learning `2026-07-18-web-1-root-doppler-unit-needs-home-…`). | Real arm persists `DOPPLER_TOKEN=<boot token>` into `/etc/default/luks-monitor` (0600 root, preserving the baked DSN). **Also add `Environment=HOME=/root` to `luks-monitor.service`** — a latent bug that would make the daily timer probe fail even with the token present. |
+| conditional environment `${{ inputs.dry_run && '' || 'X' }}` (the "obvious" form) | This is **inverted**: `''` is falsy, so `true && '' → ''` then `'' || 'X' → 'X'` ⇒ ALWAYS gated. | Use the fail-closed complement `${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (truth table in `## Architecture Decision`). This mirrors the existing `DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}` logic (`:110`) — same boolean coercion the file already trusts. |
+| `hcloud_volume.workspaces_luks.id` → by-id device | `cloud-init.yml:573-574` mounts `/mnt/data` via `/dev/disk/by-id/scsi-0HC_Volume_${workspaces_volume_id}` — the confirmed convention. Volume name literal is `soleur-web-platform-data-luks` (`workspaces-luks.tf:166`). The Hetzner token variable `hcloud_token` ← Doppler `HCLOUD_TOKEN` in `prd_terraform` (`main.tf:88`, `variables.tf:15`) — a Hetzner API token, NOT a GitHub PAT (no GitHub-App alternative applies). | Derive the id via the hcloud API by volume name using `HCLOUD_TOKEN` (workflow already holds a `prd_terraform` `DOPPLER_TOKEN`); construct `WORKSPACES_LUKS_DEV=/dev/disk/by-id/scsi-0HC_Volume_<id>`. Terraform-output is the documented fallback. |
+
+**Premise validation (Phase 0.6):** #6649 is OPEN (title: "wire WORKSPACES_HEADER_BUCKET + R2 creds into the workspaces-luks freeze path"). The prior `#6649` plan (`2026-07-18-fix-6649-workspaces-luks-header-escrow-wiring-plan.md`) delivered ONLY the header-escrow bucket/creds + probe machinery — it does NOT touch content-carrier, boot-token delivery, `WORKSPACES_LUKS_DEV`, or the autonomy gate. All four blockers here are fresh. Every cited file/line/symbol was read directly and holds.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a `dry_run=true` rehearsal that still cannot prove the escrow path (probe never reached), so the FIRST real freeze runs against an unproven escrow — and if the passphrase/header escrow is in fact unusable, every user's checked-out source code becomes unreadable forever the moment the plaintext backstop is wiped. A subtler failure: the autonomy change mis-gates and lets a real freeze (`dry_run=false`) run WITHOUT the human authorization.
+**If this leaks, the user's data is exposed via:** the boot token (`WORKSPACES_LUKS_BOOT_TOKEN`) resolves ~116 `prd` secrets (branch-config inheritance, workspaces-luks.tf:77-89) — a leak of it is a full-prd credential exposure. Its exposure surfaces, each mitigated/scoped-out (review-completeness, #6649):
+- *In transit to the host:* delivered ONLY over a mode-0600 root env file via stdin (never `sudo VAR=val`, never argv), shredded on a host-local EXIT trap. Guard: H14 (sudo-independent argv-leak forbiddance).
+- *Repo-level GitHub Actions secret* (`github_actions_secret.workspaces_luks_boot_token`): readable by any default-branch workflow. Scope-out: mirrors the accepted `doppler_token_inngest_arm` precedent; fork PRs receive no secrets; main-write == operator trust; and web-1 already carries a full-prd `DOPPLER_TOKEN`, so a repo-secret-exfil attacker gains no net-new capability.
+- *Persistent 0600-root copy at `/etc/default/luks-monitor`* (written only in the real freeze arm, for the daily timer probe): outside the `docker run --env-file` TMPENV path, so the CWE-522 container boundary holds; born 0600 via `umask 077` (no world-readable window); mirrors the baked `SOLEUR_SENTRY_DSN` + sibling root-doppler units.
+- *Root host mutation on the ungated dry-run:* `ensure_aws` runs `apt-get install` + a SHA256-pinned aws-cli installer as root on every autonomous rehearsal (additive, idempotent, no service restart — full scope-out in `## Architecture Decision`).
+- **Brand-survival threshold:** single-user incident
+
+CPO sign-off required at plan time (headless: recorded in frontmatter `requires_cpo_signoff: true`; `user-impact-reviewer` runs at review-time per the review skill's conditional-agent block). security-sentinel + architecture-strategist confirm the autonomy change preserves C19/AC20b.
+
+## Hypotheses (network-outage gate)
+
+The feature description matches SSH/timeout keywords, but this is NOT a connectivity diagnosis. Per the task context and `2026-07-18-cutover-bridge-dryrun-guard-…` the L3/L4 layers are **verified green**: the CF-Tunnel SSH bridge reaches web-1 (private `10.0.1.10`), the bridge runs unconditionally on the dry-run path (`workspaces-luks-cutover.yml:88-93`), and `workspaces-cutover.sh` already runs ON the host. The observed `rc=1` is at **L7 (the script body)** — BASH_SOURCE unbound / missing Doppler token / missing device — not a firewall, DNS, or routing failure. No firewall/`admin_ips`/fail2ban change is proposed or needed (`hr-ssh-diagnosis-verify-firewall` satisfied: firewall confirmed not the cause).
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (grep/verify, no code)
+- Confirm `WEB_HOST_SSH` format is `ssh -i <keyfile> -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root` (`.github/actions/cf-tunnel-ssh-bridge/action.yml`) — lands as root, pipes tar + stdin.
+- Confirm the scoped cutover `-target` set (`apply-web-platform-infra.yml:2660-2664`) is EXACTLY the five workspaces_luks resources — the new `github_actions_secret` must NOT be added there (the sourced `workspaces_luks_cutover_gate` would abort it as `out_of_scope`).
+- Verify (WebFetch GitHub Actions docs) that a job `environment:` evaluating to an EMPTY string runs with no environment gate. If NOT confirmed, use the split-job fallback (`## Architecture Decision`).
+
+### Phase 1 — BLOCKER 3: content-carrier → file execution (RED test first)
+1. Harden `workspaces-cutover.sh`: replace every `${BASH_SOURCE[0]}` with `${BASH_SOURCE[0]:-}` (`:63`, `:475`, `:477`, `:478`) and, where a bare-empty dirname would resolve to `.`, anchor on `SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"` computed once near the top so file-execution is unambiguous. (`luks-monitor.sh:29` is NOT hardened — code-simplicity: it is always run as a file, so `${BASH_SOURCE[0]}` is never unbound; dropped from scope to keep the change minimal.)
+2. In `workspaces-luks-cutover.yml`'s "Run workspaces-luks cutover" step: replace the `bash -s < script` pipe with:
+   - **[security P1 — F7]** `REMOTE_DIR=$(${WEB_HOST_SSH} "$WEB_HOST" 'mkdir -p /var/lib/workspaces-luks && chmod 700 /var/lib/workspaces-luks && mktemp -d -p /var/lib/workspaces-luks')` — the bundle + `.env` land on the **persistent `STATE_DIR`, NOT `mktemp -d`'s default `/tmp`**. A tmpfs `/tmp` makes the `shred` a no-op against the raw device — the exact F7 anti-pattern the script already fixed for the LUKS header at `workspaces-cutover.sh:296-297`. The boot token is a full-prd-capable secret, so its temp file MUST be shreddable.
+   - `tar czf - -C "$INFRA_DIR" workspaces-cutover.sh workspaces-luks-emit.sh luks-monitor.sh luks-monitor.service luks-monitor.timer | ${WEB_HOST_SSH} "$WEB_HOST" "tar xzf - -C '$REMOTE_DIR'"`
+   - **[security P2 — close the write→trap window]** Write the `.env` (Phase 2/3) AND arm the shred trap AND run the script in a SINGLE remote `bash -c`, so the trap covers the `.env`'s ENTIRE lifetime (no window where the 0600 token file exists un-trapped). Because the script now runs as a file, host stdin is free for the `.env` payload: `printf 'DOPPLER_TOKEN=%s\nWORKSPACES_LUKS_DEV=%s\nDRY_RUN=%s\nROLLBACK=%s\n' … | ${WEB_HOST_SSH} "$WEB_HOST" "bash -c 'install -m600 /dev/stdin \"$REMOTE_DIR/.env\"; trap \"shred -u \\\"$REMOTE_DIR/.env\\\" 2>/dev/null || rm -f \\\"$REMOTE_DIR/.env\\\"\" EXIT; set -a; . \"$REMOTE_DIR/.env\"; set +a; bash \"$REMOTE_DIR/workspaces-cutover.sh\"'"` — NO `sudo` (bridge lands `-l root`; dropping sudo preserves `HOME=/root` for `doppler`; execution is `bash <file>`, so a `noexec` mount is irrelevant). Env-file fields are metacharacter-free (dp.st token / `/dev/disk/by-id/…` path / `0`/`1`) so `set -a; . .env` is injection-safe — a Sharp Edge constraint to preserve.
+   - Preserve the existing `set +e`/`rc=$?`/`::error::` diagnostic and the `[[ -n "${WEB_HOST_SSH:-}" ]]` guard (diff field-by-field per learning `2026-03-20-ssh-forced-command-workflow-refactoring-drops-parameters`).
+   - **[spec-flow/arch P2]** The nested-quoting of this assembled command is fragile — the Phase-5 mutation test MUST exercise the ASSEMBLED command string (that `install`+`trap`+`bash <file>` all appear in one remote invocation), not merely grep for `tar xzf`.
+3. Add an `if: always()` teardown step that SSHes `rm -rf "$REMOTE_DIR"` (belt-and-suspenders; the `.env` is shredded by the trap even on SSH drop).
+4. In `workspaces-luks-verify.yml`: tar-pipe `luks-monitor.sh` + `workspaces-luks-emit.sh` to a `STATE_DIR` temp dir, deliver the boot token via the **SAME 0600-stdin-env-file + host-local shred-trap discipline** (security/arch P2 — verify.yml widens the token to a second workflow, so it must not regress the delivery discipline), run `bash <dir>/luks-monitor` sourcing the `.env` — replacing `sudo /usr/local/bin/luks-monitor`. Keeps read-only (luks-monitor mutates nothing; verified) and removes the dependency on a prior cutover having installed the binary. **NOTE (scope dissent recorded):** code-simplicity flagged verify.yml as cuttable (it runs an already-installed file, no BASH_SOURCE bug; not on #6649's dry-run-green critical path). Kept per the task's explicit "BOTH workflows" direction + the genuine token-delivery bug (manual `sudo luks-monitor` has no `EnvironmentFile`, so `doppler` fails); dissent logged in `decision-challenges.md`.
+
+### Phase 2 — BLOCKER 4: deliver the prd_workspaces_luks boot token
+1. **(a) Publish the token.** Add to `apps/web-platform/infra/workspaces-luks.tf` (mirrors `inngest-arm-write-token.tf`; repo-level — the TF GitHub App cannot write environment secrets):
+   ```hcl
+   resource "github_actions_secret" "workspaces_luks_boot_token" {
+     repository      = "soleur"
+     secret_name     = "WORKSPACES_LUKS_BOOT_TOKEN"
+     plaintext_value = doppler_service_token.workspaces_luks.key
+     # NO lifecycle.ignore_changes — a -replace rotation of the token propagates the new key here.
+   }
+   ```
+   **[architecture P1 — mirror the inngest precedent exactly; #5566 silent-un-applied class]** Add TWO explicit `-target` lines to the DEFAULT allow-list in `apply-web-platform-infra.yml` (near `:361`): `-target=doppler_service_token.workspaces_luks` AND `-target=github_actions_secret.workspaces_luks_boot_token` — exactly as `inngest_arm_write` + `doppler_token_inngest_arm` are both targeted. Then **REMOVE `doppler_service_token.workspaces_luks` from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS`** in `terraform-target-parity.test.ts` — the rule at `:686-688` forbids excluding a token that feeds a `github_actions_secret` ("MUST be targeted"), because publishing `.key` reclassifies it from operator-applied-host-token to CI-published token. Do NOT rely on `-target` transitivity + a self-contradicting exclusion (a comment reconciliation is insufficient — the classification changed). **/work MUST verify against the inngest precedent side-by-side** the interaction with (i) the general 5-resource `OPERATOR_APPLIED_EXCLUSIONS` and (ii) the scoped cutover gate (`workspaces-luks-cutover-gate.sh` asserts only `vc/ac/sc` creates, not a token create, so a token already in state from the DEFAULT apply is fine; the scoped `-target` set at `apply-web-platform-infra.yml:2660-2664` still lists the token — idempotent).
+   Update the stale `workspaces-luks.tf:190-210` env-gate comment AND the `workspaces-luks-cutover.yml:9-16` workflow comment block (the "environment gate ... covers every dispatch / is the ONLY human authorization" prose) to say the environment is applied ONLY to the real freeze arm (dry-run rehearsals run ungated for autonomy; the reviewer set stays non-empty for the freeze). Both doc sites must be reconciled, not just line 62.
+2. **(b) Inject into the host script env.** In cutover.yml, add step env `WORKSPACES_LUKS_BOOT_TOKEN: ${{ secrets.WORKSPACES_LUKS_BOOT_TOKEN }}` + a fail-loud presence check. Write the `.env` file:
+   ```
+   printf 'DOPPLER_TOKEN=%s\nWORKSPACES_LUKS_DEV=%s\nDRY_RUN=%s\nROLLBACK=%s\n' \
+     "$WORKSPACES_LUKS_BOOT_TOKEN" "$LUKS_DEV" "$DRY_RUN" "$ROLLBACK" \
+     | ${WEB_HOST_SSH} "$WEB_HOST" "install -m600 /dev/stdin '$REMOTE_DIR/.env'"
+   ```
+   NEVER `sudo VAR=val bash` (leaks the token into the host process list). Shredded on the host-local EXIT trap (Phase 1.2).
+3. **(c) Persist for the daily timer (real arm only).** In `workspaces-cutover.sh`, in the `DRY_RUN != 1` arm (near the luks-monitor unit install, `:474-482`), write `DOPPLER_TOKEN=<the boot token from env>` into `/etc/default/luks-monitor` (0600 root) preserving the baked `SOLEUR_SENTRY_DSN`, so `luks-monitor.service`'s `EnvironmentFile` supplies the token to the daily probe. Add `Environment=HOME=/root` to `luks-monitor.service` (a root doppler unit dies without it).
+
+### Phase 3 — BLOCKER 5: derive + pass WORKSPACES_LUKS_DEV
+1. In cutover.yml, before writing the `.env`, resolve the volume id:
+   ```
+   HCLOUD_TOKEN=$(doppler secrets get HCLOUD_TOKEN --plain -p soleur -c prd_terraform)
+   VID=$(curl -fsS --max-time 15 -H "Authorization: Bearer $HCLOUD_TOKEN" \
+     'https://api.hetzner.cloud/v1/volumes?name=soleur-web-platform-data-luks' | jq -r '.volumes[0].id')
+   [[ "$VID" =~ ^[0-9]+$ ]] || { echo "::error::could not resolve workspaces_luks volume id"; exit 1; }
+   LUKS_DEV="/dev/disk/by-id/scsi-0HC_Volume_${VID}"
+   ```
+   (Fallback documented: `terraform init` + `terraform show -json | jq …hcloud_volume.workspaces_luks.id`.) `curl --max-time` is pinned (`hr-never-run-commands-with-unbounded-output` / dig-timeout Sharp Edge). Pass `WORKSPACES_LUKS_DEV=$LUKS_DEV` through the Phase 2 `.env`.
+
+### Phase 4 — AUTONOMY: gate only the freeze arm
+1. Change `workspaces-luks-cutover.yml:62` from `environment: workspaces-luks-cutover` to `environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (fail-closed; truth table in `## Architecture Decision`). Fallback: split into `rehearse` (`if: ${{ inputs.dry_run }}`, no environment) + `freeze` (`if: ${{ !inputs.dry_run }}`, static `environment: workspaces-luks-cutover`) jobs.
+2. Amend ADR-119 (`## Architecture Decision`).
+
+### Phase 5 — Tests (write RED first, `cq-write-failing-tests-before`)
+Extend `apps/web-platform/infra/workspaces-luks-header.test.sh` (it already loads `$YML`=cutover.yml, `$SH`=script) with mutation-tested assertions:
+- The cutover Run step runs the script as a FILE from a tar-shipped dir (asserts `tar xzf` + `bash "$REMOTE_DIR/workspaces-cutover.sh"`; RED on a `bash -s <` re-introduction).
+- The boot token is delivered via `install -m600 /dev/stdin` and NEVER via `sudo` argv nor `DOPPLER_TOKEN=…` on a command line (extend the H7 `p_creds_not_in_workflow` family to also forbid a bare `sudo DOPPLER_TOKEN=` / `sudo WORKSPACES_LUKS_BOOT_TOKEN=` argv form).
+- The `.env` is shredded on an EXIT trap.
+- `WORKSPACES_LUKS_DEV` is passed to the host.
+- The environment expression is fail-closed: gate present unless `dry_run` is exactly true (assert the literal `!inputs.dry_run && 'workspaces-luks-cutover'`).
+- `luks-monitor.service` carries `Environment=HOME=/root` and `EnvironmentFile=-/etc/default/luks-monitor`.
+- `reviewers.users` in `workspaces-luks.tf` stays non-empty (learning `2026-07-17-workflow-env-gate-references-unprovisioned-environment-auto-approves` — two independent checks).
+- Confirm `workspaces-luks.test.sh`, `web-1-swap-concurrency-parity.test.sh`, `terraform-target-parity.test.ts`, and `test-workspaces-luks-cutover-gate.sh` still pass (run `bash apps/web-platform/infra/workspaces-luks.test.sh` etc.).
+
+## Files to Edit
+- `.github/workflows/workspaces-luks-cutover.yml` — tar-pipe bundle + file execution; boot-token + `WORKSPACES_LUKS_DEV` via 0600 stdin env file; conditional environment; volume-id derivation; teardown.
+- `.github/workflows/workspaces-luks-verify.yml` — tar-pipe `luks-monitor.sh`+emit; boot-token delivery; run `bash <dir>/luks-monitor` (read-only).
+- `apps/web-platform/infra/workspaces-cutover.sh` — `${BASH_SOURCE[0]:-…}` hardening; persist `DOPPLER_TOKEN` to `/etc/default/luks-monitor` (real arm); optional `systemctl is-enabled luks-monitor.timer` fail-loud assert after the `install … || true` unit installs (real arm) so a silently-missing unit fails the freeze loud.
+- `apps/web-platform/infra/luks-monitor.service` — add `Environment=HOME=/root`.
+- `apps/web-platform/infra/workspaces-luks.tf` — add `github_actions_secret.workspaces_luks_boot_token`; reconcile the env-gate comment (`:190-210`) for the conditional/split gate.
+- `.github/workflows/apply-web-platform-infra.yml` — add TWO `-target` lines to the DEFAULT allow-list: `doppler_service_token.workspaces_luks` + `github_actions_secret.workspaces_luks_boot_token` (NOT the scoped `:2660-2664` set).
+- `plugins/soleur/test/terraform-target-parity.test.ts` — **REMOVE** `doppler_service_token.workspaces_luks` from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS` (it is now CI-published; #5566 rule at `:686-688`).
+- `apps/web-platform/infra/workspaces-luks-header.test.sh` — new mutation-tested assertions (Phase 5).
+- `knowledge-base/engineering/architecture/decisions/ADR-119-luks-at-rest-for-the-live-workspaces-volume.md` — authorization-model addendum.
+
+## Files to Create
+- (none — all changes extend existing files.)
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+- `${BASH_SOURCE[0]}` no longer appears un-guarded in `workspaces-cutover.sh`/`luks-monitor.sh` (`grep -n 'BASH_SOURCE\[0\]}' ` shows only `:-`-guarded forms).
+- cutover.yml runs the script as a FILE from a tar-shipped temp dir; no `bash -s <` pipe remains; `install -m600 /dev/stdin` is the token-delivery mechanism; no `sudo DOPPLER_TOKEN=`/`sudo WORKSPACES_LUKS_BOOT_TOKEN=` argv form exists; the `.env` EXIT-trap shred is present.
+- `workspaces-luks.tf` declares `github_actions_secret.workspaces_luks_boot_token` referencing `doppler_service_token.workspaces_luks.key` with no `ignore_changes`; `apply-web-platform-infra.yml` DEFAULT allow-list carries the matching `-target`; the scoped cutover `-target` set is unchanged (still exactly five).
+- `workspaces-luks-cutover.yml` environment expression is `${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (or the split-job fallback with a static `environment:` on the freeze job); `reviewers.users` stays `[54279]`.
+- `luks-monitor.service` carries `Environment=HOME=/root`; the real arm persists `DOPPLER_TOKEN` to `/etc/default/luks-monitor` 0600 root.
+- New `workspaces-luks-header.test.sh` assertions are mutation-tested (each predicate goes RED on the drift it names); all existing suites green (`workspaces-luks.test.sh`, `web-1-swap-concurrency-parity.test.sh`, `terraform-target-parity.test.ts` via vitest, `test-workspaces-luks-cutover-gate.sh`).
+- ADR-119 addendum recorded; security-sentinel + architecture-strategist confirm C19/AC20b is preserved (freeze remains gated; only the reversible dry-run is ungated).
+- PR body uses `Ref #6649` (NOT `Closes` — closure is post-merge after the probe goes green, per the ops-remediation Sharp Edge).
+
+### Post-merge (autonomous — zero operator steps)
+- (i) Trigger the DEFAULT apply (`gh workflow run apply-web-platform-infra.yml --ref main -f apply_target=manual-rerun -f reason='publish WORKSPACES_LUKS_BOOT_TOKEN (#6649)'`, or the merge push) → `WORKSPACES_LUKS_BOOT_TOKEN` GH secret published; `hcloud_volume_attachment.workspaces_luks` live (by-id device exists on web-1). Verify via the apply run log + `gh secret list`. Automatable via `gh` CLI.
+- (ii) Confirm `config prd_workspaces_luks` contains `WORKSPACES_HEADER_BUCKET`, `WORKSPACES_HEADER_R2_ENDPOINT`, `WORKSPACES_HEADER_R2_ACCESS_KEY_ID`, `WORKSPACES_HEADER_R2_SECRET_ACCESS_KEY` (all four; `load_escrow_creds` is fail-loud) via `doppler secrets --config prd_workspaces_luks` read.
+- (iii) `gh workflow run workspaces-luks-cutover.yml --ref main -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS` — MUST run with NO human approval wait (autonomy) and reach `escrow_probe`.
+- (iv) On the escrow probe-PUT + negative over-scope probe GREEN (read the verdict from Better Stack / Sentry `feature=workspaces-luks op=workspaces-luks-drift` and the run log — NEVER SSH-eyeball), close #6649: `gh issue close 6649 --comment "<run URL> — escrow probe green"`.
+
+## Infrastructure (IaC)
+### Terraform changes
+- `apps/web-platform/infra/workspaces-luks.tf`: +1 resource `github_actions_secret.workspaces_luks_boot_token` (provider `integrations/github`, already pinned). Sensitive value = `doppler_service_token.workspaces_luks.key` (lands in `terraform.tfstate` on the R2 encrypted backend — same as every other token). No new `TF_VAR_*`.
+### Apply path
+- (a) cloud-init-only for FUTURE hosts (out of scope — web-1 is `ignore_changes=[user_data]`, unrebuildable); (b) the running host is provisioned by `workspaces-cutover.sh` writing `/etc/default/luks-monitor` (real arm) — this is the "idempotent bootstrap on already-running host" path. The `github_actions_secret` lands via the DEFAULT `apply-web-platform-infra.yml` apply (existing IaC boundary). Blast radius: publishes one GH Actions secret; zero host downtime.
+### Distinctness / drift safeguards
+- The scoped cutover apply gate (`workspaces-luks-cutover-gate.sh`) is unchanged (terraform-side; unrelated to the GH environment). `-target` is transitive: the DEFAULT apply's `-target=github_actions_secret.workspaces_luks_boot_token` pulls `doppler_service_token.workspaces_luks` transitively — a benign create (or no-op if already in state); the scoped gate does not require the token create, so no conflict.
+### Vendor-tier reality check
+- github/doppler/hcloud providers already in use; no free-tier limit affects a `github_actions_secret` or a read-scoped service token.
+
+## Observability
+```yaml
+liveness_signal:
+  what: dry-run cutover run reaching escrow_probe GREEN (probe-PUT + negative over-scope) + the daily luks-monitor.timer heartbeat post-cutover
+  cadence: on-dispatch (rehearsal) / daily (steady-state probe)
+  alert_target: Better Stack heartbeat (WORKSPACES_LUKS_HEARTBEAT_URL) + Sentry issue alert (feature=workspaces-luks ∧ op IS_IN workspaces-luks-drift)
+  configured_in: workspaces-cutover.sh escrow_probe + luks-monitor.sh + workspaces-luks-emit.sh
+error_reporting:
+  destination: Sentry direct-curl envelope (workspaces-luks-emit.sh), feature=workspaces-luks op=workspaces-luks-drift
+  fail_loud: yes — this PR RESTORES the Sentry channel that BLOCKER 3 darkened (emit sibling now sourced because the script runs as a file with its siblings co-located)
+failure_modes:
+  - {mode: escrow probe-PUT fails, detection: emit_drift escrow_probe_put_failed → Sentry, alert_route: sentry_issue_alert}
+  - {mode: over-scoped token reaches tfstate bucket, detection: emit_drift escrow_creds_overscoped, alert_route: sentry_issue_alert}
+  - {mode: boot token missing/unreadable, detection: workflow fail-loud presence check + emit_drift doppler_unreachable/header_*_unreadable, alert_route: workflow ::error:: + Sentry}
+  - {mode: WORKSPACES_LUKS_DEV unresolved, detection: workflow volume-id regex guard (fail before SSH), alert_route: workflow ::error::}
+  - {mode: daily probe dark (post-cutover), detection: Better Stack heartbeat miss (Persistent=true), alert_route: Better Stack policy}
+logs:
+  where: GitHub Actions run log (probe verdict) + journald SyslogIdentifier=luks-monitor → Vector → Better Stack
+  retention: GH Actions default / Better Stack retention
+discoverability_test:
+  command: gh workflow view workspaces-luks-verify.yml
+  expected_output: "workspaces-luks verify"
+  # The above is the SSH-free, pre-merge-runnable probe that the read-only verify surface (this
+  # feature's no-SSH discoverability artifact) is registered + queryable. The escrow-specific GREEN
+  # verdict is inherently POST-MERGE (needs the merged workflow + published boot-token secret + the
+  # dry-run rehearsal): read it from the cutover run log (`escrow probe OK — PUT/read-back/delete`)
+  # AND Sentry (feature=workspaces-luks op=workspaces-luks-drift) — NEVER by SSH-eyeballing the host.
+```
+Affected-surface note (§2.9.2): the host script runs on web-1 (an operator-blind surface). Its `emit_drift` events carry the nine discriminating `WL_*` fields in ONE envelope — this PR is what makes that channel actually fire (BLOCKER 3 fix), so the blind surface becomes observable.
+
+## Architecture Decision (ADR/C4)
+### ADR
+Amend `ADR-119-luks-at-rest-for-the-live-workspaces-volume.md` with an **Authorization-Model addendum**: the `workspaces-luks-cutover` GitHub Environment gate (the sole human authorization on the irreversible freeze — C19/AC20b, DP-11 F8) is applied by the workflow **conditionally**, ONLY on the real freeze arm (`dry_run=false`). The dry-run rehearsal runs ungated because it performs NO irreversible operation — verified against `workspaces-cutover.sh`: `luksFormat`/`luksOpen` (`:257/:263-264`), FREEZE (`:376`), repoint (`:439`), and the `CONFIRM_WIPE` wipe (separate dispatch) are ALL behind `DRY_RUN != 1`; the dry-run reaches only `ensure_aws` (additive), `escrow_probe` (a namespaced `.probe/<run-id>` PUT/head/rm), device `blkid` reads, and manifest enumeration — all reversible. **Explicit acknowledgment (architecture P2):** the removed gate also covered `ensure_aws` (`:86-101`), which runs `apt-get install unzip` + a SHA256-pinned aws-cli installer AS ROOT on the sole prod host — so the autonomy change moves a root host-package mutation from gated to ungated. It is additive, SHA256-pinned (`:95`), and idempotent (a present `aws` short-circuits), so it is accepted; but the ADR addendum states this explicitly rather than framing the dry-run as side-effect-free. The AWSCLI_SHA256/AWSCLI_VERSION pin (`:55-56`) must be current for the autonomous dry-run to succeed (reachability GAP B). The fail-closed expression `${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` guarantees the gate is present whenever `DRY_RUN='0'`:
+
+| `inputs.dry_run` | `!inputs.dry_run` | environment | freeze reachable? | gated? |
+|---|---|---|---|---|
+| true | false | `''` (none) | no (`DRY_RUN='1'`) | n/a — nothing irreversible |
+| false | true | `workspaces-luks-cutover` | yes (`DRY_RUN='0'`) | **YES** |
+| null/unset | true | `workspaces-luks-cutover` | yes (`DRY_RUN='0'`) | **YES** (fail-closed) |
+
+This is a divergence from the ADR's current "the environment gate covers every dispatch"; the addendum records the decision + the reversibility proof. **security-sentinel + architecture-strategist MUST confirm** the irreversible path stays gated and the empty-string-environment behavior is verified (else split-job fallback with a static `environment:`).
+### C4 views
+No C4 impact. Enumeration (all three `.c4` files to be read at /work per the completeness mandate, and confirmed already-modeled or out-of-boundary): external human actor = the operator/founder reviewer (@deruelle, id 54279 — the existing solo-founder actor); external systems = GitHub Actions environment gate, web-1 host, Cloudflare R2 escrow bucket, Doppler `prd_workspaces_luks`, Hetzner volume API — all infra-CI vendors outside the app C4 container view; no new data store; no app-level access-relationship change. The change is a CI authorization-timing refinement, not an app-architecture change.
+### Sequencing
+The ADR addendum ships in THIS PR (describes the now-true state); it is not deferred.
+
+## Domain Review
+**Domains relevant:** Engineering (infra + security). Product: NONE (no UI-surface file — nothing under `components/**`, `app/**/page.tsx`, `app/**/layout.tsx`).
+
+### Engineering / Security
+**Status:** reviewed (framing). **Assessment:** This is an infra/CI/security change on the LUKS-at-rest authorization + escrow path. The mandated review is at plan-review (escalated to +architecture-strategist +spec-flow-analyzer at single-user-incident threshold) and deepen-plan (security-sentinel via the domain triad). The load-bearing security questions: (1) the boot token never reaches a host process list or workflow argv (0600 stdin env file, shred-on-EXIT, no `sudo VAR=val`); (2) the autonomy change keeps the irreversible freeze gated (truth table above); (3) verify.yml stays read-only. GDPR gate (2.7): the change alters no data processing — it makes an existing at-rest-encryption rehearsal autonomous; advisory-only, no regulated-data surface added.
+
+### Product/UX Gate
+Skipped — no UI surface (mechanical UI-surface override did not fire).
+
+## Open Code-Review Overlap
+None — no open `code-review` issue body references any of the nine files in scope (checked 2026-07-18 via `gh issue list --label code-review`).
+
+## Test Scenarios
+1. **File-execution restores the emit channel:** run the bundle as a file with `/usr/local/bin/workspaces-luks-emit.sh` absent → `emit_drift` still reaches Sentry (sibling sourced from the temp dir); a re-introduced `bash -s <` form → RED assertion.
+2. **Token never in argv:** mutation appending `sudo DOPPLER_TOKEN=${{ secrets.WORKSPACES_LUKS_BOOT_TOKEN }} bash …` → the extended H7 predicate goes RED.
+3. **Fail-closed gate:** the environment expression with `dry_run` null/false → gated; only `dry_run=true` → ungated (assert the literal expression; a `dry_run && '' || 'X'` inversion → RED).
+4. **Device regex guard:** a non-numeric volume-id API response → workflow fails before SSH (no partial run).
+5. **Daily probe env:** `luks-monitor.service` without `Environment=HOME=/root` → RED (the doppler-`$HOME` failure mode).
+6. **Read-only verify:** verify.yml runs `luks-monitor` (not `workspaces-cutover.sh`) — assert no device-opening call reachable from verify's entrypoint.
+
+## Reachability Preconditions (dry-run → escrow_probe)
+
+Spec-flow confirmed the ordered death chain the four fixes remove: `:63` (BLOCKER 3) → `:248` KEY (BLOCKER 4 token) → `:253` `WORKSPACES_LUKS_DEV` (BLOCKER 5, checked BEFORE the escrow reads) → `:279` escrow creds (BLOCKER 4 token) → `:280` probe. After the fixes the code deaths are gone, but the probe is reached only if these INFRA/HOST preconditions also hold (each maps to a post-merge verification step — they are acknowledged sequencing dependencies, not unhandled logic):
+
+| Gap | Precondition | Severity | Covered by |
+|---|---|---|---|
+| A | `hcloud_volume_attachment.workspaces_luks` LIVE on web-1 so the by-id device node physically exists (`:253` `[ -e "$FRESH_DEV" ]`) | HIGH | Post-merge step (i) — the DEFAULT apply attaches it |
+| B | web-1 outbound HTTPS to `awscli.amazonaws.com` + apt for `unzip`, AND a current `AWSCLI_SHA256` pin — `ensure_aws` (`:86-101`) dies otherwise, BEFORE the probe | HIGH | New verification note (below); pin currency checked at /work Phase 0 |
+| C | all four `WORKSPACES_HEADER_*` secrets present in `prd_workspaces_luks` (`load_escrow_creds` fail-loud `:110-113`) | MEDIUM | Post-merge step (ii) |
+| D | the fresh volume carries raw or `crypto_LUKS` (not a stray fs signature) — `:261` dies even in dry-run | MEDIUM | Fresh volume born raw (no `format` attr, workspaces-luks.tf A4) |
+| E | `HOME=/root` for the host `doppler` read — handled by DROPPING `sudo` (bridge lands `-l root`); a regression to `sudo` without `-H` reintroduces a misleading "empty WORKSPACES_LUKS_KEY" death | LOW (load-bearing) | Phase 1.2 drops sudo; Phase 5 asserts no `sudo` in the run step |
+| F | `/mnt/data` mounted at run time (`:240` L3 gate) | LOW | Steady state |
+
+GAP A and GAP B are the two most likely to leave a "blockers-fixed" dry-run still dying short of the probe; both are verified by the post-merge autonomous sequence before #6649 is closed.
+
+## Deepen-Plan Review Synthesis
+
+Deepened 2026-07-18 with 5 parallel agents (security-sentinel, architecture-strategist, spec-flow-analyzer, code-simplicity-reviewer, observability/verify-negative Explore) + the 4.6/4.7/4.8/4.9 hard gates. Verdicts + corrections folded in above:
+
+- **Autonomy gate — CONFIRMED SOUND (security-sentinel).** Decisive property: the env gate and `DRY_RUN` derive from the SAME `inputs.dry_run` operand, so **freeze-reachable ⟺ gated** in every input case (including `dry_run` null/string). The empty-string-environment vendor behavior affects ONLY whether the DRY-RUN is ungated (the autonomy goal) — NOT whether the freeze is gated (the freeze arm always evaluates to the literal `'workspaces-luks-cutover'`, never empty). So C19/AC20b is preserved regardless of empty-string handling; Phase 0's WebFetch check confirms autonomy is *achieved*, not safety.
+- **Mechanism (architecture-strategist P2):** prefers SPLIT-JOB (static literal `environment:` on the freeze job) for static auditability at single-user-incident threshold. Kept conditional-environment as primary (task's first-listed option + minimal diff + the freeze arm is always a literal string) with split-job as the documented fallback if Phase 0 empty-string verification fails or the PR-time security reviewer prefers it. Dissent logged in `decision-challenges.md`.
+- **Token classification (architecture-strategist P1) — CORRECTED.** Explicit `-target` for `doppler_service_token.workspaces_luks` + de-exclude from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS` (mirror inngest; #5566 rule). See Phase 2.1 + Research Reconciliation.
+- **`.env` on tmpfs (security-sentinel P1) — CORRECTED.** `.env`+bundle on `STATE_DIR` (F7), write+trap+run consolidated into one `bash -c`. See Phase 1.2.
+- **HOME=/root + token bake (verify-negative Explore, both P1-latent) — CONFIRMED needed.** Sibling root-doppler units (`web-git-data-probe.service:15` etc.) all set `Environment=HOME=/root` with dedicated tests (`web-git-data-probe.test.sh:120-121`); Phase 5 mirrors that assertion.
+- **Reachability (spec-flow) — 6 preconditions** enumerated in the section above.
+- **Scope (code-simplicity):** dropped `luks-monitor.sh` hardening (always a file); `.env`-on-STATE_DIR resolves the shred-vs-rm tension in favor of a meaningful shred; the tf-published-volume-id alternative (`github_actions_variable`) is recorded as a considered option but hcloud-API-runtime kept per the task direction (logged in `decision-challenges.md`); verify.yml kept per the task's explicit "both workflows" direction (dissent logged).
+- **Root package install ungated (architecture P2)** — `ensure_aws` acknowledged in the ADR addendum + GAP B.
+
+## Sharp Edges
+- A plan whose `## User-Brand Impact` section is empty or placeholder fails `deepen-plan` Phase 4.6. It is filled above.
+- The env-file fields (`DOPPLER_TOKEN`, `WORKSPACES_LUKS_DEV`, `DRY_RUN`, `ROLLBACK`) MUST stay metacharacter-free — `set -a; . .env; set +a` parses the file as shell, so a value containing whitespace/`;`/`$` would break parsing or inject. Current values are safe; preserve this as a constraint if fields are added.
+- The `.env` (full-prd token) MUST live on `STATE_DIR` (persistent fs), never `mktemp -d`'s tmpfs default, or the shred is a no-op against the raw device (F7, workspaces-cutover.sh:296-297). This is a P1 the deepen review caught.
+- Empty-string GitHub Actions `environment:` = ungated is a third-party-behavior claim — verify against GH docs at /work (Phase 0); split-job fallback if unconfirmed. Do NOT ship the conditional environment unverified.
+- The naive `${{ inputs.dry_run && '' || 'X' }}` is INVERTED (`''` is falsy). Use `!inputs.dry_run && 'X' || ''`. Grep the final workflow to confirm the correct form landed.
+- Doppler SERVICE token ignores `--config` (learning `2026-03-29-doppler-service-token-config-scope-mismatch`) — the boot token's built-in scope IS `prd_workspaces_luks`, so the script's `--config prd_workspaces_luks` reads resolve correctly; do not "fix" the flag away.
+- `-target` is transitive (learnings `2026-07-03`/`2026-07-17`): the DEFAULT apply's `-target=github_actions_secret.workspaces_luks_boot_token` pulls the token; benign (create allowed on the default path). Do NOT add the secret to the scoped cutover `-target` set — the gate would abort it `out_of_scope`.
+- `WEB_HOST_SSH` lands as root; keeping `sudo` re-scrubs `HOME`/the sourced env → the host `doppler` read dies `$HOME is not defined`. Drop `sudo` (or use `sudo -H` and source inside).
+- The `.env` shred trap must be HOST-LOCAL (in the outer remote `bash -c`), so a dropped SSH session still shreds the token — mirrors the DP-6 host-side EXIT trap.

--- a/knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md
+++ b/knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md
@@ -37,6 +37,7 @@ The `/workspaces` LUKS cutover (ADR-119, epic #6588) has a working escrow *desig
 This is a `single-user incident` brand-survival plan: the surface is sole-copy user source code, and the escrow proof this rehearsal exercises is the ONLY defense against the ADR-119 terminal failure (passphrase/header loss ⇒ unreadable forever). The autonomy change touches the authorization boundary on that irreversible path, so security-sentinel + architecture-strategist review is a hard gate (see `## Architecture Decision`).
 
 ## Research Reconciliation — Spec vs. Codebase
+<!-- lint-infra-ignore start (automated CI -target apply + SSH-bridge format prose; OPERATOR_APPLIED_* identifier + -target…apply co-occurrence is a false positive) -->
 
 | Task-prescribed claim | Codebase reality (verified) | Plan response |
 |---|---|---|
@@ -46,6 +47,7 @@ This is a `single-user incident` brand-survival plan: the surface is sole-copy u
 | BLOCKER 4c: "persist the token to /etc/default/luks-monitor … so the daily probe works" | cloud-init bakes `/etc/default/luks-monitor` with ONLY `SOLEUR_SENTRY_DSN` (`cloud-init.yml:422-424`) — NO `DOPPLER_TOKEN`. AND `luks-monitor.service` has NO `Environment=HOME=/root`; a root systemd unit running `doppler` dies `$HOME is not defined` (learning `2026-07-18-web-1-root-doppler-unit-needs-home-…`). | Real arm persists `DOPPLER_TOKEN=<boot token>` into `/etc/default/luks-monitor` (0600 root, preserving the baked DSN). **Also add `Environment=HOME=/root` to `luks-monitor.service`** — a latent bug that would make the daily timer probe fail even with the token present. |
 | conditional environment `${{ inputs.dry_run && '' || 'X' }}` (the "obvious" form) | This is **inverted**: `''` is falsy, so `true && '' → ''` then `'' || 'X' → 'X'` ⇒ ALWAYS gated. | Use the fail-closed complement `${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (truth table in `## Architecture Decision`). This mirrors the existing `DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}` logic (`:110`) — same boolean coercion the file already trusts. |
 | `hcloud_volume.workspaces_luks.id` → by-id device | `cloud-init.yml:573-574` mounts `/mnt/data` via `/dev/disk/by-id/scsi-0HC_Volume_${workspaces_volume_id}` — the confirmed convention. Volume name literal is `soleur-web-platform-data-luks` (`workspaces-luks.tf:166`). The Hetzner token variable `hcloud_token` ← Doppler `HCLOUD_TOKEN` in `prd_terraform` (`main.tf:88`, `variables.tf:15`) — a Hetzner API token, NOT a GitHub PAT (no GitHub-App alternative applies). | Derive the id via the hcloud API by volume name using `HCLOUD_TOKEN` (workflow already holds a `prd_terraform` `DOPPLER_TOKEN`); construct `WORKSPACES_LUKS_DEV=/dev/disk/by-id/scsi-0HC_Volume_<id>`. Terraform-output is the documented fallback. |
+<!-- lint-infra-ignore end -->
 
 **Premise validation (Phase 0.6):** #6649 is OPEN (title: "wire WORKSPACES_HEADER_BUCKET + R2 creds into the workspaces-luks freeze path"). The prior `#6649` plan (`2026-07-18-fix-6649-workspaces-luks-header-escrow-wiring-plan.md`) delivered ONLY the header-escrow bucket/creds + probe machinery — it does NOT touch content-carrier, boot-token delivery, `WORKSPACES_LUKS_DEV`, or the autonomy gate. All four blockers here are fresh. Every cited file/line/symbol was read directly and holds.
 
@@ -68,9 +70,11 @@ The feature description matches SSH/timeout keywords, but this is NOT a connecti
 ## Implementation Phases
 
 ### Phase 0 — Preconditions (grep/verify, no code)
+<!-- lint-infra-ignore start (Phase 0 preconditions describe the automated CF-tunnel SSH bridge format + CI -target set — not human-run steps) -->
 - Confirm `WEB_HOST_SSH` format is `ssh -i <keyfile> -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null -l root` (`.github/actions/cf-tunnel-ssh-bridge/action.yml`) — lands as root, pipes tar + stdin.
 - Confirm the scoped cutover `-target` set (`apply-web-platform-infra.yml:2660-2664`) is EXACTLY the five workspaces_luks resources — the new `github_actions_secret` must NOT be added there (the sourced `workspaces_luks_cutover_gate` would abort it as `out_of_scope`).
 - Verify (WebFetch GitHub Actions docs) that a job `environment:` evaluating to an EMPTY string runs with no environment gate. If NOT confirmed, use the split-job fallback (`## Architecture Decision`).
+<!-- lint-infra-ignore end -->
 
 ### Phase 1 — BLOCKER 3: content-carrier → file execution (RED test first)
 1. Harden `workspaces-cutover.sh`: replace every `${BASH_SOURCE[0]}` with `${BASH_SOURCE[0]:-}` (`:63`, `:475`, `:477`, `:478`) and, where a bare-empty dirname would resolve to `.`, anchor on `SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"` computed once near the top so file-execution is unambiguous. (`luks-monitor.sh:29` is NOT hardened — code-simplicity: it is always run as a file, so `${BASH_SOURCE[0]}` is never unbound; dropped from scope to keep the change minimal.)
@@ -93,8 +97,10 @@ The feature description matches SSH/timeout keywords, but this is NOT a connecti
      # NO lifecycle.ignore_changes — a -replace rotation of the token propagates the new key here.
    }
    ```
+<!-- lint-infra-ignore start (DEFAULT-apply -target reclassification prose; OPERATOR_APPLIED_TOKEN_EXCLUSIONS identifier co-occurs with -target…apply — automated CI, not a human step) -->
    **[architecture P1 — mirror the inngest precedent exactly; #5566 silent-un-applied class]** Add TWO explicit `-target` lines to the DEFAULT allow-list in `apply-web-platform-infra.yml` (near `:361`): `-target=doppler_service_token.workspaces_luks` AND `-target=github_actions_secret.workspaces_luks_boot_token` — exactly as `inngest_arm_write` + `doppler_token_inngest_arm` are both targeted. Then **REMOVE `doppler_service_token.workspaces_luks` from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS`** in `terraform-target-parity.test.ts` — the rule at `:686-688` forbids excluding a token that feeds a `github_actions_secret` ("MUST be targeted"), because publishing `.key` reclassifies it from operator-applied-host-token to CI-published token. Do NOT rely on `-target` transitivity + a self-contradicting exclusion (a comment reconciliation is insufficient — the classification changed). **/work MUST verify against the inngest precedent side-by-side** the interaction with (i) the general 5-resource `OPERATOR_APPLIED_EXCLUSIONS` and (ii) the scoped cutover gate (`workspaces-luks-cutover-gate.sh` asserts only `vc/ac/sc` creates, not a token create, so a token already in state from the DEFAULT apply is fine; the scoped `-target` set at `apply-web-platform-infra.yml:2660-2664` still lists the token — idempotent).
    Update the stale `workspaces-luks.tf:190-210` env-gate comment AND the `workspaces-luks-cutover.yml:9-16` workflow comment block (the "environment gate ... covers every dispatch / is the ONLY human authorization" prose) to say the environment is applied ONLY to the real freeze arm (dry-run rehearsals run ungated for autonomy; the reviewer set stays non-empty for the freeze). Both doc sites must be reconciled, not just line 62.
+<!-- lint-infra-ignore end -->
 2. **(b) Inject into the host script env.** In cutover.yml, add step env `WORKSPACES_LUKS_BOOT_TOKEN: ${{ secrets.WORKSPACES_LUKS_BOOT_TOKEN }}` + a fail-loud presence check. Write the `.env` file:
    ```
    printf 'DOPPLER_TOKEN=%s\nWORKSPACES_LUKS_DEV=%s\nDRY_RUN=%s\nROLLBACK=%s\n' \

--- a/knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/decision-challenges.md
+++ b/knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/decision-challenges.md
@@ -1,0 +1,18 @@
+# Decision Challenges — feat-one-shot-6649-luks-escrow-autonomy
+
+Recorded at plan/deepen-plan time (headless one-shot). `ship` renders these into the PR body and files an `action-required` issue for the operator (ADR-084). Each is a Taste / User-Challenge where a reviewer's recommendation diverges from the task's stated direction; the task direction is kept as the default, dissent surfaced here.
+
+## 1. Autonomy mechanism: conditional-environment vs split-job (Taste)
+- **Task direction / plan default:** conditional `environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (the task's first-listed option; minimal diff).
+- **architecture-strategist (P2):** prefers SPLIT-JOB (static literal `environment:` on a separate freeze job) for static auditability at single-user-incident threshold — the C19/AC20b property is then verifiable by inspection, not by trusting empty-string-environment vendor behavior.
+- **Resolution:** kept conditional-environment as primary because the freeze arm always evaluates to the literal `'workspaces-luks-cutover'` (never empty), so the SAFETY property does not depend on empty-string handling — only the autonomy property does. Split-job documented as the fallback if Phase 0 empty-string verification fails or the PR-time security reviewer prefers it. **Operator may prefer split-job for auditability — flag for decision.**
+
+## 2. verify.yml in scope (Scope)
+- **Task direction:** BLOCKER 3 explicitly names "BOTH .github/workflows/workspaces-luks-cutover.yml AND workspaces-luks-verify.yml."
+- **code-simplicity-reviewer:** cut verify.yml — it runs an already-installed file (no BASH_SOURCE bug) and is not on #6649's dry-run-green critical path.
+- **Resolution:** kept per the task direction AND because verify.yml has a genuine token-delivery bug (manual `sudo /usr/local/bin/luks-monitor` has no `EnvironmentFile`, so `doppler` fails). Scoped its change to the token delivery + run-from-shipped-copy. **Operator may defer verify.yml to a follow-up if desired.**
+
+## 3. WORKSPACES_LUKS_DEV derivation: hcloud API vs tf-published variable (Taste)
+- **Task direction:** "terraform output or hcloud API" — runtime derivation.
+- **code-simplicity-reviewer:** since the PR already adds a tf-published `github_actions_secret`, publish the device path as a `github_actions_variable` in the same apply and read `${{ vars.WORKSPACES_LUKS_DEV }}` — deterministic-at-apply, removes the runtime curl + `HCLOUD_TOKEN` read + regex guard.
+- **Resolution:** kept hcloud-API-runtime (task direction; no extra tf resource / parity burden; the API call runs on the runner with a bounded `--max-time` + regex guard). **tf-published variable is a reasonable alternative if the operator prefers zero runtime network calls in the cutover.**

--- a/knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/session-state.md
@@ -1,0 +1,18 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md
+- Status: complete
+
+### Errors
+None. (Two non-blocking notes: spec-flow-analyzer first launched under a wrong namespace then re-spawned; deepen-plan 4.8 PAT-shaped gate matched only the pre-existing Hetzner var.hcloud_token — benign false-positive, reworded.)
+
+### Decisions
+- Autonomy gate: conditional `environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (security-sentinel proved fail-closed: env gate and DRY_RUN share the same operand, so freeze-reachable ⟺ gated). Split-job recorded as auditability-preferred fallback.
+- Token-classification P1: mirror inngest precedent — explicitly -target both doppler_service_token.workspaces_luks and the new github_actions_secret, and REMOVE the token from OPERATOR_APPLIED_TOKEN_EXCLUSIONS (#5566 rule).
+- Secret-delivery P1: 0600 .env on persistent STATE_DIR (not tmpfs mktemp) or shred is a no-op (F7); write+trap+run in one remote bash -c.
+- Two latent host P1s folded in: luks-monitor.service lacks Environment=HOME=/root; /etc/default/luks-monitor bakes only Sentry DSN (no token).
+- Reachability preconditions mapped to autonomous post-merge verification before #6649 closes.
+
+### Components Invoked
+soleur:plan, soleur:deepen-plan; Explore, learnings-researcher, security-sentinel, architecture-strategist, spec-flow-analyzer, code-simplicity-reviewer

--- a/knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6649-luks-escrow-autonomy/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — workspaces-luks escrow autonomy (#6649)
+
+Plan: `knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md`
+Lane: cross-domain · Brand threshold: single-user incident · ADR-119 (addendum)
+
+## Phase 0 — Preconditions (verify, no code)
+- [ ] 0.1 Confirm `WEB_HOST_SSH` = `ssh … -l root` (lands root; pipes tar + stdin) — `.github/actions/cf-tunnel-ssh-bridge/action.yml`.
+- [ ] 0.2 Confirm scoped cutover `-target` set is EXACTLY the five workspaces_luks resources (`apply-web-platform-infra.yml:2660-2664`) — new `github_actions_secret` must NOT go there.
+- [ ] 0.3 Verify (WebFetch GH Actions docs) an empty-string job `environment:` runs ungated; else use split-job fallback.
+
+## Phase 1 — BLOCKER 3: content-carrier → file execution
+- [ ] 1.1 Harden `workspaces-cutover.sh` `${BASH_SOURCE[0]}` → `${BASH_SOURCE[0]:-…}` (`:63/:475/:477/:478`). (luks-monitor.sh NOT hardened — always run as a file.)
+- [ ] 1.2 cutover.yml: `REMOTE_DIR` on **STATE_DIR** (`mktemp -d -p /var/lib/workspaces-luks`, chmod 700 — NOT tmpfs `/tmp`, or shred is a no-op / F7); tar-pipe bundle (workspaces-cutover.sh + workspaces-luks-emit.sh + luks-monitor.{sh,service,timer}); write `.env` + arm shred trap + run `bash <dir>/workspaces-cutover.sh` in ONE remote `bash -c` (no sudo — root already, preserves HOME=/root); preserve `WEB_HOST_SSH` guard + `set +e`/rc/`::error::`.
+- [ ] 1.3 cutover.yml: `if: always()` teardown SSHes `rm -rf "$REMOTE_DIR"` (belt-and-suspenders; trap already shredded `.env`).
+- [ ] 1.4 verify.yml: tar-pipe `luks-monitor.sh`+emit to STATE_DIR; SAME 0600-stdin-envfile + host-local shred discipline for the boot token; run `bash <dir>/luks-monitor` (read-only) — replaces `sudo /usr/local/bin/luks-monitor`.
+
+## Phase 2 — BLOCKER 4: boot-token delivery
+- [ ] 2.1 workspaces-luks.tf: add `github_actions_secret.workspaces_luks_boot_token` → `doppler_service_token.workspaces_luks.key` (no `ignore_changes`); reconcile the env-gate comment (`:190-210`) AND the `workspaces-luks-cutover.yml:9-16` comment block for the conditional/split gate.
+- [ ] 2.2 apply-web-platform-infra.yml: add TWO `-target` lines to the DEFAULT allow-list (near `:361`): `doppler_service_token.workspaces_luks` + `github_actions_secret.workspaces_luks_boot_token`. (Mirror the inngest precedent.)
+- [ ] 2.3 terraform-target-parity.test.ts: **REMOVE** `doppler_service_token.workspaces_luks` from `OPERATOR_APPLIED_TOKEN_EXCLUSIONS` (#5566 rule `:686-688` — a token feeding a github_actions_secret MUST be targeted, not excluded). Verify interaction with the general 5-resource exclusion + scoped gate against the inngest precedent.
+- [ ] 2.4 cutover.yml: step env `WORKSPACES_LUKS_BOOT_TOKEN` + fail-loud presence check; write 0600 root `.env` over stdin (`install -m600 /dev/stdin`) with DOPPLER_TOKEN+WORKSPACES_LUKS_DEV+DRY_RUN+ROLLBACK; source it; shred on host-local EXIT trap (same `bash -c` as 1.2). NEVER `sudo VAR=val`.
+- [ ] 2.5 workspaces-cutover.sh (real arm): persist `DOPPLER_TOKEN` into `/etc/default/luks-monitor` (0600 root, preserve baked DSN).
+- [ ] 2.6 luks-monitor.service: add `Environment=HOME=/root`.
+
+## Phase 3 — BLOCKER 5: WORKSPACES_LUKS_DEV
+- [ ] 3.1 cutover.yml: resolve volume id via hcloud API by name `soleur-web-platform-data-luks` (HCLOUD_TOKEN from prd_terraform), regex-guard numeric, build `/dev/disk/by-id/scsi-0HC_Volume_<id>`; `curl --max-time` pinned. Pass via the Phase-2 `.env`.
+
+## Phase 4 — AUTONOMY: gate only the freeze arm
+- [ ] 4.1 workspaces-luks-cutover.yml:62 → `environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}` (fail-closed). Fallback: split rehearse/freeze jobs with static `environment:` on freeze.
+- [ ] 4.2 ADR-119 authorization-model addendum (conditional gate + reversibility proof + truth table).
+
+## Phase 5 — Tests + verification
+- [ ] 5.1 Extend `workspaces-luks-header.test.sh` (cover BOTH cutover.yml + verify.yml): file-execution (assert the ASSEMBLED `install`+`trap`+`bash <file>` command, not just `tar xzf`) / no-`bash -s` / no `sudo VAR=val` argv / token-via-stdin-only / `.env` on STATE_DIR (not tmpfs) / shred-on-EXIT / WORKSPACES_LUKS_DEV passed / fail-closed env expression (mutation-RED on the inverted `dry_run && '' || 'X'` form) / `HOME=/root` in service (mirror `web-git-data-probe.test.sh:120-121`) / reviewers non-empty. Mutation-test each.
+- [ ] 5.2 Run all suites green: workspaces-luks.test.sh, web-1-swap-concurrency-parity.test.sh, terraform-target-parity.test.ts (vitest), test-workspaces-luks-cutover-gate.sh.
+- [ ] 5.3 Post-merge (autonomous): DEFAULT apply publishes token + attaches volume → confirm prd_workspaces_luks has 4 header keys → `gh workflow run workspaces-luks-cutover.yml -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS` runs WITHOUT approval → probe GREEN (read from Sentry/Better Stack) → `gh issue close 6649 --comment "<run URL> — escrow probe green"`.

--- a/plugins/soleur/test/terraform-target-parity.test.ts
+++ b/plugins/soleur/test/terraform-target-parity.test.ts
@@ -570,18 +570,19 @@ const OPERATOR_APPLIED_EXCLUSIONS = new Set<string>([
   //   hcloud_volume and is evaluated BEFORE the destroy_count sum, so `[ack-destroy]`
   //   deliberately cannot reach it. A net-new hcloud_volume that CI could plan would HALT
   //   the per-PR apply path.
-  //   `doppler_service_token.workspaces_luks` is an OPERATOR-APPLIED token exception (see
-  //   OPERATOR_APPLIED_TOKEN_EXCLUSIONS below), same class as doppler_service_token.git_data:
-  //   it is minted into the operator-created `prd_workspaces_luks` Doppler config and read by
-  //   the web-1 HOST at unlock time — never published into a paired github_actions_secret. The
-  //   config does not exist until the operator creates it (runbook precondition), so CI cannot
-  //   apply it. The dedicated config is what keeps the key OUT of the `--config prd` download
-  //   that feeds `docker run --env-file` (CWE-522 — see workspaces-luks.tf).
+  //   NOTE (#6649): `doppler_service_token.workspaces_luks` is DELIBERATELY NOT excluded here.
+  //   #6649 publishes its `.key` into `github_actions_secret.workspaces_luks_boot_token`
+  //   (workspaces-luks.tf) and adds an explicit `-target` for BOTH to the DEFAULT allow-list, so it
+  //   is now a CI-PUBLISHED token (the #5566 rule: a token feeding a github_actions_secret MUST be
+  //   targeted, never excluded — mirroring inngest_arm_write, which is in neither exclusion set).
+  //   Excluding it would desensitize the default-apply coverage assertion for its `-target` line. The
+  //   web-1 host ALSO reads it directly from `prd_workspaces_luks` at unlock time; publishing does not
+  //   change the CWE-522 container-boundary rationale (see workspaces-luks.tf + OPERATOR_APPLIED_TOKEN_EXCLUSIONS).
+  //   The four resources below ride ONLY the scoped operator cutover apply, so they stay excluded.
   "random_password.workspaces_luks",
   "doppler_secret.workspaces_luks_key",
   "hcloud_volume.workspaces_luks",
   "hcloud_volume_attachment.workspaces_luks",
-  "doppler_service_token.workspaces_luks",
   // #6604 — the daily luks-monitor probe's Better Stack heartbeat + its Doppler URL secret. Same
   // class as betteruptime_heartbeat.git_data_prd + doppler_secret.git_data_heartbeat_url_prd
   // (both excluded, applied together by the operator apply; the heartbeat is paused until the
@@ -688,18 +689,14 @@ const OPERATOR_APPLIED_EXCLUSIONS = new Set<string>([
 // a github_actions_secret — that is the #5566 silent-un-applied class and MUST be targeted.
 const OPERATOR_APPLIED_TOKEN_EXCLUSIONS = new Set<string>([
   "doppler_service_token.git_data",
-  // #6588 (ADR-119) — minted into the operator-created `prd_workspaces_luks` config and read by
-  // the web-1 host at LUKS-unlock time (NOT published to a CI github_actions_secret). CI cannot
-  // apply it — the config does not exist until the operator creates it. Same class as
-  // doppler_service_token.git_data. The dedicated config is a SECURITY boundary, not hygiene:
-  // web-1's cloud-init runs `doppler secrets download --config prd` into the TMPENV that feeds
-  // `docker run --env-file`, so a key in shared `prd` would be readable via /proc/self/environ
-  // by the agent container whose own data it encrypts (CWE-522). The mechanism is inheritance
-  // DIRECTIONALITY (root → branch), NOT scope reduction: this token still resolves the full prd
-  // set, exactly like the "leaky prd_registry branch config" named below — see #6167 and
-  // learnings/security-issues/2026-07-07-doppler-branch-config-does-not-isolate-secrets.md.
-  // It is free here because web-1 already carries a full-prd DOPPLER_TOKEN.
-  "doppler_service_token.workspaces_luks",
+  // #6649 (ADR-119) — doppler_service_token.workspaces_luks is DELIBERATELY NOT excluded here.
+  // It was an operator-applied-host-token (same class as git_data), but #6649 publishes its `.key`
+  // into github_actions_secret.workspaces_luks_boot_token (workspaces-luks.tf) so the cutover/verify
+  // workflows can deliver it host-side over the SSH bridge. Per the #5566 rule below, a token that
+  // feeds a github_actions_secret MUST be CI-targeted, never excluded — so it is now explicitly
+  // `-target`ed in apply-web-platform-infra.yml's DEFAULT allow-list (mirroring the inngest_arm_write
+  // precedent). web-1 still ALSO reads prd_workspaces_luks directly via the same token at unlock
+  // time; publishing it does not change the CWE-522 container-boundary rationale in workspaces-luks.tf.
   // #6122 (ADR-096) — minted into the ISOLATED `soleur-registry` project's `prd` root config
   // (TF-created via doppler_project.registry in the operator full apply; its own root holds ONLY
   // the two ZOT tokens — true cross-project isolation, NOT the leaky `prd_registry` branch config


### PR DESCRIPTION
## Summary

Makes the `/workspaces` LUKS escrow **dry-run rehearsal fully autonomous** and lets it reach the escrow probe (the P.5 success criterion), resolving four host-provisioning + execution-model gaps found while resuming #6649. Plan: `knowledge-base/project/plans/2026-07-18-fix-6649-workspaces-luks-escrow-autonomy-plan.md`.

- **BLOCKER 3 — content-carrier execution.** The cutover piped the whole script via `sudo … bash -s`, so `${BASH_SOURCE[0]}` was unbound → the emit sibling was never sourced (Sentry drift channel dark) and the run died. Now the script + siblings ship as a tar bundle and run **as a file** (self-path hardened under `set -u`); the emit channel is restored.
- **BLOCKER 4 — boot-token delivery.** `doppler_service_token.workspaces_luks` (the only credential that reads `prd_workspaces_luks`) was created but published nowhere. Now published to `github_actions_secret.WORKSPACES_LUKS_BOOT_TOKEN` (DEFAULT-apply `-target`; removed from both parity-test exclusion sets per the #5566 rule), injected host-side via a mode-0600 stdin `.env` (`umask 077`, shred-on-EXIT, never argv), and persisted to `/etc/default/luks-monitor` for the daily timer probe. `HOME=/root` added to `luks-monitor.service`.
- **BLOCKER 5 — `WORKSPACES_LUKS_DEV`.** `prepare_luks_target` died before the probe. Now the workflow derives the fresh volume's by-id path from the Hetzner API (single-match assertion + numeric guard) and passes it through the `.env`.
- **Autonomy.** The environment gate now applies to the **real freeze arm only** (`environment: ${{ !inputs.dry_run && 'workspaces-luks-cutover' || '' }}`, fail-closed) so `dry_run=true` rehearsals run unattended; the C19/AC20b human authorization on the irreversible freeze is preserved (ADR-119 addendum + truth table).

`verify.yml` mirrors the file-execution + stdin-token discipline (read-only). Adds mutation-tested drift guards H13–H20 to `workspaces-luks-header.test.sh`.

## User-Brand Impact

- **Exposed artifact / vector:** the boot token resolves ~116 `prd` secrets (branch-config inheritance). Delivery is mode-0600-stdin-`.env` (`umask 077`, shred-on-EXIT, never argv); it is also a repo GitHub Actions secret (mirrors the accepted `doppler_token_inngest_arm` precedent — fork PRs get no secrets, and web-1 already carries a full-prd `DOPPLER_TOKEN`, so no net-new capability) and a persistent 0600-root copy in `/etc/default/luks-monitor` (outside the container `--env-file` path, CWE-522 boundary preserved).
- **If it lands broken:** a dry-run that still can't prove the escrow path, or a real freeze running ungated. The gate and `DRY_RUN` derive from the same `!inputs.dry_run` operand → freeze-reachable ⟺ gated (fail-closed); dry-run touches only the fresh by-id volume with destructive ops behind `DRY_RUN != 1`.
- **Brand-survival threshold:** single-user incident

## Model Dissents (informational)

Recorded at plan time (ADR-084); task direction kept as default. The operator may prefer these alternatives:

1. **Autonomy mechanism (Taste):** architecture-strategist preferred a split-job with a static `environment:` on a separate freeze job for inspection-only auditability. Kept the conditional expression (freeze arm always evaluates to the literal, so the safety property never depends on empty-string handling); split-job is the documented fallback.
2. **verify.yml scope (Scope):** code-simplicity-reviewer suggested cutting verify.yml. Kept — it has a genuine token-delivery bug (the old `sudo /usr/local/bin/luks-monitor` had no `EnvironmentFile`).
3. **`WORKSPACES_LUKS_DEV` derivation (Taste):** code-simplicity-reviewer suggested publishing the device path as a tf `github_actions_variable`. Kept runtime hcloud-API derivation (no extra tf parity burden; bounded `--max-time` + numeric guard).

## Changelog

- fix(infra): autonomous workspaces-luks escrow rehearsal — content-carrier execution, `prd_workspaces_luks` boot-token delivery, `WORKSPACES_LUKS_DEV` derivation, and a freeze-arm-only human gate.

## Test plan

- [x] `workspaces-luks-header.test.sh` (62 assertions, H13–H20 mutation-tested), `workspaces-luks.test.sh`, `web-1-swap-concurrency-parity.test.sh`, `terraform-target-parity.test.ts`, `test-workspaces-luks-cutover-gate.sh` — all green.
- [x] `terraform fmt -check` + `terraform validate` green; full `scripts/test-all.sh` green.
- [x] Nested remote-command quoting verified end-to-end (`.env` sourced + shredded, 0600).
- [ ] Post-merge autonomous sequence (executed inline this session after merge — zero operator steps): trigger the DEFAULT apply to publish `WORKSPACES_LUKS_BOOT_TOKEN` + attach the volume; verify the four `WORKSPACES_HEADER_*` secrets in `prd_workspaces_luks`; run `gh workflow run workspaces-luks-cutover.yml --ref main -f dry_run=true -f confirm=CUTOVER-WORKSPACES-LUKS` (runs WITHOUT approval); on the escrow probe-PUT + negative over-scope probe GREEN, close issue #6649 with the run URL (manual, post-verification — NOT an auto-close keyword).

Ref #6649

Generated with [Claude Code](https://claude.com/claude-code)
