### PR TITLE
fix(web-platform): emitTerminal must call the logger method, not extract it

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
+++ b/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
@@ -1460,8 +1460,30 @@ function emitTerminal(
   });
 
   if (BENIGN_OUTCOMES.has(result.outcome)) {
-    const log = result.outcome === "config_missing" ? logger.warn : logger.info;
-    log({ fn: FN_ID, ...extra }, `reissue outcome=${result.outcome}`);
+    // ‼️ CALL THE METHOD, DO NOT EXTRACT IT. `const log = logger.info` drops the
+    // receiver, and inngest's ProxyLogger.info() begins `if (!this.enabled)
+    // return;` — so an extracted reference throws
+    // `Cannot read properties of undefined (reading 'enabled')`.
+    //
+    // That throw escapes emitTerminal, propagates out of the handler, exhausts
+    // `retries: 1`, and fires onFailure — so EVERY benign terminal, including
+    // `issued`, was recorded as `reissue_incomplete_restore_ok`. A SUCCESSFUL
+    // remediation reported itself as a failure.
+    //
+    // It never fired before #6698 because the only benign outcomes reachable in
+    // practice were `issued` (never achieved — the cert was wedged) and
+    // `not_stuck`; every observed live fire ended non-benign and took the
+    // reportSilentFallback branch below, which does not touch the ctx logger.
+    // `probe_only_complete` is the first benign terminal to actually execute in
+    // production, which is how the new step markers surfaced this on the first
+    // post-deploy fire.
+    const msg = `reissue outcome=${result.outcome}`;
+    const payload = { fn: FN_ID, ...extra };
+    if (result.outcome === "config_missing") {
+      logger.warn(payload, msg);
+    } else {
+      logger.info(payload, msg);
+    }
     return;
   }
   // Every remediation-failure terminal path mirrors to Sentry (fail-loud → the

--- a/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
@@ -1311,6 +1311,80 @@ describe("#6698 onFailure envelope", () => {
   });
 });
 
