### PR TITLE
fix(security): remove @-mention credfile-exfil footgun in preflight skill + add repo guard

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,8 +10,15 @@
       "Bash(gh pr merge:*)"
     ],
     "deny": [
+      "Read(**/.aws/**)",
+      "Read(**/.config/gcloud/**)",
+      "Read(**/.docker/config.json)",
+      "Read(**/.doppler/**)",
       "Read(**/.env)",
       "Read(**/.env.*)",
+      "Read(**/.git-credentials)",
+      "Read(**/.netrc)",
+      "Read(**/.ssh/**)",
       "Read(**/lib/stripe.ts)"
     ]
   },

--- a/.github/scripts/test/test-no-at-mention-credfile-footgun.sh
+++ b/.github/scripts/test/test-no-at-mention-credfile-footgun.sh
@@ -10,9 +10,11 @@
 # documentation example in preflight/SKILL.md that wrote such a token pointing at the
 # Doppler CLI config caused the operator's live root token to be auto-attached.
 #
-# This guard forbids that token shape in the AUTO-LOADED content surface (skills,
-# agents, commands, plugin docs, AGENTS*.md, .claude hooks) — the content the harness
-# injects into agent context. Historical, read-on-demand artifacts under
+# This guard forbids that token shape in the AUTO-LOADED content surface — the content
+# the harness injects into agent context: skills, agents, commands, plugin docs, every
+# AGENTS.md / CLAUDE.md (root AND plugin-level, since CLAUDE.md `@AGENTS.md`-imports the
+# plugin instruction body), and every hook dir whose stdout is injected (.claude/hooks
+# AND plugins/soleur/hooks). Historical, read-on-demand artifacts under
 # knowledge-base/project/{plans,brainstorms,learnings,specs} are intentionally out of
 # scope (lower-frequency vector; would otherwise require editing archived records).
 #
@@ -56,7 +58,9 @@ SELF="${BASH_SOURCE[0]##*/}"
 # git ls-files → committed files only; glob-expanded by git (no eval).
 mapfile -t FILES < <(cd "$ROOT" && git ls-files \
   'plugins/soleur/skills/**' 'plugins/soleur/agents/**' 'plugins/soleur/commands/**' \
-  'plugins/soleur/docs/**' 'AGENTS.md' 'AGENTS.*.md' '.claude/hooks/**' 2>/dev/null)
+  'plugins/soleur/docs/**' 'plugins/soleur/hooks/**' '.claude/hooks/**' \
+  'AGENTS.md' 'AGENTS.*.md' 'CLAUDE.md' \
+  'plugins/**/AGENTS.md' 'plugins/**/AGENTS.*.md' 'plugins/**/CLAUDE.md' 2>/dev/null)
 hits=0
 for f in "${FILES[@]}"; do
   [[ "$f" == *"$SELF" ]] && continue          # never scan this guard itself

