### PR TITLE
fix(web-platform): AAAA is only terminal once A-records prove post-flip state

### DIFF
--- a/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
+++ b/apps/web-platform/server/inngest/functions/cron-gh-pages-cert-reissue.ts
@@ -350,11 +350,40 @@ export function checkDnsPropagated(
   // first request of a validation — redirects get no retry. A Cloudflare-proxied
   // AAAA answers successfully with the WRONG content, so there is no fallback at
   // all and validation fails silently at any window length.
+  const a4AllGitHub =
+    inputs.resolved4.length > 0 && inputs.resolved4.every(isGitHubPagesV4);
+
   if (inputs.resolved6.length > 0) {
+    // ‼️ An AAAA is only TERMINAL once the A-records prove we are actually
+    // looking at the post-flip answer. The public resolvers flap between the
+    // new GitHub answer and the still-cached Cloudflare one for the whole
+    // propagation window (independent caches on 1.1.1.1 and 8.8.8.8), and a
+    // tick that lands on the stale Cloudflare answer returns Cloudflare's
+    // A-records AND its synthetic AAAA together. Treating that as a surviving
+    // zone AAAA aborts a perfectly healthy remediation on a transient read.
+    //
+    // Measured on the 2026-07-19 probe fire (runId 01KXXR3BBF): five ticks
+    // alternated 185.199.x / 188.114.x with ENODATA, then a sixth landed on
+    // 188.114.x WITH the AAAA and terminated the run — while the zone provably
+    // has zero AAAA records (`GET /zones/{id}/dns_records?type=AAAA` → count 0).
+    //
+    // When the A-records HAVE converged to GitHub anycast and an AAAA is still
+    // answered, that is the real H-W4 condition and remains terminal: Let's
+    // Encrypt prefers IPv6 and will not fall back, so no window length helps.
+    if (!a4AllGitHub) {
+      return {
+        status: "retry",
+        reason:
+          `AAAA present (${inputs.resolved6.join(", ")}) but A-records are ` +
+          `${inputs.resolved4.length > 0 ? inputs.resolved4.join(", ") : "absent"} — ` +
+          `this is the pre-flip cached answer, not a surviving AAAA; waiting for propagation`,
+      };
+    }
     return {
       status: "failed",
       reason:
-        `AAAA still resolves after the DNS-only flip (${inputs.resolved6.join(", ")}) — ` +
+        `AAAA still resolves after the DNS-only flip (${inputs.resolved6.join(", ")}) ` +
+        `while A-records have converged to GitHub anycast — ` +
         `Let's Encrypt prefers IPv6 and will not fall back, so no window length can succeed. ` +
         `Fix the zone (the toggle set covers only A + CNAME) before remediating.`,
     };

--- a/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
+++ b/apps/web-platform/test/server/inngest/cron-gh-pages-cert-reissue.test.ts
@@ -714,11 +714,40 @@ describe("#6698 checkDnsPropagated — pure verdict function (AC8)", () => {
     expect(v.reason).toMatch(/188\.114\.96\.2/);
   });
 
+  it("AAAA present WITH stale Cloudflare A-records → retry, not terminal", () => {
+    // Measured in production (runId 01KXXR3BBF, 2026-07-19): the public
+    // resolvers flap between the new GitHub answer and the still-cached
+    // Cloudflare one for the whole propagation window, and a tick landing on
+    // the stale answer returns Cloudflare's A-records AND its synthetic AAAA
+    // together. The zone provably has zero AAAA records, so treating that as a
+    // surviving AAAA aborts a healthy remediation on a transient read.
+    const v = checkDnsPropagated({
+      ...base,
+      resolved4: ["188.114.96.1", "188.114.97.1"],
+      resolved6: ["2a06:98c1:3121::1", "2a06:98c1:3120::1"],
+      resolve6Error: null,
+    });
+    expect(v.status).toBe("retry");
+    expect(v.reason).toMatch(/pre-flip cached answer/);
+  });
+
+  it("AAAA present with NO A-record answer → retry (cannot confirm post-flip state)", () => {
+    const v = checkDnsPropagated({
+      ...base,
+      resolved4: [],
+      resolved6: ["2a06:98c1:3121::1"],
+      resolve6Error: null,
+    });
+    expect(v.status).toBe("retry");
+  });
+
   it("AAAA present → failed, NOT retry (H-W4 is terminal, waiting cannot help)", () => {
     // Let's Encrypt prefers IPv6 and will not fall back from a proxied AAAA that
     // answers 200 with the wrong content, so no window length can succeed. A
     // `retry` here would burn the remaining budget lengthening a public TLS
     // outage for an outcome that cannot change.
+    // A-records CONVERGED to GitHub anycast (base fixture) AND an AAAA still
+    // answers — that is the real H-W4 condition, and it stays terminal.
     const v = checkDnsPropagated({
       ...base,
       resolved6: ["2a06:98c1:3120::2"],
@@ -726,6 +755,7 @@ describe("#6698 checkDnsPropagated — pure verdict function (AC8)", () => {
     });
     expect(v.status).toBe("failed");
     expect(v.reason).toMatch(/prefers IPv6/);
+    expect(v.reason).toMatch(/converged to GitHub anycast/);
   });
 
   it("A-records right but ACME not GitHub-shaped → retry (challenge intercepted)", () => {


### PR DESCRIPTION
## Summary

The DNS-propagation gate treated **any** AAAA answer as terminal. It aborts a healthy remediation on a transient read, because the observation itself can be stale.

Public resolvers flap between the new GitHub answer and the still-cached Cloudflare one for the whole propagation window (1.1.1.1 and 8.8.8.8 have independent caches and TTLs). A tick landing on the stale answer returns Cloudflare's A-records **and** its synthetic AAAA together.

## Evidence (production, runId `01KXXR3BBF`)

| t | A-records | AAAA | verdict |
| --- | --- | --- | --- |
| +7s | `185.199.x` (GitHub) | `[]` `ENODATA` | retry |
| +45s | `188.114.x` (Cloudflare) | `[]` | retry |
| +81s | `185.199.x` | `[]` | retry |
| +117s | `185.199.x` | `[]` | retry |
| +154s | `188.114.x` (CF) | `[]` | retry |
| +190s | `188.114.x` (CF) | **present** | **failed → terminal** |

The zone provably has **zero** AAAA records — `GET /zones/{id}/dns_records?type=AAAA` returns `count: 0` (the Phase 0.1 gate from #6698). So the AAAA on that final tick is Cloudflare's synthetic answer inside a stale cached response, not a surviving zone record.

## Fix

An AAAA is terminal **only once the A-records prove we are looking at post-flip state**. If they still show Cloudflare (or are absent), the whole answer is the pre-flip cached one and the correct verdict is `retry`.

The real H-W4 protection is preserved: an AAAA answered while A-records **have** converged to GitHub anycast stays terminal, because Let's Encrypt prefers IPv6 and will not fall back — no window length helps there.

## How it was found

By the step markers shipped in #6698, on the second production probe fire. The per-tick resolver answers are what made the flapping visible; without them this would have looked like a flat `dns_propagation_failed` and been misread as the AAAA root cause the gate was built to detect — the precise misdiagnosis it exists to prevent.

Introduced during #6698's review round: making AAAA terminal-not-retryable was correct about Let's Encrypt's behaviour, but neither the review nor I modelled that the observation could be stale.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `scripts/test-all.sh` — 192/192 suites, exit 0
- [x] New: stale-CF-A + AAAA → `retry`; no-A + AAAA → `retry`
- [x] Existing terminal case tightened to assert A-records converged
- [x] Mutation-verified — forcing terminal-on-any-AAAA reds both new tests

Ref #6698

Generated with [Claude Code](https://claude.com/claude-code)