+describe("emitTerminal must CALL the logger method, not extract it", () => {
+  // A plain `{ info: vi.fn() }` fake cannot catch this class: object-literal
+  // methods have no `this` dependency, so an extracted reference works fine
+  // against the fake and throws only in production. This fake mirrors inngest's
+  // real ProxyLogger, whose info()/warn() begin `if (!this.enabled) return;`.
+  class ProxyLoggerLike {
+    enabled = true;
+    calls: Array<[unknown, unknown]> = [];
+    info(...args: unknown[]) {
+      if (!this.enabled) return;
+      this.calls.push([args[0], args[1]]);
+    }
+    warn(...args: unknown[]) {
+      if (!this.enabled) return;
+      this.calls.push([args[0], args[1]]);
+    }
+    error(...args: unknown[]) {
+      if (!this.enabled) return;
+      this.calls.push([args[0], args[1]]);
+    }
+  }
+
+  it("does not throw on a BENIGN terminal (issued / not_stuck / probe_only_complete)", async () => {
+    // Observed in production on the first post-deploy fire: extracting the
+    // method produced `Cannot read properties of undefined (reading 'enabled')`,
+    // which escaped the handler, exhausted retries and fired onFailure — so a
+    // SUCCESSFUL remediation was recorded as reissue_incomplete_restore_ok.
+    for (const [cfg, ctx, expected] of [
+      [{ willIssue: true }, remediationCtx(), "issued"],
+      [{ stateOverride: "issued" }, remediationCtx(), "not_stuck"],
+      [{}, probeCtx(), "probe_only_complete"],
+    ] as Array<[FakeConfig, ReissueRunContext, string]>) {
+      const { deps } = makeFake(cfg);
+      const proxyLogger = new ProxyLoggerLike();
+      deps.logger = proxyLogger as unknown as ReissueDeps["logger"];
+
+      const result = await runReissueSteps(
+        makeStep(),
+        deps,
+        deps.logger,
+        ctx,
+      );
+
+      expect(result.outcome, expected).toBe(expected);
+      // The benign branch must have actually logged through the bound method.
+      expect(proxyLogger.calls.length, expected).toBeGreaterThan(0);
+      const [payload, msg] = proxyLogger.calls[proxyLogger.calls.length - 1];
+      expect(msg).toBe(`reissue outcome=${expected}`);
+      expect(payload).toMatchObject({ outcome: expected });
+    }
+  });
+
+  it("config_missing routes to warn, still bound", async () => {
+    const proxyLogger = new ProxyLoggerLike();
+    const prevToken = process.env.CF_API_TOKEN_DNS_EDIT;
+    const prevZone = process.env.CF_ZONE_ID;
+    process.env.CF_API_TOKEN_DNS_EDIT = "";
+    process.env.CF_ZONE_ID = "";
+    try {
+      const result = await cronGhPagesCertReissueHandler({
+        step: makeStep(),
+        logger: proxyLogger as unknown as ReissueDeps["logger"],
+      } as unknown as Parameters<typeof cronGhPagesCertReissueHandler>[0]);
+      expect(result.outcome).toBe("config_missing");
+      expect(proxyLogger.calls.length).toBeGreaterThan(0);
+    } finally {
+      if (prevToken === undefined) delete process.env.CF_API_TOKEN_DNS_EDIT;
+      else process.env.CF_API_TOKEN_DNS_EDIT = prevToken;
+      if (prevZone === undefined) delete process.env.CF_ZONE_ID;
+      else process.env.CF_ZONE_ID = prevZone;
+    }
+  });
+});
+
 describe("#6698 routine_runs projection", () => {
   it("sets ok/errorSummary so runLogMiddleware can distinguish outcomes", async () => {
     // run-log.ts projects EXACTLY { ok?, errorSummary? } off the return value.


### PR DESCRIPTION
## Summary

`emitTerminal` extracted the logger method instead of calling it:

```ts
const log = result.outcome === "config_missing" ? logger.warn : logger.info;
log({ fn: FN_ID, ...extra }, `reissue outcome=${result.outcome}`);
```

That drops the receiver. inngest's `ProxyLogger.info()` begins `if (!this.enabled) return;`, so the extracted reference throws `Cannot read properties of undefined (reading 'enabled')`. The throw escapes `emitTerminal`, exhausts `retries: 1`, and fires `onFailure` — so **every benign terminal, including `issued`, was recorded as `reissue_incomplete_restore_ok`.** A successful remediation reported itself as a failure.

Pre-existing, and it had never fired: the only reachable benign outcomes were `issued` (never achieved — the cert has been wedged) and `not_stuck`. Every observed live fire ended non-benign and took the `reportSilentFallback` branch, which does not touch the ctx logger. `probe_only_complete` is the first benign terminal to actually execute in production.

## How it was found

By the step markers added in the #6698 work, on the very first post-deploy fire — the observability change catching a latent crash it exists to make visible. The marker stream showed the full run (`preflight` → `pre-flip-dns` → `flip-dns-only` → `dns-propagation` → `restore` → `terminal`), then an `onfailure-restore` carrying the TypeError verbatim. Before those markers, this would have surfaced only as an opaque retries-exhausted failure.

Blast radius was contained: `onFailure` restored steady state, apex/www returned to `proxied=true`, and `soleur.ai` stayed HTTP 200 throughout.

## Why tests missed it

The existing fake logger is an object literal, whose methods have no `this` dependency — the extraction works fine against the fake and throws only in production. The regression test uses a `ProxyLogger`-shaped class whose `info()`/`warn()` read `this.enabled`, matching the real one.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Suite green (99 tests)
- [x] Mutation-verified: reintroducing `const log = logger.info` reds both new tests
- [x] Mechanism confirmed against `node_modules/inngest/middleware/logger.js` (`if (!this.enabled) return;`) and reproduced standalone

Ref #6698

Generated with [Claude Code](https://claude.com/claude-code)
