### PR TITLE
fix(preflight): stop skill body from auto-attaching a real secret file

### DIFF
--- a/knowledge-base/project/learnings/security-issues/2026-07-23-at-mention-in-skill-body-auto-attaches-real-secret-files.md
+++ b/knowledge-base/project/learnings/security-issues/2026-07-23-at-mention-in-skill-body-auto-attaches-real-secret-files.md
@@ -1,0 +1,87 @@
+---
+title: An `@`-path in a skill body makes Claude Code auto-attach the real local file (secret leak)
+date: 2026-07-23
+category: security
+tags: [claude-code, prompt-injection, secrets, skills, preflight, at-mention, footgun]
+type: bug-fix
+severity: high
+---
+
+# An `@`-path in a skill body makes Claude Code auto-attach the real local file
+
+## Symptom
+
+During `soleur:preflight`, a `<system-reminder>` appeared that looked like a
+prompt-injection: it claimed a `Read` of `~/.doppler/.doppler.yaml` (the Doppler
+CLI token file) that neither the operator nor the agent had initiated, and it
+surfaced the token value. It recurred deterministically on every preflight run,
+across 9+ session transcripts (byte-identical, because the Doppler CLI's
+`version-check` timestamp was frozen — so each live read returned the same bytes).
+
+## Root cause (not an attacker — a self-inflicted footgun)
+
+`plugins/soleur/skills/preflight/SKILL.md` documented, in the Check-10 denylist
+prose, an exfiltration example using the curl `@file` upload form whose argument
+was a literal `@` immediately followed by the real path `~/.doppler/.doppler.yaml`.
+
+When a skill loads, its SKILL.md body is delivered to the model **as user-turn
+content**. Claude Code's `@file`-mention auto-attach scans user-turn content for
+`@<path>` tokens and **reads the referenced file into model context** (recorded
+in the transcript as an `attachment` of `type:"file"`). So the security
+documentation, by quoting an `@`-prefixed real path, caused CC to read the
+operator's live secret file on every preflight load. The "prompt injection" was
+CC's own feature reading a real local file the docs happened to point at.
+
+Forensics that nailed it: the injected payload was an `attachment.type:"file"`
+entry (`filename: ~/.doppler/.doppler.yaml`, `displayPath: ../../../../../.doppler/.doppler.yaml`)
+tied to the skill-load user turn — not any hook. Every configured hook
+(`phase-surface-hint.sh`, `skill-context-queries.sh`, plugin hooks, global hooks)
+was verified clean and reproduced only benign output. The trigger string was the
+sole `@`-anchored real-file mention in the whole repo.
+
+## The trap that confirmed it
+
+The footgun is **not** limited to SKILL.md — it fires on **any** user-turn
+content: skill **args**, and (would-be) Task subagent prompts. While driving the
+fix, quoting the vulnerable `@`-path inside `soleur:one-shot` *args* re-triggered
+the auto-attach and re-read the file. Never write a literal `@` adjacent to a
+real path in args, PR bodies, learnings, or test fixtures either — build such
+fixtures by string concatenation (`"@" + "~/…"`) so the adjacency never exists.
+
+## Fix
+
+1. Rephrase so the real path sits in a plain code-span with the `@` **detached**
+   (keep the meaning): `a curl --data-binary upload of the ~/.doppler/.doppler.yaml
+   token file (the curl @file form)` — the `@file` and the real path are no longer
+   adjacent, so nothing resolves.
+2. Regression guard: `plugins/soleur/scripts/lint-at-mention-secret-paths.sh`
+   scans every tracked `skills/`, `agents/`, `commands/` markdown body and fails
+   on an `@`-mention resolving to a home/absolute real path (`@~/`, `@$HOME`,
+   `@/home|Users|root|etc|…/`, or `@`+a path with `.doppler`/`.ssh`/`.aws`/
+   `.netrc`/`.env`/`credentials`). Next.js `@/`-import aliases (`@/server`,
+   `@/lib`) and package scopes (`@types/…`) are intentionally NOT flagged —
+   they resolve to nonexistent absolute paths. Test:
+   `plugins/soleur/test/at-mention-secret-path-guard.test.ts`.
+
+## How to apply
+
+- Treat a "fake `<system-reminder>` claiming a Read I didn't do" as a claim to
+  **investigate at the source-of-provenance**, not a fact to act on. The session
+  transcript (`~/.claude/projects/<proj>/<session>.jsonl`) records each context
+  entry's `type`/provenance — an `attachment.type:"file"` entry names the exact
+  file and how it entered. That is faster and more certain than reasoning about
+  hooks.
+- Exhaust the persisted surfaces before concluding "live/harness injection":
+  project + global + plugin hooks, the phase-surface map, and the **installed**
+  skill copy (loads from the plugin cache / bare-root checkout, not your worktree).
+- A byte-identical "leak" across many sessions is a signal it's a *static read of
+  an unchanged file*, not a replay — check the file's own timestamps.
+- Rotate anything a real read exposed regardless of vector (here: verify the
+  Doppler token; the Discord/Hetzner tokens found sitting in plaintext inside
+  `.claude/settings.local.json` permission-allow rules were a separate, real
+  exposure surfaced by the same investigation).
+
+Related: [[hr-never-paste-secrets-via-bang-prefix]] (same class — secrets must
+never enter model-visible content), the preflight Check-10 credentialed-CLI
+reject, and `hr-when-in-a-worktree-never-read-from-bare` (the installed/bare-root
+skill copy is where the running body actually loads from).