--- a/.github/scripts/test/test-no-at-mention-credfile-footgun.sh
+++ b/.github/scripts/test/test-no-at-mention-credfile-footgun.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# test-no-at-mention-credfile-footgun.sh — repo guard (auto-globbed into the
+# REQUIRED `guard-script-fixture-tests` job via run-all.sh; bash-only, no external
+# tooling).
+#
+# WHY: Claude Code's @-mention auto-attach resolves an at-sign immediately followed
+# by a real on-disk path (tilde-home, $HOME, or an absolute system path) to the file
+# and attaches its CONTENTS to the transcript — even when the token appears inside
+# tool/skill output rather than a user message. On 2026-07-22 (PR #6830), a
+# documentation example in preflight/SKILL.md that wrote such a token pointing at the
+# Doppler CLI config caused the operator's live root token to be auto-attached.
+#
+# This guard forbids that token shape in the AUTO-LOADED content surface (skills,
+# agents, commands, plugin docs, AGENTS*.md, .claude hooks) — the content the harness
+# injects into agent context. Historical, read-on-demand artifacts under
+# knowledge-base/project/{plans,brainstorms,learnings,specs} are intentionally out of
+# scope (lower-frequency vector; would otherwise require editing archived records).
+#
+# The detector matches an at-sign IMMEDIATELY followed by: `~`, `$HOME`/`${HOME`, or an
+# absolute path whose first segment is a real filesystem root (home/Users/root/etc/tmp/
+# var/opt/usr/mnt). It deliberately does NOT match npm scopes (`@scope/pkg`), TS path
+# aliases (`@/lib/...`), emails (`user@host`), GitHub @mentions, or `@<placeholder>`.
+set -uo pipefail
+
+# The forbidden token shape. Kept in ONE place; the self-test and the repo scan share it.
+PATTERN='@(~|\$\{?HOME|/(home|Users|root|etc|tmp|var|opt|usr|mnt)/)'
+
+PASS=0
+FAIL=0
+ok()   { PASS=$((PASS+1)); }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+
+# detect: prints matching substrings (one per line) for the given text on stdin.
+detect() { grep -oE "$PATTERN[^[:space:]\`\"']*" 2>/dev/null || true; }
+
+echo "=== 1. non-vacuity: the detector MUST flag every real-path footgun shape ==="
+# Built by concatenation so this test file itself never contains a contiguous literal
+# that a future scope-widening of the scan could self-flag.
+AT='@'
+for tok in "${AT}~/.ssh/id_rsa" "${AT}~/.doppler/.doppler.yaml" "${AT}\$HOME/.aws/credentials" \
+           "${AT}\${HOME}/.netrc" "${AT}/home/alice/.git-credentials" "${AT}/root/.ssh/id_ed25519" \
+           "${AT}/etc/shadow" "${AT}/tmp/secret.json"; do
+  if printf '%s\n' "curl --data-binary $tok" | detect | grep -q .; then ok; else bad "detector missed: $tok"; fi
+done
+
+echo "=== 2. no false positives on legitimate at-sign uses ==="
+for tok in "${AT}11ty/eleventy" "${AT}types/node" "${AT}anthropic-ai/sdk" "${AT}/lib/foo" \
+           "${AT}/components/x" "user${AT}example.com" "${AT}octocat" "${AT}<doppler-config-file>" \
+           "${AT}<credential-file>"; do
+  if printf '%s\n' "$tok" | detect | grep -q .; then bad "false positive on: $tok"; else ok; fi
+done
+
+echo "=== 3. repo scan: auto-loaded content surface must contain ZERO footgun tokens ==="
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+SELF="${BASH_SOURCE[0]##*/}"
+# git ls-files → committed files only; glob-expanded by git (no eval).
+mapfile -t FILES < <(cd "$ROOT" && git ls-files \
+  'plugins/soleur/skills/**' 'plugins/soleur/agents/**' 'plugins/soleur/commands/**' \
+  'plugins/soleur/docs/**' 'AGENTS.md' 'AGENTS.*.md' '.claude/hooks/**' 2>/dev/null)
+hits=0
+for f in "${FILES[@]}"; do
+  [[ "$f" == *"$SELF" ]] && continue          # never scan this guard itself
+  # grep the file directly (not a pipe) so no SIGPIPE/early-match flake.
+  m=$(grep -nE "$PATTERN" "$ROOT/$f" 2>/dev/null || true)
+  if [[ -n "$m" ]]; then
+    hits=$((hits+1))
+    echo "  FOOTGUN in $f:"
+    printf '    %s\n' "$m"
+  fi
+done
+if [[ "$hits" -eq 0 ]]; then ok; else bad "$hits file(s) contain an @-mention real-path footgun (see above)"; fi
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+  echo "test-no-at-mention-credfile-footgun: FAILED"
+  echo "Fix: replace the '@'+real-path token with a placeholder like @<credential-file>."
+  echo "See plugins/soleur/skills/preflight/SKILL.md near the credentialed-CLI reject for context."
+  exit 1
+fi
+echo "test-no-at-mention-credfile-footgun: OK"

