### PR TITLE
fix(infra): cert-reissue token needs BOTH administration+pages:write (Ref #6657)

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
+++ b/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
@@ -8,7 +8,8 @@
 // postmortem-proven recovery (learning 2026-02-16-github-pages-cloudflare-wiring):
 //   1. flip apex+www to DNS-only (proxied=false) so GitHub sees its own IPs,
 //   2. re-order the cert by toggling the Pages custom domain (cname:null → re-set)
-//      via the GitHub App's `pages:write` grant,
+//      via the GitHub App's `administration:write`+`pages:write` grants (PUT /pages
+//      needs BOTH),
 //   3. poll GET /pages until state ∈ {approved, issued},
 //   4. restore the declared steady state (proxied=true, cname=soleur.ai).
 //
@@ -73,12 +74,15 @@ const REISSUE_ALLOWED_STATES = ["bad_authz", "failed"] as const;
 const TOKEN_MIN_LIFETIME_MS = 15 * 60 * 1000;
 
 // Least-privilege scope: the reissue calls GET + PUT /repos/{owner}/{repo}/pages
-// (the Pages site-config endpoint), both of which require the `pages` repository
-// permission (write for the cname toggle). `administration:write` is NOT
-// sufficient — live-fire #6657 proved PUT /pages 403s "Resource not accessible by
-// integration" while the minted token held administration:write but no pages
-// grant. repositories:["soleur"] + a 15-min TTL bound the blast radius to one repo.
+// (the Pages site-config endpoint). PUT /pages (the cname toggle) requires BOTH
+// `administration:write` AND `pages:write` — NEITHER alone is sufficient. Verified
+// empirically on the live jikig-ai/soleur installation (#6657): a token with only
+// pages:write → 403, only administration:write → 403, both → 204. (GitHub's REST
+// docs do not surface the fine-grained requirement for this endpoint, so this was
+// confirmed by direct token-minting probes, not the docs.) repositories:["soleur"]
+// + a 15-min TTL bound the blast radius to one repo.
 const REISSUE_TOKEN_PERMISSIONS: Record<string, string> = {
+  administration: "write",
   pages: "write",
 };
 

--- a/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
@@ -576,7 +576,8 @@ describe("source-shape anchors (registration + replay-safety)", () => {
     ['scope: "fn"', "fn-scoped serialization"],
     ['key: \'"cron-platform"\'', "account concurrency lane"],
     ["onFailure: cronGhPagesCertReissueOnFailure", "onFailure lifecycle restore (AC3)"],
-    ['pages: "write"', "least-privilege scoped mint (AC4)"],
+    ['pages: "write"', "scoped mint: pages (AC4) — PUT /pages needs BOTH admin+pages"],
+    ['administration: "write"', "scoped mint: administration (AC4) — PUT /pages needs BOTH admin+pages"],
     ["repositories: [REPO_NAME]", "repo-scoped token (AC4)"],
     ["await step.sleep(", "poll suspends via step.sleep (ADR-077)"],
   ])("source contains %s (%s)", (anchor) => {


### PR DESCRIPTION
## Summary

Corrective follow-up to #6687. That PR scoped the reissue's minted installation token to `{ pages: "write" }` only, based on the prior session's conclusion that `administration:write` was insufficient. That was half-right — `PUT /repos/{owner}/{repo}/pages` (the cname toggle that re-orders a `bad_authz` cert) requires **BOTH** `administration:write` **AND** `pages:write`; neither alone works. So the live reissue kept 403ing after #6687 deployed.

## User-Brand Impact
- **Artifact at risk:** the public GitHub Pages TLS certificate (docs/marketing site).
- **Failure vector:** with only `pages:write`, `PUT /pages` 403s and the cert can never auto-recover from `bad_authz` (expires 2026-08-16).
- **Brand-survival threshold:** aggregate pattern

## Empirical proof (not docs)

GitHub's REST docs do not state the fine-grained permission for `PUT /pages`. Verified directly against the live `jikig-ai/soleur` installation by minting scoped installation tokens via the App JWT and probing a no-op `PUT /pages` (`cname` = current value):

| Minted token permissions | `PUT /pages` |
|---|---|
| `pages:write` only | **403** Resource not accessible by integration |
| `administration:write` only | **403** Resource not accessible by integration |
| `administration:write` + `pages:write` | **204 ✅** |

## Change
- `REISSUE_TOKEN_PERMISSIONS` → `{ administration: "write", pages: "write" }` (shared by both the body mint and the onFailure mint).
- Corrected header + scope comments to state both are required.
- Source-anchor test now locks BOTH `administration: "write"` and `pages: "write"` in the mint.

No manifest or App-settings change needed: the App manifest already declares both (administration retained + pages added in #6687), and the `jikig-ai` installation already grants both (Pages:write accepted post-#6687).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` reissue test — 48/48 pass
- [x] Empirical PUT /pages probe (table above) confirms the both-permissions requirement
- [ ] ⏳ Post-deploy: re-fire the reissue and confirm the cert reaches issued/approved (auto-closes #6657); then restore `https_enforced: true` (GitHub reset it to false while `bad_authz`)

Ref #6657

Generated with [Claude Code](https://claude.com/claude-code)