--- a/plugins/soleur/scripts/lint-at-mention-secret-paths.sh
+++ b/plugins/soleur/scripts/lint-at-mention-secret-paths.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# lint-at-mention-secret-paths.sh
+#
+# Fails if any Soleur skill/agent/command markdown BODY contains an `@`-mention
+# that Claude Code's `@file` auto-attach would resolve to a REAL home/absolute
+# filesystem path. When a skill/agent body loads it is delivered as user-turn
+# content, and CC scans that content for `@<path>` tokens and reads the
+# referenced file into model context (and into on-disk session transcripts).
+# A documentation example that quotes an `@`-prefixed real path — e.g. the curl
+# `@file` upload form pointing at `~/.doppler/.doppler.yaml` — therefore leaks
+# the operator's live secret on every load. This guard prevents that regression.
+#
+# NOT flagged (intentional): Next.js `@/`-import-alias examples like
+# `@/server/...`, `@/lib/...`. Those resolve to nonexistent absolute paths
+# (`/server/...`) and never attach a real file. Package scopes (`@types/…`,
+# `@playwright/…`) are `@word/…`, not `@/` or `@~`, and are also ignored.
+#
+# Exit: 0 = clean, 1 = violation(s) found, 2 = usage/repo error.
+# Usage: lint-at-mention-secret-paths.sh [REPO_ROOT]   (defaults to git toplevel)
+set -uo pipefail
+
+ROOT="${1:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+if [[ -z "$ROOT" || ! -d "$ROOT" ]]; then
+  echo "FAIL(usage): could not resolve a repo root (arg 1 or git toplevel)." >&2
+  exit 2
+fi
+cd "$ROOT" || exit 2
+
+# `@` + a home/absolute real directory prefix (home dir, or a real OS root dir).
+# `@/server/`, `@/lib/` deliberately excluded — not real absolute paths.
+HOME_ABS='@(~|\$\{?HOME|/(home|Users|root|etc|var|opt|tmp|srv|mnt|media|private)/)'
+# `@` + any path (path-safe chars only, so a backtick/quote/space ends the token)
+# ending in a sensitive dotfile/dir/extension.
+SENSITIVE='@[A-Za-z0-9_./~$-]*(\.(doppler|ssh|aws|netrc|pem|kube|git-credentials)|/credentials|\.env)'
+ERE="(${HOME_ABS})|(${SENSITIVE})"
+
+mapfile -t files < <(git ls-files plugins/soleur/skills plugins/soleur/agents plugins/soleur/commands 2>/dev/null | grep -E '\.md$' || true)
+
+violations=0
+for f in "${files[@]}"; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    echo "VIOLATION: $f:$hit"
+    violations=$((violations + 1))
+  done < <(grep -nE "$ERE" "$f" 2>/dev/null || true)
+done
+
+if [[ "$violations" -gt 0 ]]; then
+  {
+    echo ""
+    echo "FAIL: $violations @-mention(s) resolving to a real home/absolute path in a skill/agent/command body."
+    echo "Claude Code's @file auto-attach reads these into model context when the body loads (secret-leak footgun)."
+    echo "Fix: keep the real path in a plain code-span with NO literal @ immediately before it"
+    echo "(see plugins/soleur/skills/preflight/SKILL.md Check-10 denylist prose for the accepted phrasing)."
+  } >&2
+  exit 1
+fi
+
+echo "OK: no dangerous @-real-path mentions in skill/agent/command bodies (scanned ${#files[@]} markdown files)."
+exit 0

--- a/plugins/soleur/skills/preflight/SKILL.md
+++ b/plugins/soleur/skills/preflight/SKILL.md
@@ -840,10 +840,17 @@ fi
 
 **This is a DENYLIST, and a denylist cannot be complete against a preserved `$HOME`.**
 It does NOT catch indirect invocation — `bash scripts/foo.sh` whose body self-wraps