--- a/knowledge-base/project/learnings/2026-07-23-at-mention-auto-attach-credfile-exfil-footgun.md
+++ b/knowledge-base/project/learnings/2026-07-23-at-mention-auto-attach-credfile-exfil-footgun.md
@@ -1,0 +1,80 @@
+---
+date: 2026-07-23
+category: security-issues
+module: preflight-skill / claude-code-harness
+tags: [prompt-injection, credential-exfil, at-mention, auto-attach, doppler, footgun]
+severity: single-user incident
+---
+
+# An at-sign + a real file path in skill text auto-attaches that file's contents
+
+## Problem
+
+During PR #6830's ship (2026-07-22), the operator's **live Doppler root token** appeared
+in the session transcript, formatted to look like a `Read` tool result the agent had
+performed. No such Read was ever invoked.
+
+## Root cause
+
+Claude Code's **`@`-mention auto-attach** resolves an at-sign immediately followed by a
+real on-disk path (tilde-home, `$HOME`, or an absolute system path) to the file and
+attaches its **contents** to the transcript — and it does this even when the token
+appears inside **tool/skill output**, not just a user-typed message.
+
+`plugins/soleur/skills/preflight/SKILL.md` (Check 10, "reject credentialed CLIs")
+documented an exfiltration *example* whose literal text was an at-sign followed by the
+real Doppler CLI config path. When preflight loaded, the harness parsed that token,
+resolved the real 0600 file, and attached its contents — **exfiltrating the exact
+credential the documentation was warning about.**
+
+Forensics that pinned it (all reproducible from the session JSONL):
+
+- The token-bearing block is a genuine CC `attachment` record (`attachment.type=="file"`,
+  keys `content`/`displayPath`/`filename`), child of the preflight Skill result message —
+  **not** any `tool_result`, and not in any committed repo file.
+- The same skill sentence names 7 credential files, **all of which exist on the machine**,
+  but **only the one written with a leading `@` was attached** — the `@`-mention is the
+  precise trigger, not "any path in the text."
+
+## Solution
+
+1. **Fix the instance:** replace the `@`+real-path token in `preflight/SKILL.md` with a
+   non-resolvable placeholder (`@<doppler-config-file>`), plus an inline SECURITY comment
+   so no future editor restores the literal path.
+2. **Prevent the class (repo guard):**
+   `.github/scripts/test/test-no-at-mention-credfile-footgun.sh` — auto-globbed into the
+   REQUIRED `guard-script-fixture-tests` job (bash-only). It forbids an at-sign +
+   real-home/absolute path in the **auto-loaded content surface** (skills, agents,
+   commands, plugin docs, `AGENTS*.md`, `.claude/hooks`). It is non-vacuous:
+   proves detection on synthetic footguns, proves no false positives on npm scopes / TS
+   `@/` aliases / emails / GitHub @mentions / `@<placeholder>`, and is mutation-tested
+   end-to-end.
+3. **Defense-in-depth:** `.claude/settings.json` `permissions.deny` now denies `Read()`
+   on the credential locations preflight Check 10 enumerates (doppler, ssh, aws, gcloud,
+   docker, netrc, git-credentials). This does not break the credential CLIs — they read
+   their configs internally as subprocesses, not via the `Read` tool.
+4. **Rotate:** the leaked Doppler token was root-scoped; the operator rotated it (a fresh
+   `doppler login` minted a new token, invalidating the leaked one).
+
+## Key insight
+
+A credential **path literal** is not inert in agent-loaded text: prefixed with the
+`@` sigil it becomes an *attach-this-file directive* the harness executes. Two
+generalizations:
+
+- **Never write an at-sign immediately before a resolvable home/absolute path** in any
+  content that loads into agent context — describe it, placeholder it, or break the sigil
+  from the path. The repo guard now enforces this.
+- **The vector generalizes beyond documentation.** Any untrusted text entering the
+  context (a fetched web page in a research flow, a third-party repo file, an issue body)
+  that contains `@`+a-real-path can trigger the same attach. The harness-level fix is
+  Anthropic's; the `permissions.deny` credential-read denylist is the operator-side
+  backstop, and treating research/WebFetch against untrusted content as a credential-exfil
+  surface is the standing posture.
+
+## Related
+
+- Incident observed during PR #6830 (the `/soleur:go 6827` one-shot run).
+- `hr-never-paste-secrets-via-bang-prefix` (sibling secret-handling rule).
+- Lower-risk sibling instance (out of guard scope, transient `/tmp` path):
+  `knowledge-base/project/plans/2026-05-17-feat-r2-lock-rules-gdpr-override-plan.md:75`.

--- a/plugins/soleur/skills/preflight/SKILL.md
+++ b/plugins/soleur/skills/preflight/SKILL.md
@@ -840,10 +840,19 @@ fi
 
 **This is a DENYLIST, and a denylist cannot be complete against a preserved `$HOME`.**
 It does NOT catch indirect invocation — `bash scripts/foo.sh` whose body self-wraps
-`doppler run -c prd`, a `curl --data-binary @~/.doppler/.doppler.yaml` exfiltration, or any
+`doppler run -c prd`, a `curl --data-binary @<doppler-config-file>` exfiltration, or any
 credentialed verb not listed. Those remain reachable and are accepted for now; the durable
 fix is an ALLOWLIST of probe verbs (curl/dig/getent/bun/bash), tracked separately. Do not
 describe this reject as though it closed the class.
