### PR TITLE
fix(security): correct credential permissions.deny to effective ~/ syntax (follow-up to #6862)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,16 +10,16 @@
       "Bash(gh pr merge:*)"
     ],
     "deny": [
-      "Read(**/.aws/**)",
-      "Read(**/.config/gcloud/**)",
-      "Read(**/.docker/config.json)",
-      "Read(**/.doppler/**)",
       "Read(**/.env)",
       "Read(**/.env.*)",
-      "Read(**/.git-credentials)",
-      "Read(**/.netrc)",
-      "Read(**/.ssh/**)",
-      "Read(**/lib/stripe.ts)"
+      "Read(**/lib/stripe.ts)",
+      "Read(~/.aws/**)",
+      "Read(~/.config/gcloud/**)",
+      "Read(~/.docker/config.json)",
+      "Read(~/.doppler/**)",
+      "Read(~/.git-credentials)",
+      "Read(~/.netrc)",
+      "Read(~/.ssh/**)"
     ]
   },
   "env": {


### PR DESCRIPTION
## Summary

Corrects the credential `permissions.deny` rules added in #6862, which used `Read(**/.doppler/**)`-style globs. Per the Claude Code permissions docs (and confirmed empirically — a pre-existing `Read(**/.env)` did not block reading an absolute `/tmp/x/.env`), `**/`-anchored globs match only the project/cwd tree, so those rules never matched the real credential files in `$HOME`. Switched the 7 home-credential entries to the effective `~/` home-scope form.

## Changelog

- `.claude/settings.json` — `Read(**/.doppler/**)` → `Read(~/.doppler/**)` and the same for `.ssh`, `.aws`, `.config/gcloud`, `.docker/config.json`, `.netrc`, `.git-credentials`. Project-relative entries (`**/.env`, `**/.env.*`, `**/lib/stripe.ts`) unchanged. `allow[]` untouched → passes settings-integrity.

## Scope / honesty note

`~/` denies **definitively** block the Read tool on these paths (per docs) and are best-effort for `@`-mentions in prompts. The original incident's exact vector — auto-attach from a `@`-mention in **tool/skill output** — is officially undocumented and remains unverified even with correct syntax. The reliable control is the required-CI guard from #6862 (`test-no-at-mention-credfile-footgun.sh`), which prevents the footgun token from entering agent-loaded content at all. This change is strictly-better defense-in-depth for the Read-tool path.

## Test plan

- [x] `~/` = home, `//` = absolute-root syntax verified against code.claude.com/docs permissions.md.
- [x] Diff modifies only `permissions.deny`; `allow[]` byte-identical; valid JSON.

Follow-up to #6862.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