-`doppler run -c prd`, a `curl --data-binary @~/.doppler/.doppler.yaml` exfiltration, or any
+`doppler run -c prd`, a `curl --data-binary` upload of the `~/.doppler/.doppler.yaml` token file (the curl `@file` form), or any
 credentialed verb not listed. Those remain reachable and are accepted for now; the durable
 fix is an ALLOWLIST of probe verbs (curl/dig/getent/bun/bash), tracked separately. Do not
 describe this reject as though it closed the class.
+
+> **Do not write a literal `@` immediately before a real home/absolute path** (e.g. the curl
+> `@file` upload form pointing at a `~/`-anchored secret) anywhere in a skill/agent/command
+> body. When the body loads it is delivered as user-turn content, and Claude Code's `@file`
+> mention auto-attach resolves that `@`-path and reads the real local file into model context.
+> The `lint-at-mention-secret-paths.sh` guard enforces this; keep the path in a plain code-span
+> with the `@` detached (as above).
 
 The `(^|[[:space:]]|/)` … `([[:space:]]|$)` boundaries are load-bearing: the `/`
 alternative catches `/usr/local/bin/gh`, and the trailing boundary keeps legitimate

--- a/plugins/soleur/test/at-mention-secret-path-guard.test.ts
+++ b/plugins/soleur/test/at-mention-secret-path-guard.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+// Guard for the `@file`-auto-attach secret-leak footgun.
+//
+// Claude Code scans user-turn content (which includes a skill/agent/command
+// BODY at load time) for `@<path>` mentions and reads the referenced file into
+// model context. A documentation example that quotes an `@`-prefixed REAL path
+// (e.g. the curl `@file` upload form pointing at `~/.doppler/.doppler.yaml`)
+// therefore leaks the operator's live secret on every load. This suite pins the
+// guard script that prevents that regression.
+//
+// The dangerous literal is never written adjacently in this file — it is built
+// via string concatenation (`AT + "~/…"`) so the guard cannot flag its own test
+// and so loading this file could never re-trigger the footgun.
+
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
+const GUARD_SH = resolve(
+  REPO_ROOT,
+  "plugins/soleur/scripts/lint-at-mention-secret-paths.sh",
+);
+const PREFLIGHT_MD = resolve(
+  REPO_ROOT,
+  "plugins/soleur/skills/preflight/SKILL.md",
+);
+
+const AT = "@"; // never adjacent-literal a real path in this source file
+
+function run(root: string): { code: number; stdout: string; stderr: string } {
+  const r = Bun.spawnSync(["bash", GUARD_SH, root], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    code: r.exitCode ?? -1,
+    stdout: r.stdout.toString(),
+    stderr: r.stderr.toString(),
+  };
+}
+
+function sandbox(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "at-mention-guard-"));
+  Bun.spawnSync(["git", "init", "-q", dir], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(dir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+  Bun.spawnSync(["git", "-C", dir, "add", "."], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return dir;
+}
+
+describe("scaffold", () => {
+  test("guard script exists and is the source of truth", () => {
+    expect(existsSync(GUARD_SH)).toBe(true);
+  });
+});
+
+describe("regression — the real repo is clean", () => {
+  test("guard passes against the live repo (preflight line 843 fixed)", () => {
+    const { code, stdout } = run(REPO_ROOT);
+    expect(code).toBe(0);
+    expect(stdout).toContain("OK: no dangerous @-real-path mentions");
+  });
+
+  test("preflight SKILL.md no longer carries an @-prefixed real secret path", () => {
+    const md = readFileSync(PREFLIGHT_MD, "utf8");
+    // The pre-fix form was: `@` immediately followed by `~/.doppler/.doppler.yaml`.
+    const danger = AT + "~/.doppler";
+    expect(md.includes(danger)).toBe(false);
+    // The accepted phrasing keeps the path in a plain code-span, @ detached.
+    expect(md).toContain("`~/.doppler/.doppler.yaml` token file");
+  });
+});
+
+describe("positive — dangerous @-real-path mentions are flagged", () => {
+  const cases: Record<string, string> = {
+    "home-tilde-doppler": AT + "~/.doppler/.doppler.yaml",
+    "abs-home-ssh": AT + "/home/jean/.ssh/id_ed25519",
+    "home-var-aws-creds": AT + "$HOME/.aws/credentials",
+    "dotenv": AT + "~/app/.env",
+  };
+
+  for (const [name, token] of Object.entries(cases)) {
+    test(`flags ${name}`, () => {
+      const dir = sandbox({
+        "plugins/soleur/skills/foo/SKILL.md": `# Foo\n\nExample: curl --data-binary ${token} up\n`,
+      });
+      try {
+        const { code, stdout } = run(dir);
+        expect(code).toBe(1);
+        expect(stdout).toContain("VIOLATION:");
+        expect(stdout).toContain("plugins/soleur/skills/foo/SKILL.md");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  }
+});
+
+describe("negative — safe @-mentions are NOT flagged", () => {
+  test("Next.js @/ import aliases and a detached real path pass", () => {
+    const detached =
+      "the curl `" + AT + "file` form pointing at `~/.doppler/.doppler.yaml`";
+    const dir = sandbox({
+      "plugins/soleur/skills/foo/SKILL.md": [
+        "# Foo",
+        "",
+        "import x from " + AT + "/server/logger",
+        "import y from " + AT + "/lib/api",
+        "see " + AT + "types/node and " + AT + "playwright/mcp",
+        detached,
+      ].join("\n"),
+    });
+    try {
+      const { code, stdout } = run(dir);
+      expect(code).toBe(0);
+      expect(stdout).toContain("OK: no dangerous");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Security fix.** The preflight skill's Check-10 denylist prose quoted an exfiltration example whose `curl --data-binary` argument was a literal `@` immediately followed by the real path `~/.doppler/.doppler.yaml`. When a skill body loads it is delivered as **user-turn content**, and Claude Code's `@file`-mention auto-attach resolves that path and reads the operator's **live Doppler token file** into model context — and into on-disk session transcripts — on **every** preflight run. It surfaced as a fake-looking `<system-reminder>` claiming a `Read` nobody initiated.

Root cause was confirmed via session-transcript forensics: the payload was an `attachment` of `type:"file"` (`filename: ~/.doppler/.doppler.yaml`) tied to the skill-load user turn — **not** any hook. Every configured hook (project/global/plugin) was verified clean and reproduced only benign output; the quoted path was the sole `@`-anchored real-file mention in the repo.

## Changes

- **preflight/SKILL.md** — rephrase the example so the real path sits in a plain code-span with the `@` **detached** (meaning preserved; nothing resolves), plus a blockquote warning against the pattern.
- **`plugins/soleur/scripts/lint-at-mention-secret-paths.sh`** — repo guard that fails on any `@`-mention resolving to a home/absolute real path (`@~/`, `@$HOME`, `@/home|Users|root|etc|…/`, or `@`+a path with `.doppler`/`.ssh`/`.aws`/`.netrc`/`.env`/`credentials`) in a skill/agent/command markdown body. Next.js `@/` import aliases (`@/server`, `@/lib`) and package scopes (`@types/…`) are intentionally **not** flagged — they resolve to nonexistent absolute paths.
- **`plugins/soleur/test/at-mention-secret-path-guard.test.ts`** — auto-discovered by `bun test plugins/soleur/`; regression against the live repo + positive/negative fixtures. Dangerous strings are built by concatenation so no literal `@`-adjacent real path exists in the test source.
- **security learning** documenting the footgun and the forensic method.

## Changelog

- Fixed: preflight skill no longer causes Claude Code to auto-attach the operator's real `~/.doppler/.doppler.yaml` (and other local secret files) into model context when the skill body loads. Added a CI guard + test to prevent regression across all skill/agent/command bodies.

## User-Brand Impact

- **Artifact:** the operator's local secret files (Doppler token; by extension any `@`-referenced home/absolute path) read into model context and persisted in session transcripts.
- **Vector:** a skill/agent/command body (or any user-turn content) containing a literal `@` before a real path → Claude Code `@file` auto-attach.
- **Brand-survival threshold:** single-user incident (operator secret exposure).

## Observability

```yaml
discoverability_test:
  command: bash plugins/soleur/scripts/lint-at-mention-secret-paths.sh
  expected_output: "OK: no dangerous @-real-path mentions"
  # Unauthenticated, local, no ssh / no gh / no doppler / no credentialed CLI:
  # the guard scans tracked markdown and exits 0 clean, non-zero on a violation.
```

## Notes

- Delivered as a **controlled, hand-built PR** (not autonomous one-shot) on purpose: quoting the vulnerable `@`-path in skill args re-triggers the auto-attach, so every delivered string here is kept defused.
- Separate operator action (out of scope for this PR): rotate the exposed credentials — verify the Doppler token, and the Discord/Hetzner tokens found in plaintext inside `.claude/settings.local.json` permission-allow rules.
- Independent of PR #6831 (action-required SLA contract); does not touch that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