+<!-- SECURITY (at-mention auto-attach footgun): the exfil example above uses the
+     PLACEHOLDER `<doppler-config-file>`, NOT a real resolvable path. Never write an
+     at-sign immediately followed by a real home/absolute path (tilde-slash,
+     dollar-HOME-slash, or a `/home` `/Users` `/root` `/etc` absolute) in ANY
+     skill/agent/doc that loads into agent context: Claude Code's @-mention auto-attach
+     resolves such a token to the real on-disk file and attaches its CONTENTS to the
+     transcript. Observed 2026-07-22 during PR #6830's ship — the prior literal here
+     resolved to the operator's live Doppler root token and auto-attached it. The guard
+     .github/scripts/test/test-no-at-mention-credfile-footgun.sh enforces this repo-wide. -->>
 
 The `(^|[[:space:]]|/)` … `([[:space:]]|$)` boundaries are load-bearing: the `/`
 alternative catches `/usr/local/bin/gh`, and the trailing boundary keeps legitimate

--- a/plugins/soleur/skills/preflight/SKILL.md
+++ b/plugins/soleur/skills/preflight/SKILL.md
@@ -852,7 +852,7 @@ describe this reject as though it closed the class.
      resolves such a token to the real on-disk file and attaches its CONTENTS to the
      transcript. Observed 2026-07-22 during PR #6830's ship — the prior literal here
      resolved to the operator's live Doppler root token and auto-attached it. The guard
-     .github/scripts/test/test-no-at-mention-credfile-footgun.sh enforces this repo-wide. -->>
+     .github/scripts/test/test-no-at-mention-credfile-footgun.sh enforces this repo-wide. -->
 
 The `(^|[[:space:]]|/)` … `([[:space:]]|$)` boundaries are load-bearing: the `/`
 alternative catches `/usr/local/bin/gh`, and the trailing boundary keeps legitimate


### PR DESCRIPTION
## Summary

Fixes a real credential-exfiltration footgun found while investigating an incident during PR #6830's ship, where the operator's live Doppler root token appeared in the transcript formatted as a `Read` result that was never invoked.

**Root cause:** Claude Code's `@`-mention auto-attach resolves an at-sign immediately followed by a real on-disk path (tilde-home, `$HOME`, or an absolute system path) to the file and attaches its **contents** to the transcript — and it does so even when the token appears in **tool/skill output**, not just a user message. `preflight/SKILL.md` (Check 10) documented an exfiltration *example* whose literal text was `@` + the real Doppler CLI config path; loading the skill auto-attached that file. The same sentence names 7 credential files (all present on disk) but only the `@`-prefixed one was attached — confirming the `@`-mention as the exact trigger.

The leaked token was root-scoped and has been **rotated** by the operator.

## Changelog

- **`preflight/SKILL.md`** — replace the `@`+real-path token with a non-resolvable `@<doppler-config-file>` placeholder + an inline SECURITY comment so it is not restored.
- **`.github/scripts/test/test-no-at-mention-credfile-footgun.sh`** (new) — repo guard, auto-globbed into the **required** `guard-script-fixture-tests` job (bash-only). Forbids the `@`+real-home/absolute-path shape across the auto-loaded content surface (skills, agents, commands, plugin docs, `AGENTS*.md`, `.claude/hooks`; 689 files). Non-vacuous: proves detection on synthetic footguns, proves no false positives (npm scopes / TS `@/` aliases / emails / GitHub @mentions / placeholders), and mutation-tested end-to-end.
- **`.claude/settings.json`** — defense-in-depth `permissions.deny` on the credential locations preflight Check 10 enumerates (doppler, ssh, aws, gcloud, docker, netrc, git-credentials). Purely additive; the CLIs read their configs internally as subprocesses, so no workflow breaks.
- **Learning** capturing the incident, forensics, and prevention.

## Test plan

- [x] Guard passes green on the repo (18/18: 8 detection, 9 no-false-positive, 1 clean scan).
- [x] Guard mutation-tested: planting `@`+real-path in a scanned file makes it fail and name the file; reverting restores green.
- [x] Corpus coverage verified: nested agents, `AGENTS.core.md`, commands, hooks all matched.
- [x] `.claude/settings.json` change is additive (`allow[]` intact, valid JSON) — passes the settings-integrity gate.
- [x] Leaked Doppler token rotated (operator).

Observed during PR #6830. Self-contained security fix; no tracking issue to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
