### PR TITLE
feat(pwa): offline fallback + update/install UX — Phase 2 (ADR-137, handwritten SW)

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -20,6 +20,7 @@ import { useNavResume } from "@/hooks/use-nav-resume";
 import { MembershipRevokedScreen } from "@/components/dashboard/membership-revoked-screen";
 import { NoApiKeyBanner } from "@/components/dashboard/no-api-key-banner";
 import { PendingInviteBannerRecovery } from "@/components/dashboard/pending-invite-banner-recovery";
+import { PwaControls } from "@/components/pwa/pwa-controls";
 import { NAV_ITEMS, ADMIN_NAV_ITEMS } from "@/components/command-palette/nav-items";
 import { InboxNavBadge } from "@/components/dashboard/inbox-nav-badge";
 import { ConversationsNavBadge } from "@/components/dashboard/conversations-nav-badge";
@@ -669,6 +670,10 @@ export default function DashboardLayout({
       {/* AC-FLOW2: terminal overlay rendered when ws.close(4012) fires. Mount
           once at the dashboard root so it survives across route changes. */}
       <MembershipRevokedScreen />
+
+      {/* PWA progressive-enhancement chrome: update pill / install button / iOS
+          A2HS card. Renders null when standalone or when nothing is offerable. */}
+      <PwaControls />
     </div>
     {/* Command layer (feat-web-app-shortcuts) — portal-rendered (Radix), so
         placement inside the provider is positional only. Both no-op when the

--- a/apps/web-platform/app/sw-register.tsx
+++ b/apps/web-platform/app/sw-register.tsx
@@ -2,10 +2,25 @@
 
 import { useEffect } from "react";
 import { subscribeToPush } from "@/lib/push-subscription";
+import {
+  hasSwResetFlag,
+  unregisterAllAndClearCaches,
+  cleanResetUrl,
+} from "@/lib/pwa/sw-reset";
 
 export function SwRegister() {
   useEffect(() => {
     if ("serviceWorker" in navigator) {
+      // Kill switch (ADR-137 brand-survival recovery): if a bad worker bricks the
+      // installed app, `?sw-reset` on any URL wipes all workers + caches and
+      // reloads clean. Runs BEFORE (re)registration so a broken worker is torn
+      // down rather than re-registered.
+      if (hasSwResetFlag()) {
+        unregisterAllAndClearCaches().finally(() => {
+          window.location.replace(cleanResetUrl());
+        });
+        return;
+      }
       navigator.serviceWorker
         .register("/sw.js", { scope: "/", updateViaCache: "none" })
         .then((registration) => {

--- a/apps/web-platform/components/pwa/pwa-controls.tsx
+++ b/apps/web-platform/components/pwa/pwa-controls.tsx
@@ -43,6 +43,7 @@ export function PwaControls() {
       if (!dismissed) setShowIosCard(true);
     }
 
+    let cancelled = false;
     const cleanups: Array<() => void> = [];
 
     // Update lifecycle: watch for a waiting worker + reload once when it takes
@@ -51,7 +52,12 @@ export function PwaControls() {
       cleanups.push(reloadOnControllerChange());
       navigator.serviceWorker.ready
         .then((registration) => {
-          cleanups.push(watchForUpdate(registration, (worker) => setWaiting(worker)));
+          // If the effect already cleaned up before `ready` resolved, do not
+          // register a listener whose unsubscribe would be orphaned — tear it
+          // down immediately instead.
+          const unsub = watchForUpdate(registration, (worker) => setWaiting(worker));
+          if (cancelled) unsub();
+          else cleanups.push(unsub);
         })
         .catch(() => {
           // Non-fatal: no SW → no update affordance.
@@ -66,15 +72,16 @@ export function PwaControls() {
       ),
     );
 
-    return () => cleanups.forEach((fn) => fn());
+    return () => {
+      cancelled = true;
+      cleanups.forEach((fn) => fn());
+    };
   }, []);
 
   if (standalone) return null;
 
   const showUpdate = waiting !== null && !updateDismissed;
   const showInstall = installPrompt !== null;
-
-  if (!showUpdate && !showInstall && !showIosCard) return null;
 
   async function handleInstall() {
     if (!installPrompt) return;
@@ -97,14 +104,17 @@ export function PwaControls() {
   }
 
   return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-40 flex flex-col items-center gap-2 px-4">
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed inset-x-0 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-40 flex flex-col items-center gap-2 px-4"
+    >
       {showUpdate && (
         <div className="pointer-events-auto flex items-center gap-3 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2 px-4 py-2 shadow-lg">
           <span className="text-sm text-soleur-text-primary">Update available</span>
           <button
             type="button"
             onClick={handleReload}
-            className="min-h-8 rounded-md bg-soleur-accent-gold-fill px-3 py-1 text-sm font-medium text-soleur-text-on-accent hover:opacity-90"
+            className="min-h-11 rounded-md bg-soleur-accent-gold-fill px-3 py-1 text-sm font-medium text-soleur-text-on-accent hover:opacity-90"
           >
             Reload
           </button>
@@ -112,7 +122,7 @@ export function PwaControls() {
             type="button"
             aria-label="Dismiss update notice"
             onClick={() => setUpdateDismissed(true)}
-            className="flex min-h-8 min-w-8 items-center justify-center rounded-md text-soleur-text-muted hover:text-soleur-text-primary"
+            className="flex min-h-11 min-w-11 items-center justify-center rounded-md text-soleur-text-muted hover:text-soleur-text-primary"
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M18 6 6 18M6 6l12 12" />
@@ -144,7 +154,7 @@ export function PwaControls() {
             type="button"
             aria-label="Dismiss install guidance"
             onClick={dismissIosCard}
-            className="flex min-h-8 min-w-8 shrink-0 items-center justify-center rounded-md text-soleur-text-muted hover:text-soleur-text-primary"
+            className="flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-md text-soleur-text-muted hover:text-soleur-text-primary"
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M18 6 6 18M6 6l12 12" />

--- a/apps/web-platform/components/pwa/pwa-controls.tsx
+++ b/apps/web-platform/components/pwa/pwa-controls.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  watchForUpdate,
+  postSkipWaiting,
+  reloadOnControllerChange,
+} from "@/lib/pwa/sw-update";
+import {
+  isStandalone,
+  isIosSafari,
+  watchInstallPrompt,
+  type BeforeInstallPromptEvent,
+} from "@/lib/pwa/install";
+
+const IOS_CARD_DISMISSED_KEY = "soleur:pwa-ios-card-dismissed";
+
+/**
+ * Progressive-enhancement PWA chrome mounted once in the dashboard layout:
+ *   - an "Update available" pill when a new service worker is waiting,
+ *   - an "Install app" button when the browser offered beforeinstallprompt,
+ *   - an iOS "Add to Home Screen" guidance card (iOS Safari only).
+ *
+ * Renders `null` when already running standalone (installed), and each
+ * affordance is independently dismissible. Bottom-anchored and safe-area-aware
+ * so it clears the home indicator; z-40 keeps it below modals (z-50).
+ */
+export function PwaControls() {
+  const [standalone, setStandalone] = useState(true); // assume standalone → render nothing until proven otherwise (avoids a flash)
+  const [waiting, setWaiting] = useState<ServiceWorker | null>(null);
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [showIosCard, setShowIosCard] = useState(false);
+  const [updateDismissed, setUpdateDismissed] = useState(false);
+
+  useEffect(() => {
+    if (isStandalone()) return;
+    setStandalone(false);
+
+    // iOS Safari cannot use beforeinstallprompt — offer the Share→A2HS card
+    // once per session (until dismissed).
+    if (isIosSafari()) {
+      const dismissed = sessionStorage.getItem(IOS_CARD_DISMISSED_KEY) === "1";
+      if (!dismissed) setShowIosCard(true);
+    }
+
+    const cleanups: Array<() => void> = [];
+
+    // Update lifecycle: watch for a waiting worker + reload once when it takes
+    // control after the user accepts.
+    if ("serviceWorker" in navigator) {
+      cleanups.push(reloadOnControllerChange());
+      navigator.serviceWorker.ready
+        .then((registration) => {
+          cleanups.push(watchForUpdate(registration, (worker) => setWaiting(worker)));
+        })
+        .catch(() => {
+          // Non-fatal: no SW → no update affordance.
+        });
+    }
+
+    // Install lifecycle (Chromium): capture the deferred prompt, hide on install.
+    cleanups.push(
+      watchInstallPrompt(
+        (event) => setInstallPrompt(event),
+        () => setInstallPrompt(null),
+      ),
+    );
+
+    return () => cleanups.forEach((fn) => fn());
+  }, []);
+
+  if (standalone) return null;
+
+  const showUpdate = waiting !== null && !updateDismissed;
+  const showInstall = installPrompt !== null;
+
+  if (!showUpdate && !showInstall && !showIosCard) return null;
+
+  async function handleInstall() {
+    if (!installPrompt) return;
+    await installPrompt.prompt();
+    // Whatever the outcome, the prompt is single-use — clear it.
+    setInstallPrompt(null);
+  }
+
+  function handleReload() {
+    if (waiting) postSkipWaiting(waiting);
+  }
+
+  function dismissIosCard() {
+    setShowIosCard(false);
+    try {
+      sessionStorage.setItem(IOS_CARD_DISMISSED_KEY, "1");
+    } catch {
+      // sessionStorage can throw in private mode — dismissal just won't persist.
+    }
+  }
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-40 flex flex-col items-center gap-2 px-4">
+      {showUpdate && (
+        <div className="pointer-events-auto flex items-center gap-3 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-2 px-4 py-2 shadow-lg">
+          <span className="text-sm text-soleur-text-primary">Update available</span>
+          <button
+            type="button"
+            onClick={handleReload}
+            className="min-h-8 rounded-md bg-soleur-accent-gold-fill px-3 py-1 text-sm font-medium text-soleur-text-on-accent hover:opacity-90"
+          >
+            Reload
+          </button>
+          <button
+            type="button"
+            aria-label="Dismiss update notice"
+            onClick={() => setUpdateDismissed(true)}
+            className="flex min-h-8 min-w-8 items-center justify-center rounded-md text-soleur-text-muted hover:text-soleur-text-primary"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {showInstall && (
+        <button
+          type="button"
+          onClick={handleInstall}
+          className="pointer-events-auto flex min-h-11 items-center gap-2 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-2 text-sm text-soleur-text-primary shadow-lg hover:bg-soleur-bg-surface-2"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M12 3v12M7 10l5 5 5-5M5 21h14" />
+          </svg>
+          Install app
+        </button>
+      )}
+
+      {showIosCard && (
+        <div className="pointer-events-auto flex max-w-sm items-start gap-3 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3 shadow-lg">
+          <p className="text-sm text-soleur-text-secondary">
+            <span className="font-medium text-soleur-text-primary">Install Soleur:</span> tap the
+            Share icon, then <span className="font-medium text-soleur-text-primary">Add to Home Screen</span>.
+          </p>
+          <button
+            type="button"
+            aria-label="Dismiss install guidance"
+            onClick={dismissIosCard}
+            className="flex min-h-8 min-w-8 shrink-0 items-center justify-center rounded-md text-soleur-text-muted hover:text-soleur-text-primary"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-platform/lib/pwa/install.ts
+++ b/apps/web-platform/lib/pwa/install.ts
@@ -38,7 +38,16 @@ export function isIos(): boolean {
 export function isIosSafari(): boolean {
   if (!isIos()) return false;
   const ua = window.navigator.userAgent;
-  return /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|GSA/.test(ua);
+  // Real iOS Safari UAs carry a `Version/<n>` token. iOS in-app WKWebViews
+  // (Facebook FBAN/FBAV, Instagram, LinkedInApp, Line, TikTok, Snapchat, …) put
+  // "Safari" in the UA but OMIT `Version/` and have no Share→Add-to-Home-Screen
+  // affordance — showing them the guidance card would be a dead end. Require the
+  // positive `Version/` marker AND exclude the dedicated third-party iOS browsers.
+  return (
+    /Version\/\d/.test(ua) &&
+    /Safari/.test(ua) &&
+    !/CriOS|FxiOS|EdgiOS|GSA/.test(ua)
+  );
 }
 
 /**

--- a/apps/web-platform/lib/pwa/install.ts
+++ b/apps/web-platform/lib/pwa/install.ts
@@ -1,0 +1,70 @@
+// PWA install-affordance helpers: standalone detection, iOS detection, and
+// beforeinstallprompt capture. All are browser-only (guard `typeof window`).
+
+/** The (non-standard, Chromium-only) beforeinstallprompt event shape. */
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  prompt: () => Promise<void>;
+  readonly userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+/** True when the app is running as an installed standalone PWA (any platform). */
+export function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const displayModeStandalone =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(display-mode: standalone)").matches;
+  // iOS Safari exposes navigator.standalone instead of the display-mode query.
+  const iosStandalone =
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true;
+  return displayModeStandalone || iosStandalone;
+}
+
+/** True on iOS/iPadOS (including iPadOS 13+ which masquerades as macOS). */
+export function isIos(): boolean {
+  if (typeof window === "undefined") return false;
+  const ua = window.navigator.userAgent;
+  const iosDevice = /iPad|iPhone|iPod/.test(ua);
+  const iPadOs = ua.includes("Macintosh") && "ontouchend" in window;
+  return iosDevice || iPadOs;
+}
+
+/**
+ * True on iOS Safari specifically — the only iOS browser that can install a
+ * PWA via the Share → Add to Home Screen flow. In-app browsers and iOS
+ * Chrome/Firefox/Edge (CriOS/FxiOS/EdgiOS) cannot, so we do NOT show them the
+ * guidance card.
+ */
+export function isIosSafari(): boolean {
+  if (!isIos()) return false;
+  const ua = window.navigator.userAgent;
+  return /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|GSA/.test(ua);
+}
+
+/**
+ * Capture the deferred `beforeinstallprompt` event (Chromium) and observe
+ * `appinstalled`. `onCapture` receives the prompt event (already
+ * `preventDefault()`-ed so the browser's mini-infobar is suppressed and we own
+ * the affordance); `onInstalled` fires once the app is installed.
+ * Returns an unsubscribe function.
+ */
+export function watchInstallPrompt(
+  onCapture: (event: BeforeInstallPromptEvent) => void,
+  onInstalled: () => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const onBeforeInstallPrompt = (event: Event) => {
+    event.preventDefault();
+    onCapture(event as BeforeInstallPromptEvent);
+  };
+  const onAppInstalled = () => onInstalled();
+
+  window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+  window.addEventListener("appinstalled", onAppInstalled);
+
+  return () => {
+    window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt);
+    window.removeEventListener("appinstalled", onAppInstalled);
+  };
+}

--- a/apps/web-platform/lib/pwa/sw-reset.ts
+++ b/apps/web-platform/lib/pwa/sw-reset.ts
@@ -1,0 +1,36 @@
+// PWA kill switch — the brand-survival recovery mitigation for the
+// single-user-incident threshold (ADR-137).
+//
+// If a bad service worker ever bricks the installed app, navigating to ANY URL
+// with the `?sw-reset` query flag unregisters every service worker and clears
+// all Cache Storage, then reloads to the clean URL. Because HTML is served
+// network-only (fresh per-request), the document + this recovery code still
+// load even when the worker's fetch/cache logic is broken — so the escape hatch
+// is reachable. Wired into <SwRegister/> (app/layout.tsx) so it works on every
+// route, including /login.
+
+export const SW_RESET_PARAM = "sw-reset";
+
+/** True when the current URL carries the `?sw-reset` recovery flag. */
+export function hasSwResetFlag(search: string = window.location.search): boolean {
+  return new URLSearchParams(search).has(SW_RESET_PARAM);
+}
+
+/** Unregister every service worker and delete every Cache Storage bucket. */
+export async function unregisterAllAndClearCaches(): Promise<void> {
+  if ("serviceWorker" in navigator) {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((registration) => registration.unregister()));
+  }
+  if (typeof caches !== "undefined") {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key)));
+  }
+}
+
+/** The current URL with the `?sw-reset` flag stripped (path + remaining query + hash). */
+export function cleanResetUrl(href: string = window.location.href): string {
+  const url = new URL(href);
+  url.searchParams.delete(SW_RESET_PARAM);
+  return url.pathname + url.search + url.hash;
+}

--- a/apps/web-platform/lib/pwa/sw-update.ts
+++ b/apps/web-platform/lib/pwa/sw-update.ts
@@ -1,0 +1,67 @@
+// Service-worker update-lifecycle helpers.
+//
+// The service worker (public/sw.js) no longer calls skipWaiting() on install —
+// a new version installs and then WAITS. These helpers detect the waiting
+// worker, tell it to activate when the user accepts, and reload the page once
+// (guarded) when the new worker takes control.
+
+export type WaitingListener = (worker: ServiceWorker) => void;
+
+/**
+ * Watch a registration for a waiting worker (a new SW version that installed
+ * but has not yet activated because it is waiting for the current one to be
+ * released). Fires `onUpdate` with the waiting worker:
+ *   - immediately, if one is already waiting when this is called, and
+ *   - on `updatefound` → the new worker reaching `installed` while a controller
+ *     is already active (the "there was already a worker, so this is an update"
+ *     signal — a first install has no controller yet and must NOT prompt).
+ * Returns an unsubscribe function.
+ */
+export function watchForUpdate(
+  registration: ServiceWorkerRegistration,
+  onUpdate: WaitingListener,
+): () => void {
+  if (registration.waiting && navigator.serviceWorker.controller) {
+    onUpdate(registration.waiting);
+  }
+
+  const onUpdateFound = () => {
+    const installing = registration.installing;
+    if (!installing) return;
+    installing.addEventListener("statechange", () => {
+      if (installing.state === "installed" && navigator.serviceWorker.controller) {
+        // registration.waiting is the newly-installed worker at this point.
+        onUpdate(registration.waiting ?? installing);
+      }
+    });
+  };
+
+  registration.addEventListener("updatefound", onUpdateFound);
+  return () => registration.removeEventListener("updatefound", onUpdateFound);
+}
+
+/** Ask the waiting worker to activate (it calls self.skipWaiting()). */
+export function postSkipWaiting(worker: ServiceWorker): void {
+  worker.postMessage({ type: "SKIP_WAITING" });
+}
+
+/**
+ * Reload the page exactly once when the active service worker changes
+ * (i.e. the new worker took control after skipWaiting). The reload is guarded
+ * so a browser that fires `controllerchange` more than once cannot loop.
+ * `container` and `reload` are injectable for testing.
+ * Returns an unsubscribe function.
+ */
+export function reloadOnControllerChange(
+  container: ServiceWorkerContainer = navigator.serviceWorker,
+  reload: () => void = () => window.location.reload(),
+): () => void {
+  let reloaded = false;
+  const handler = () => {
+    if (reloaded) return;
+    reloaded = true;
+    reload();
+  };
+  container.addEventListener("controllerchange", handler);
+  return () => container.removeEventListener("controllerchange", handler);
+}

--- a/apps/web-platform/lib/pwa/sw-update.ts
+++ b/apps/web-platform/lib/pwa/sw-update.ts
@@ -25,19 +25,31 @@ export function watchForUpdate(
     onUpdate(registration.waiting);
   }
 
+  // Track the installing worker + its statechange handler so the unsubscribe can
+  // detach BOTH listeners (the returned cleanup must honor "detaches everything").
+  let installingWorker: ServiceWorker | null = null;
+  let onStateChange: (() => void) | null = null;
+
   const onUpdateFound = () => {
     const installing = registration.installing;
     if (!installing) return;
-    installing.addEventListener("statechange", () => {
+    installingWorker = installing;
+    onStateChange = () => {
       if (installing.state === "installed" && navigator.serviceWorker.controller) {
         // registration.waiting is the newly-installed worker at this point.
         onUpdate(registration.waiting ?? installing);
       }
-    });
+    };
+    installing.addEventListener("statechange", onStateChange);
   };
 
   registration.addEventListener("updatefound", onUpdateFound);
-  return () => registration.removeEventListener("updatefound", onUpdateFound);
+  return () => {
+    registration.removeEventListener("updatefound", onUpdateFound);
+    if (installingWorker && onStateChange) {
+      installingWorker.removeEventListener("statechange", onStateChange);
+    }
+  };
 }
 
 /** Ask the waiting worker to activate (it calls self.skipWaiting()). */
@@ -57,10 +69,16 @@ export function reloadOnControllerChange(
   reload: () => void = () => window.location.reload(),
 ): () => void {
   let reloaded = false;
+  // On a FIRST, uncontrolled visit the initial activate → clients.claim() fires
+  // a `controllerchange` on this page. That is NOT an update taking over — it's
+  // the initial claim — and must be consumed WITHOUT reloading, or every new
+  // visitor gets a spurious full-page reload on first load. Only reload when a
+  // controller already existed when we started watching (a genuine update).
+  const hadController = Boolean(container.controller);
   const handler = () => {
     if (reloaded) return;
     reloaded = true;
-    reload();
+    if (hadController) reload();
   };
   container.addEventListener("controllerchange", handler);
   return () => container.removeEventListener("controllerchange", handler);

--- a/apps/web-platform/lib/routes.ts
+++ b/apps/web-platform/lib/routes.ts
@@ -60,6 +60,13 @@ export const PUBLIC_PATHS = [
   // NARROW exact path — do NOT broaden to /api.
   "/api/waitlist",
   "/invite",
+  // /offline.html: static, script-free PWA offline fallback (public/offline.html)
+  // served by the service worker's navigate branch. The middleware matcher does
+  // NOT exclude .html (only sw.js + image extensions), so without PUBLIC_PATHS
+  // membership Supabase middleware 307→/login and the SW precache would capture
+  // the redirect body instead of the real offline page. Same class as
+  // /manifest.webmanifest (#4587). NARROW exact path.
+  "/offline.html",
 ];
 
 /** Auth required, but T&C check skipped (user must reach these to accept terms) */

--- a/apps/web-platform/public/offline.html
+++ b/apps/web-platform/public/offline.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<!--
+  Static, script-free offline fallback served by the service worker's navigate
+  branch (public/sw.js) when the network is unavailable.
+
+  INVARIANTS (do not regress):
+  - NO <script> of any kind. The app's CSP is `script-src 'strict-dynamic'`
+    (lib/csp.ts) — a non-nonce inline script is blocked, and this page is served
+    from the SW cache so it can never carry a per-request nonce. Keep it inert.
+  - Inline <style> only — `style-src 'self' 'unsafe-inline'` allows it.
+  - Must be in PUBLIC_PATHS (lib/routes.ts) so precaching this route fetches the
+    real HTML, not a 307→/login redirect body.
+  - Theme-aware via prefers-color-scheme so it matches the app in both modes
+    without reading localStorage (no script). Colors mirror the brand tokens in
+    app/globals.css (--soleur-bg-base #0a0a0a, gold #c9a962).
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Offline — Soleur</title>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --surface: #f5f5f4;
+        --text: #1c1917;
+        --muted: #78716c;
+        --border: #e7e5e4;
+        --gold: #a07d2c;
+        --on-gold: #ffffff;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0a0a0a;
+          --surface: #141414;
+          --text: #ededed;
+          --muted: #a3a3a3;
+          --border: #2a2a2a;
+          --gold: #c9a962;
+          --on-gold: #0a0a0a;
+        }
+      }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100dvh;
+        padding: calc(1.5rem + env(safe-area-inset-top)) 1.5rem calc(1.5rem + env(safe-area-inset-bottom));
+        background-color: var(--bg);
+        color: var(--text);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      .card {
+        width: 100%;
+        max-width: 24rem;
+        text-align: center;
+      }
+      .glyph {
+        width: 3rem;
+        height: 3rem;
+        margin: 0 auto 1.25rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 9999px;
+        background-color: var(--surface);
+        border: 1px solid var(--border);
+      }
+      .glyph svg { width: 1.5rem; height: 1.5rem; stroke: var(--muted); }
+      h1 { margin: 0 0 0.5rem; font-size: 1.25rem; font-weight: 600; }
+      p { margin: 0 0 1.5rem; color: var(--muted); font-size: 0.95rem; }
+      a.retry {
+        display: inline-block;
+        padding: 0.625rem 1.25rem;
+        min-height: 44px;
+        line-height: 1.5;
+        border-radius: 0.5rem;
+        background-color: var(--gold);
+        color: var(--on-gold);
+        font-size: 0.95rem;
+        font-weight: 500;
+        text-decoration: none;
+      }
+      a.retry:hover { opacity: 0.9; }
+      a.retry:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+    </style>
+  </head>
+  <body>
+    <main class="card">
+      <div class="glyph" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 1l22 22" />
+          <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+          <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+          <path d="M10.71 5.05A16 16 0 0 1 22.58 9" />
+          <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+          <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+          <line x1="12" y1="20" x2="12.01" y2="20" />
+        </svg>
+      </div>
+      <h1>You're offline</h1>
+      <p>Soleur can't reach the network right now. Check your connection and try again — your work is safe.</p>
+      <a class="retry" href="/dashboard">Try again</a>
+    </main>
+  </body>
+</html>

--- a/apps/web-platform/public/sw.js
+++ b/apps/web-platform/public/sw.js
@@ -1,25 +1,34 @@
 // Bumping the suffix triggers the activate handler's cache cleanup, which
 // purges _next/static/** chunks cached against an old project ref. Keep
 // push-notification subscriptions intact (registration is unchanged).
-const CACHE_NAME = "soleur-app-shell-v9";
+const CACHE_NAME = "soleur-app-shell-v10";
 
 // Static shell assets cached on install (non-hashed assets only).
 // _next/static/** are cached on fetch via cache-first strategy.
+// /offline.html is the static, script-free navigate-fallback (see fetch below);
+// it MUST be in PUBLIC_PATHS (lib/routes.ts) so this precache captures the real
+// page, not a 307→/login redirect body.
 const SHELL_ASSETS = [
+  "/offline.html",
   "/icons/icon-192x192.png",
   "/icons/icon-512x512.png",
   "/icons/apple-touch-icon.png",
   "/favicon.ico",
 ];
 
-// Install: pre-cache shell assets, then activate immediately
+// Install: pre-cache shell assets. Do NOT skipWaiting() — a new worker waits
+// until the user accepts the update (the "Update available" affordance posts
+// SKIP_WAITING; see the message listener below). Silent skipWaiting can swap
+// assets mid-session under a controlled page.
 self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches
-      .open(CACHE_NAME)
-      .then((cache) => cache.addAll(SHELL_ASSETS))
-      .then(() => self.skipWaiting())
-  );
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL_ASSETS)));
+});
+
+// The client posts this when the user accepts an "Update available" prompt.
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "SKIP_WAITING") {
+    self.skipWaiting();
+  }
 });
 
 // Activate: clean old caches, claim clients immediately
@@ -67,9 +76,14 @@ self.addEventListener("fetch", (event) => {
           fetch(event.request).then((response) => {
             if (response.ok) {
               const clone = response.clone();
-              caches.open(CACHE_NAME).then((cache) =>
-                cache.put(event.request, clone)
-              );
+              // #3002: a failed cache.put (QuotaExceededError on a full
+              // storage bucket) must not reject the fetch handler — the
+              // response is already in hand. Swallow the write error; the
+              // asset just isn't cached for next time.
+              caches
+                .open(CACHE_NAME)
+                .then((cache) => cache.put(event.request, clone))
+                .catch(() => {});
             }
             return response;
           })
@@ -78,8 +92,36 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
-  // Network-only for everything else (HTML, manifest, etc.)
-  // HTML must come from network to get fresh CSP nonce
+  // Navigations (HTML documents): network-only for a fresh CSP nonce, but fall
+  // back to the static offline shell when the network is unavailable. `mode ===
+  // "navigate"` is true only for top-level document requests, so this never
+  // touches API/asset fetches. We NEVER branch on `response.ok` — a served 4xx/
+  // 5xx from the origin is the app's own error page (with a fresh nonce), not an
+  // offline condition; only a rejected fetch() (no network) yields the fallback.
+  // This catch-only shape is the brand-survival mitigation: a bad worker can
+  // never mask a live origin response with the cached shell.
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match("/offline.html"))
+    );
+    return;
+  }
+
+  // Network-only for everything else (manifest, etc.)
+  // HTML navigations are handled above; assets are cached-first above.
+});
+
+// ---------------------------------------------------------------------------
+// #3002: global error + unhandledrejection handlers. Without these, an
+// exception in an event handler is swallowed silently by the SW runtime;
+// surfacing it to the console gives a debugging breadcrumb for cache/quota
+// failures in the field. Intentionally console-only — the SW has no Sentry.
+// ---------------------------------------------------------------------------
+self.addEventListener("error", (event) => {
+  console.error("[sw] uncaught error:", event.message || event.error);
+});
+self.addEventListener("unhandledrejection", (event) => {
+  console.error("[sw] unhandled rejection:", event.reason);
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web-platform/test/components/pwa/pwa-controls.test.tsx
+++ b/apps/web-platform/test/components/pwa/pwa-controls.test.tsx
@@ -60,9 +60,13 @@ describe("PwaControls", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  test("renders nothing when not standalone and nothing is offerable", () => {
-    const { container } = render(<PwaControls />);
-    expect(container).toBeEmptyDOMElement();
+  test("shows no affordances when not standalone and nothing is offerable", () => {
+    // The aria-live wrapper stays mounted (a stable live region), but it holds
+    // no interactive affordances until an update/install becomes available.
+    render(<PwaControls />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByText("Update available")).toBeNull();
+    expect(screen.queryByText(/install app/i)).toBeNull();
   });
 
   test("shows the update pill when a worker is waiting; Reload posts SKIP_WAITING", async () => {
@@ -116,8 +120,9 @@ describe("PwaControls", () => {
   test("does NOT show the iOS card if already dismissed this session", async () => {
     h.isIosSafari = true;
     sessionStorage.setItem("soleur:pwa-ios-card-dismissed", "1");
-    const { container } = render(<PwaControls />);
-    // Nothing else offerable → empty.
-    await waitFor(() => expect(container).toBeEmptyDOMElement());
+    render(<PwaControls />);
+    // Nothing offerable → no card, no buttons (the aria-live wrapper stays mounted).
+    await waitFor(() => expect(screen.queryByText(/Add to Home Screen/i)).toBeNull());
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/apps/web-platform/test/components/pwa/pwa-controls.test.tsx
+++ b/apps/web-platform/test/components/pwa/pwa-controls.test.tsx
@@ -1,0 +1,123 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act, cleanup } from "@testing-library/react";
+
+// Hoisted holders let the mocks stash the callbacks the component registers so
+// the test can drive them (simulate a waiting worker / a captured prompt).
+const h = vi.hoisted(() => ({
+  isStandalone: false,
+  isIosSafari: false,
+  updateCb: null as ((w: unknown) => void) | null,
+  onCapture: null as ((e: unknown) => void) | null,
+  onInstalled: null as (() => void) | null,
+  postSkipWaiting: vi.fn(),
+}));
+
+vi.mock("@/lib/pwa/sw-update", () => ({
+  watchForUpdate: (_reg: unknown, cb: (w: unknown) => void) => {
+    h.updateCb = cb;
+    return () => {};
+  },
+  postSkipWaiting: h.postSkipWaiting,
+  reloadOnControllerChange: () => () => {},
+}));
+
+vi.mock("@/lib/pwa/install", () => ({
+  isStandalone: () => h.isStandalone,
+  isIosSafari: () => h.isIosSafari,
+  watchInstallPrompt: (onCapture: (e: unknown) => void, onInstalled: () => void) => {
+    h.onCapture = onCapture;
+    h.onInstalled = onInstalled;
+    return () => {};
+  },
+}));
+
+import { PwaControls } from "@/components/pwa/pwa-controls";
+
+beforeEach(() => {
+  h.isStandalone = false;
+  h.isIosSafari = false;
+  h.updateCb = null;
+  h.onCapture = null;
+  h.onInstalled = null;
+  h.postSkipWaiting.mockClear();
+  sessionStorage.clear();
+  Object.defineProperty(navigator, "serviceWorker", {
+    value: { ready: Promise.resolve({}) },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("PwaControls", () => {
+  test("renders null when running standalone", () => {
+    h.isStandalone = true;
+    const { container } = render(<PwaControls />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders nothing when not standalone and nothing is offerable", () => {
+    const { container } = render(<PwaControls />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("shows the update pill when a worker is waiting; Reload posts SKIP_WAITING", async () => {
+    render(<PwaControls />);
+    // Let navigator.serviceWorker.ready resolve so watchForUpdate registers.
+    await waitFor(() => expect(h.updateCb).not.toBeNull());
+
+    const worker = { id: "waiting" };
+    act(() => h.updateCb!(worker));
+
+    const reload = await screen.findByRole("button", { name: "Reload" });
+    expect(screen.getByText("Update available")).toBeTruthy();
+
+    fireEvent.click(reload);
+    expect(h.postSkipWaiting).toHaveBeenCalledWith(worker);
+  });
+
+  test("update pill is dismissible", async () => {
+    render(<PwaControls />);
+    await waitFor(() => expect(h.updateCb).not.toBeNull());
+    act(() => h.updateCb!({ id: "w" }));
+
+    await screen.findByText("Update available");
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss update notice" }));
+    expect(screen.queryByText("Update available")).toBeNull();
+  });
+
+  test("shows the install button when a prompt is captured; click calls prompt()", async () => {
+    render(<PwaControls />);
+    await waitFor(() => expect(h.onCapture).not.toBeNull());
+
+    const prompt = vi.fn().mockResolvedValue(undefined);
+    act(() => h.onCapture!({ prompt }));
+
+    const button = await screen.findByRole("button", { name: /install app/i });
+    fireEvent.click(button);
+    expect(prompt).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows the iOS guidance card on iOS Safari and persists dismissal", async () => {
+    h.isIosSafari = true;
+    render(<PwaControls />);
+
+    expect(await screen.findByText(/Add to Home Screen/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss install guidance" }));
+
+    expect(screen.queryByText(/Add to Home Screen/i)).toBeNull();
+    expect(sessionStorage.getItem("soleur:pwa-ios-card-dismissed")).toBe("1");
+  });
+
+  test("does NOT show the iOS card if already dismissed this session", async () => {
+    h.isIosSafari = true;
+    sessionStorage.setItem("soleur:pwa-ios-card-dismissed", "1");
+    const { container } = render(<PwaControls />);
+    // Nothing else offerable → empty.
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/apps/web-platform/test/middleware.test.ts
+++ b/apps/web-platform/test/middleware.test.ts
@@ -24,6 +24,16 @@ describe("middleware path routing", () => {
       expect(isPublicPath("/robots.txt")).toBe(true);
     });
 
+    test("/offline.html is public (SW navigate-fallback precache; #3002/Phase-2)", () => {
+      // The middleware matcher does not exclude .html, so the static offline
+      // shell must be in PUBLIC_PATHS or the SW would precache a 307→/login
+      // body instead of the real page.
+      expect(isPublicPath("/offline.html")).toBe(true);
+      // Guard the exact-match boundary: a look-alike must NOT be public.
+      expect(isPublicPath("/offline.htmlx")).toBe(false);
+      expect(isPublicPath("/offline")).toBe(false);
+    });
+
     test("/api/inngest is public (HMAC-gated by Inngest SDK, not Supabase)", () => {
       // ADR-030 I4: signature verification at /api/inngest is performed by
       // `inngest/next.serve` (signingKey from INNGEST_SIGNING_KEY).

--- a/apps/web-platform/test/pwa/install.test.tsx
+++ b/apps/web-platform/test/pwa/install.test.tsx
@@ -1,0 +1,115 @@
+// happy-dom environment (matched by the `.test.tsx` include glob) — install.ts
+// is DOM-dependent (window / navigator / matchMedia), so it runs here, not in
+// the node `unit` project.
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  isStandalone,
+  isIos,
+  isIosSafari,
+  watchInstallPrompt,
+} from "@/lib/pwa/install";
+
+const IPHONE_SAFARI =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const IPHONE_CHROME =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0 Mobile/15E148 Safari/604.1";
+const ANDROID_CHROME =
+  "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36";
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: ua,
+    configurable: true,
+  });
+}
+
+let matchMediaSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  matchMediaSpy = vi.fn().mockReturnValue({ matches: false });
+  Object.defineProperty(window, "matchMedia", {
+    value: matchMediaSpy,
+    configurable: true,
+    writable: true,
+  });
+  delete (window.navigator as Navigator & { standalone?: boolean }).standalone;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setUserAgent(ANDROID_CHROME);
+});
+
+describe("isStandalone", () => {
+  test("true when display-mode:standalone matches", () => {
+    matchMediaSpy.mockReturnValue({ matches: true });
+    expect(isStandalone()).toBe(true);
+  });
+
+  test("true when iOS navigator.standalone is set", () => {
+    (window.navigator as Navigator & { standalone?: boolean }).standalone = true;
+    expect(isStandalone()).toBe(true);
+  });
+
+  test("false in a normal browser tab", () => {
+    expect(isStandalone()).toBe(false);
+  });
+});
+
+describe("isIos / isIosSafari", () => {
+  test("iPhone Safari is iOS and iOS Safari", () => {
+    setUserAgent(IPHONE_SAFARI);
+    expect(isIos()).toBe(true);
+    expect(isIosSafari()).toBe(true);
+  });
+
+  test("iPhone Chrome (CriOS) is iOS but NOT iOS Safari", () => {
+    setUserAgent(IPHONE_CHROME);
+    expect(isIos()).toBe(true);
+    expect(isIosSafari()).toBe(false);
+  });
+
+  test("Android Chrome is neither", () => {
+    setUserAgent(ANDROID_CHROME);
+    expect(isIos()).toBe(false);
+    expect(isIosSafari()).toBe(false);
+  });
+});
+
+describe("watchInstallPrompt", () => {
+  test("captures beforeinstallprompt (preventDefault) and fires onCapture", () => {
+    const onCapture = vi.fn();
+    const onInstalled = vi.fn();
+    watchInstallPrompt(onCapture, onInstalled);
+
+    const event = new Event("beforeinstallprompt", { cancelable: true });
+    const preventSpy = vi.spyOn(event, "preventDefault");
+    window.dispatchEvent(event);
+
+    expect(preventSpy).toHaveBeenCalled();
+    expect(onCapture).toHaveBeenCalledWith(event);
+    expect(onInstalled).not.toHaveBeenCalled();
+  });
+
+  test("fires onInstalled on appinstalled", () => {
+    const onCapture = vi.fn();
+    const onInstalled = vi.fn();
+    watchInstallPrompt(onCapture, onInstalled);
+
+    window.dispatchEvent(new Event("appinstalled"));
+    expect(onInstalled).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe detaches both listeners", () => {
+    const onCapture = vi.fn();
+    const onInstalled = vi.fn();
+    const unsub = watchInstallPrompt(onCapture, onInstalled);
+    unsub();
+
+    window.dispatchEvent(new Event("beforeinstallprompt", { cancelable: true }));
+    window.dispatchEvent(new Event("appinstalled"));
+
+    expect(onCapture).not.toHaveBeenCalled();
+    expect(onInstalled).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/pwa/install.test.tsx
+++ b/apps/web-platform/test/pwa/install.test.tsx
@@ -74,6 +74,16 @@ describe("isIos / isIosSafari", () => {
     expect(isIos()).toBe(false);
     expect(isIosSafari()).toBe(false);
   });
+
+  test("iOS in-app webview (Safari token but no Version/) is iOS but NOT iOS Safari (no Share→A2HS)", () => {
+    // WKWebView in-app browsers (LinkedIn, Line, etc.) carry the "Safari" token
+    // but OMIT the `Version/<n>` token that real iOS Safari always includes.
+    const IOS_INAPP_WEBVIEW =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Safari/604.1 LinkedInApp";
+    setUserAgent(IOS_INAPP_WEBVIEW);
+    expect(isIos()).toBe(true);
+    expect(isIosSafari()).toBe(false);
+  });
 });
 
 describe("watchInstallPrompt", () => {

--- a/apps/web-platform/test/pwa/sw-reset.test.tsx
+++ b/apps/web-platform/test/pwa/sw-reset.test.tsx
@@ -1,0 +1,77 @@
+// happy-dom (via .test.tsx include) — sw-reset.ts touches window/navigator/caches.
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  SW_RESET_PARAM,
+  hasSwResetFlag,
+  unregisterAllAndClearCaches,
+  cleanResetUrl,
+} from "@/lib/pwa/sw-reset";
+
+describe("hasSwResetFlag", () => {
+  test("true when ?sw-reset is present", () => {
+    expect(hasSwResetFlag("?sw-reset")).toBe(true);
+    expect(hasSwResetFlag("?foo=1&sw-reset=1")).toBe(true);
+  });
+  test("false when absent", () => {
+    expect(hasSwResetFlag("")).toBe(false);
+    expect(hasSwResetFlag("?foo=1")).toBe(false);
+  });
+});
+
+describe("cleanResetUrl", () => {
+  test("strips the sw-reset param, preserving path + other query + hash", () => {
+    expect(cleanResetUrl("https://app.soleur.ai/dashboard?sw-reset=1")).toBe("/dashboard");
+    expect(cleanResetUrl("https://app.soleur.ai/login?next=/x&sw-reset=1#top")).toBe(
+      "/login?next=%2Fx#top",
+    );
+  });
+  test("no-op when the param is absent", () => {
+    expect(cleanResetUrl("https://app.soleur.ai/dashboard?a=b")).toBe("/dashboard?a=b");
+  });
+});
+
+describe("unregisterAllAndClearCaches", () => {
+  const originalNavigator = globalThis.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: originalNavigator,
+      configurable: true,
+      writable: true,
+    });
+    vi.restoreAllMocks();
+    // @ts-expect-error test cleanup
+    delete globalThis.caches;
+  });
+
+  test("unregisters every worker and deletes every cache", async () => {
+    const unregister = vi.fn().mockResolvedValue(true);
+    Object.defineProperty(globalThis, "navigator", {
+      value: {
+        serviceWorker: {
+          getRegistrations: vi.fn().mockResolvedValue([{ unregister }, { unregister }]),
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    const cacheDelete = vi.fn().mockResolvedValue(true);
+    // @ts-expect-error minimal CacheStorage stub
+    globalThis.caches = {
+      keys: vi.fn().mockResolvedValue(["soleur-app-shell-v10", "old"]),
+      delete: cacheDelete,
+    };
+
+    await unregisterAllAndClearCaches();
+
+    expect(unregister).toHaveBeenCalledTimes(2);
+    expect(cacheDelete).toHaveBeenCalledWith("soleur-app-shell-v10");
+    expect(cacheDelete).toHaveBeenCalledWith("old");
+  });
+});
+
+describe("SW_RESET_PARAM", () => {
+  test("is the stable sw-reset key", () => {
+    expect(SW_RESET_PARAM).toBe("sw-reset");
+  });
+});

--- a/apps/web-platform/test/pwa/sw-source.test.ts
+++ b/apps/web-platform/test/pwa/sw-source.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, test, expect } from "vitest";
+
+// Source-level invariants on public/sw.js. The service worker runs in the
+// browser SW scope (no importable module), so these guard the load-bearing
+// text: cache version, offline precache, no silent skipWaiting, the SKIP_WAITING
+// message listener, the navigate fallback, and the #3002 cache.put guard.
+const SW = readFileSync(resolve(__dirname, "../../public/sw.js"), "utf8");
+
+describe("public/sw.js invariants", () => {
+  test("CACHE_NAME bumped to v10 (purges old-version caches on activate)", () => {
+    expect(SW).toContain('const CACHE_NAME = "soleur-app-shell-v10"');
+  });
+
+  test("/offline.html is precached in SHELL_ASSETS", () => {
+    const shell = SW.match(/const SHELL_ASSETS = \[([\s\S]*?)\]/);
+    expect(shell).not.toBeNull();
+    expect(shell![1]).toContain('"/offline.html"');
+  });
+
+  test("install handler does NOT call skipWaiting (new workers wait)", () => {
+    const install = SW.match(/addEventListener\("install"[\s\S]*?\}\);/);
+    expect(install).not.toBeNull();
+    expect(install![0]).not.toContain("skipWaiting");
+  });
+
+  test("a message listener activates the waiting worker on SKIP_WAITING", () => {
+    expect(SW).toContain('addEventListener("message"');
+    expect(SW).toContain('event.data.type === "SKIP_WAITING"');
+    expect(SW).toContain("self.skipWaiting()");
+  });
+
+  test("activate still claims clients", () => {
+    expect(SW).toContain("self.clients.claim()");
+  });
+
+  test("navigate requests fall back to the offline shell (catch-only, never on response.ok)", () => {
+    expect(SW).toContain('event.request.mode === "navigate"');
+    expect(SW).toContain('fetch(event.request).catch(() => caches.match("/offline.html"))');
+  });
+
+  test("#3002: cache.put is guarded against quota failures", () => {
+    // The cache-first asset branch must swallow a failed cache.put.
+    expect(SW).toMatch(/cache\.put\(event\.request, clone\)\)\s*\.catch\(\(\) => \{\}\)/);
+  });
+
+  test("#3002: global error + unhandledrejection handlers are present", () => {
+    expect(SW).toContain('addEventListener("error"');
+    expect(SW).toContain('addEventListener("unhandledrejection"');
+  });
+
+  test("push + notificationclick handlers are preserved", () => {
+    expect(SW).toContain('addEventListener("push"');
+    expect(SW).toContain('addEventListener("notificationclick"');
+  });
+});

--- a/apps/web-platform/test/pwa/sw-update.test.ts
+++ b/apps/web-platform/test/pwa/sw-update.test.ts
@@ -1,0 +1,159 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  watchForUpdate,
+  postSkipWaiting,
+  reloadOnControllerChange,
+} from "@/lib/pwa/sw-update";
+
+// Minimal EventTarget-shaped mock with a settable state, matching the bits of
+// ServiceWorker / ServiceWorkerRegistration the helpers touch.
+function makeWorker(state = "installed") {
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    state,
+    postMessage: vi.fn(),
+    addEventListener: (type: string, cb: () => void) => {
+      (listeners[type] ??= []).push(cb);
+    },
+    fire: (type: string) => (listeners[type] ?? []).forEach((cb) => cb()),
+    setState(next: string) {
+      this.state = next;
+    },
+  };
+}
+
+function makeRegistration() {
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    waiting: null as ReturnType<typeof makeWorker> | null,
+    installing: null as ReturnType<typeof makeWorker> | null,
+    addEventListener: (type: string, cb: () => void) => {
+      (listeners[type] ??= []).push(cb);
+    },
+    removeEventListener: (type: string, cb: () => void) => {
+      listeners[type] = (listeners[type] ?? []).filter((x) => x !== cb);
+    },
+    fire: (type: string) => (listeners[type] ?? []).forEach((cb) => cb()),
+  };
+}
+
+const originalNavigator = globalThis.navigator;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    value: { serviceWorker: { controller: {} } },
+    configurable: true,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "navigator", {
+    value: originalNavigator,
+    configurable: true,
+    writable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("watchForUpdate", () => {
+  test("fires immediately when a worker is already waiting AND a controller exists", () => {
+    const reg = makeRegistration();
+    const waiting = makeWorker();
+    reg.waiting = waiting as never;
+    const onUpdate = vi.fn();
+
+    watchForUpdate(reg as never, onUpdate);
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith(waiting);
+  });
+
+  test("does NOT fire on a first install (no existing controller)", () => {
+    // First install: the page is not yet controlled.
+    (globalThis.navigator as { serviceWorker: { controller: unknown } }).serviceWorker.controller = null;
+    const reg = makeRegistration();
+    reg.waiting = makeWorker() as never;
+    const onUpdate = vi.fn();
+
+    watchForUpdate(reg as never, onUpdate);
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test("fires on updatefound → installing reaches 'installed' with a controller present", () => {
+    const reg = makeRegistration();
+    const installing = makeWorker("installing");
+    reg.installing = installing as never;
+    const onUpdate = vi.fn();
+
+    watchForUpdate(reg as never, onUpdate);
+    // No waiting worker yet → not called on entry.
+    expect(onUpdate).not.toHaveBeenCalled();
+
+    reg.fire("updatefound");
+    installing.setState("installed");
+    reg.waiting = installing as never;
+    installing.fire("statechange");
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe removes the updatefound listener", () => {
+    const reg = makeRegistration();
+    reg.installing = makeWorker("installing") as never;
+    const onUpdate = vi.fn();
+
+    const unsub = watchForUpdate(reg as never, onUpdate);
+    unsub();
+    reg.fire("updatefound"); // no listener now → no statechange wiring
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("postSkipWaiting", () => {
+  test("posts the SKIP_WAITING message to the worker", () => {
+    const worker = makeWorker();
+    postSkipWaiting(worker as never);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: "SKIP_WAITING" });
+  });
+});
+
+describe("reloadOnControllerChange", () => {
+  function makeContainer() {
+    const listeners: Record<string, Array<() => void>> = {};
+    return {
+      addEventListener: (t: string, cb: () => void) => {
+        (listeners[t] ??= []).push(cb);
+      },
+      removeEventListener: (t: string, cb: () => void) => {
+        listeners[t] = (listeners[t] ?? []).filter((x) => x !== cb);
+      },
+      fire: (t: string) => (listeners[t] ?? []).forEach((cb) => cb()),
+    };
+  }
+
+  test("reloads exactly once even if controllerchange fires multiple times", () => {
+    const container = makeContainer();
+    const reload = vi.fn();
+
+    reloadOnControllerChange(container as never, reload);
+    container.fire("controllerchange");
+    container.fire("controllerchange");
+    container.fire("controllerchange");
+
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test("unsubscribe detaches the handler so no reload fires", () => {
+    const container = makeContainer();
+    const reload = vi.fn();
+
+    const unsub = reloadOnControllerChange(container as never, reload);
+    unsub();
+    container.fire("controllerchange");
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-platform/test/pwa/sw-update.test.ts
+++ b/apps/web-platform/test/pwa/sw-update.test.ts
@@ -15,6 +15,9 @@ function makeWorker(state = "installed") {
     addEventListener: (type: string, cb: () => void) => {
       (listeners[type] ??= []).push(cb);
     },
+    removeEventListener: (type: string, cb: () => void) => {
+      listeners[type] = (listeners[type] ?? []).filter((x) => x !== cb);
+    },
     fire: (type: string) => (listeners[type] ?? []).forEach((cb) => cb()),
     setState(next: string) {
       this.state = next;
@@ -110,6 +113,22 @@ describe("watchForUpdate", () => {
 
     expect(onUpdate).not.toHaveBeenCalled();
   });
+
+  test("unsubscribe also detaches the statechange listener on the installing worker", () => {
+    const reg = makeRegistration();
+    const installing = makeWorker("installing");
+    reg.installing = installing as never;
+    const onUpdate = vi.fn();
+
+    const unsub = watchForUpdate(reg as never, onUpdate);
+    reg.fire("updatefound"); // wires the statechange listener
+    unsub(); // must detach it
+    installing.setState("installed");
+    reg.waiting = installing as never;
+    installing.fire("statechange"); // should be a no-op now
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe("postSkipWaiting", () => {
@@ -121,9 +140,10 @@ describe("postSkipWaiting", () => {
 });
 
 describe("reloadOnControllerChange", () => {
-  function makeContainer() {
+  function makeContainer(controller: unknown = {}) {
     const listeners: Record<string, Array<() => void>> = {};
     return {
+      controller,
       addEventListener: (t: string, cb: () => void) => {
         (listeners[t] ??= []).push(cb);
       },
@@ -134,8 +154,8 @@ describe("reloadOnControllerChange", () => {
     };
   }
 
-  test("reloads exactly once even if controllerchange fires multiple times", () => {
-    const container = makeContainer();
+  test("reloads exactly once on an UPDATE (a controller already existed) even if controllerchange fires multiple times", () => {
+    const container = makeContainer({}); // a controller was present → genuine update
     const reload = vi.fn();
 
     reloadOnControllerChange(container as never, reload);
@@ -146,8 +166,18 @@ describe("reloadOnControllerChange", () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
+  test("does NOT reload on a FIRST visit (no controller at start; the initial clients.claim() must not trigger a reload)", () => {
+    const container = makeContainer(null); // uncontrolled first visit
+    const reload = vi.fn();
+
+    reloadOnControllerChange(container as never, reload);
+    container.fire("controllerchange"); // this is the initial claim, not an update
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
   test("unsubscribe detaches the handler so no reload fires", () => {
-    const container = makeContainer();
+    const container = makeContainer({});
     const reload = vi.fn();
 
     const unsub = reloadOnControllerChange(container as never, reload);

--- a/knowledge-base/engineering/architecture/decisions/ADR-137-extend-handwritten-service-worker-over-serwist.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-137-extend-handwritten-service-worker-over-serwist.md
@@ -1,0 +1,111 @@
+---
+title: Extend the handwritten service worker over adopting Serwist for PWA Phase 2
+status: active
+date: 2026-07-23
+---
+
+# ADR-137: Extend the handwritten service worker over adopting Serwist
+
+## Context
+
+PWA Phase 2 (offline fallback, update UX, install UX) needs service-worker
+changes on top of the Phase 1 baseline (PR #6849, merged 2026-07-23). The
+baseline ships a **handwritten** service worker at
+`apps/web-platform/public/sw.js` (`CACHE_NAME = "soleur-app-shell-v9"`),
+registered by `apps/web-platform/app/sw-register.tsx`. Its current shape:
+
+- **Network-only HTML** — the fetch handler never `respondWith`s HTML; HTML
+  always comes from the network so every document carries a fresh per-request
+  CSP nonce (`middleware.ts` mints `nonce` per request; `lib/csp.ts` emits
+  `script-src … 'nonce-…' 'strict-dynamic'`). A cached HTML document would
+  carry a stale nonce and its framework scripts would be CSP-blocked.
+- **Cache-first `_next/static/**`** + precached icons/favicon under
+  `CACHE_NAME`; the version suffix is the cache-purge lever (bump → `activate`
+  deletes stale caches keyed to an old project ref).
+- **Push notifications** — `push` / `notificationclick` handlers with
+  per-variant tag namespacing and open-redirect origin validation
+  (security-sensitive; see learning 2026-04-13-web-push-notification-…).
+- **Silent update** — `skipWaiting()` in `install` + `clients.claim()` in
+  `activate`, so a new worker swaps assets mid-session with no prompt.
+
+The decision to record: **adopt Serwist (the Next.js `@serwist/next` SW
+toolchain) OR extend the existing handwritten `public/sw.js`?**
+
+Constraints that must not regress:
+
+1. **Network-only HTML / CSP nonce.** HTML must keep coming from the network;
+   the SW must never serve cached authenticated HTML.
+2. **ADR-067 Router-Cache hard-nav invariant.** `feat-tab-content-cache`
+   relies on hard navigations (`window.location.assign`) at every
+   auth-principal boundary so middleware re-runs. The SW must let online
+   navigations reach the network (and thus middleware) untouched.
+3. **`CACHE_NAME` / versioning + project-ref purge** must be preserved.
+4. **The deploy pipeline is broken repo-wide** (PR #6852 / decision-challenge
+   #6860). Phase 2 will merge green but not deploy until that clears. Adding a
+   build-time toolchain that reshapes `next.config.ts` raises the blast radius
+   of the already-fragile build.
+
+## Decision
+
+**Extend the existing handwritten `public/sw.js`.** Do not adopt Serwist.
+
+The Phase 2 deltas are each small, surgical edits to the handwritten worker
+and its registrant:
+
+- **Offline fallback** — precache a static, script-free `public/offline.html`
+  and serve it from a new `navigate`-mode branch of the fetch handler *only on
+  network failure* (`fetch(req).catch(() => caches.match("/offline.html"))`).
+- **Update UX** — remove `skipWaiting()` from `install` (new workers go to
+  `waiting`), add a `message` listener that calls `skipWaiting()` on
+  `{type:"SKIP_WAITING"}`, and surface an "Update available — Reload"
+  affordance client-side that posts the message and reloads on
+  `controllerchange`.
+- **Install UX** — a client component captures `beforeinstallprompt`
+  (Chromium) and renders iOS Add-to-Home-Screen guidance where it is absent.
+
+None of these require a build-time precache manifest, a `next.config.ts`
+wrapper, or touching the push handlers.
+
+## Rationale (why not Serwist)
+
+- **New build-toolchain dependency during a broken deploy pipeline.** Serwist
+  wraps `next.config.ts` (`withSerwist`) and injects a precache manifest at
+  build time. With PR #6852 already breaking the build repo-wide, adding a
+  build-graph dependency is exactly the wrong risk to take this cycle.
+- **Forced rewrite of security-sensitive push handlers.** Serwist wants to own
+  the worker entry; migrating the `push`/`notificationclick` handlers (with
+  their per-variant tag namespacing and open-redirect validation) into a
+  Serwist source SW is a rewrite of working, review-hardened, security-relevant
+  code for zero Phase 2 benefit.
+- **Build-time precache model fights the deliberate design.** The current
+  worker's `CACHE_NAME` project-ref purge and network-only-HTML posture are
+  intentional. Serwist's default `NavigationRoute` + precached app-shell model
+  would need careful de-configuration to avoid caching HTML — re-deriving the
+  exact invariant we already have.
+- **The delta is genuinely small.** Offline fallback ≈ one fetch branch + one
+  static file; update UX ≈ delete one line + add a message listener + a client
+  toast; install UX ≈ one client component. A toolchain is not warranted.
+- **Zero new dependency** keeps `bunfig.toml` `minimumReleaseAge` and the
+  supply-chain surface untouched.
+
+## Consequences
+
+- **Positive:** no new dep, no `next.config.ts` change, push handlers
+  untouched, all four invariants preserved by construction, reviewable diff.
+- **Negative / accepted:** we keep hand-maintaining precache lists (add
+  `/offline.html` to `SHELL_ASSETS`) and the update lifecycle by hand. If the
+  precache surface ever grows to need build-time revisioning of many hashed
+  assets, revisit Serwist (the `_next/static/**` cache-first-on-fetch strategy
+  already avoids that need today).
+- **Sticky-SW risk** (see plan Risks): a bad fetch handler can brick the
+  installed app until storage is cleared. Mitigations: keep the `navigate`
+  branch a transparent network passthrough with a catch-only fallback; retain
+  the ability to ship a self-unregistering recovery worker as a kill switch.
+
+## Alternatives considered
+
+| Option | Verdict | Why |
+| --- | --- | --- |
+| Adopt `@serwist/next` | Rejected | Build-toolchain dep amid broken deploy pipeline; forces push-handler rewrite; precache model re-derives invariants we already hold. |
+| Extend handwritten `public/sw.js` | **Chosen** | Lowest risk; preserves CACHE_NAME/versioning, network-only HTML, ADR-067 hard-nav, push handlers; zero new dep. |
+| Raw Workbox (no Next wrapper) | Rejected | Same rewrite cost as Serwist without the Next integration; still a new dep. |

--- a/knowledge-base/project/learnings/2026-07-23-pwa-sw-lifecycle-and-brick-recovery.md
+++ b/knowledge-base/project/learnings/2026-07-23-pwa-sw-lifecycle-and-brick-recovery.md
@@ -1,0 +1,52 @@
+---
+title: "PWA service-worker lifecycle traps: first-visit reload, iOS-webview detection, mandated kill switch, aria-live timing"
+date: 2026-07-23
+branch: feat-one-shot-pwa-offline-install-phase-2
+category: ui-bugs
+tags: [pwa, service-worker, controllerchange, ios-safari, user-agent, aria-live, brand-survival, user-impact-reviewer]
+---
+
+# Learning: four non-obvious PWA/service-worker traps (Phase 2)
+
+## Problem
+
+PWA Phase 2 (offline fallback + update/install UX, ADR-137: extend the handwritten `public/sw.js`) surfaced four traps that unit tests + tsc passed but multi-agent review caught — two of them user-visible regressions.
+
+## Solution / Key Insights
+
+### 1. `clients.claim()` fires `controllerchange` on the FIRST visit — a reload handler must guard on prior-controller
+
+A handwritten SW whose `activate` calls `self.clients.claim()` (needed so the SW controls the first page load) fires a `controllerchange` event on a **brand-new, uncontrolled** visit — that's the *initial claim*, not an update taking over. A naive "reload the page on the first `controllerchange`" (the standard update-took-effect pattern) therefore reloads **100% of new visitors** on first load.
+
+Fix: capture whether a controller already existed when you START watching, and only reload on a genuine update:
+```ts
+const hadController = Boolean(container.controller); // false on a first, uncontrolled visit
+const handler = () => { if (reloaded) return; reloaded = true; if (hadController) reload(); };
+```
+Test both arms: `controller` present → reloads once; `controller` absent → never reloads.
+
+### 2. iOS in-app WKWebviews carry "Safari" but omit `Version/` — `isIosSafari()` must positively require `Version/`
+
+Detecting iOS Safari (the only iOS browser that can install a PWA via Share → Add to Home Screen) by *excluding* the dedicated third-party browsers (`CriOS|FxiOS|EdgiOS|GSA`) is **insufficient**: iOS in-app WKWebviews (Facebook `FBAN/FBAV`, Instagram, LinkedIn `LinkedInApp`, Line, TikTok, Snapchat) put `Safari` in the UA, lack those tokens, yet have no Share→A2HS affordance — so an "Add to Home Screen" card is a dead end there. Real iOS Safari UAs always carry a `Version/<n>` token; in-app webviews omit it. Gate positively:
+```ts
+return /Version\/\d/.test(ua) && /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS|GSA/.test(ua);
+```
+
+### 3. A `single-user-incident` plan that MANDATES a mitigation must IMPLEMENT it in the diff
+
+When a plan's `## User-Brand Impact` (brand-survival threshold `single-user incident`) mandates a specific mitigation — here "a self-unregistering recovery worker remains available as a kill switch" — `user-impact-reviewer` treats **"claimed mitigated-in-diff but absent from diff"** as a BLOCKING finding, even if the prose is well-written. The mitigation must ship or the threshold is unmet. The PWA brick-recovery kill switch = a client-side escape hatch (no separate worker needed): `?sw-reset` on any URL → `navigator.serviceWorker.getRegistrations().then(unregister all)` + `caches.keys()→delete all` → reload to the clean URL, wired into the SW-register component so it runs before (re)registration and on every route. It works even when the worker is broken because HTML is served network-only.
+
+### 4. An `aria-live` region must exist BEFORE its content is inserted
+
+A component that returns `null` until an affordance exists, then mounts a wrapper *with* the affordance, cannot announce it — screen readers only announce mutations to a live region that was **already present**. Keep a stable, always-mounted (possibly empty) `aria-live="polite"` wrapper and conditionally render the children inside it. An empty `pointer-events-none` wrapper is inert (does not intercept clicks), so keeping it mounted costs nothing.
+
+## Session Errors
+
+1. **The `aria-live` always-mounted wrapper broke two existing "empty container" test assertions.** — Recovery: updated the tests to assert "no affordances" (`queryByRole("button")` null) instead of `toBeEmptyDOMElement()`. **Prevention:** when a fix changes a component from "returns null" to "always mounts an (empty) region," grep its test file for `toBeEmptyDOMElement`/empty-container assertions in the same edit.
+2. **First in-app-webview test UA lacked the `Safari` token entirely**, so it would have passed `isIosSafari()===false` for the wrong reason (not exercising the new `Version/` discriminator). — Recovery: swapped to a `Safari`-but-no-`Version/` UA. **Prevention:** a negative test for a positive-marker gate must fail ONLY on the marker under test — hold every other discriminator constant.
+3. **New statechange-cleanup test needed `removeEventListener` on the mock worker, which the mock lacked.** — Recovery: added it. **Prevention:** when adding a cleanup path that calls `removeEventListener`, extend the event-target mock's remover in the same edit.
+4. **The `hadController` reload guard broke the existing "reloads once" test** (mock container had no `controller`). — Recovery: parameterized the mock container to set `controller` for the update case. **Prevention:** changing a function to read a new property means updating the shared mock factory's default shape.
+
+## Tags
+category: ui-bugs
+module: apps/web-platform (public/sw.js, lib/pwa/*, components/pwa/pwa-controls.tsx, app/sw-register.tsx)

--- a/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
+++ b/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
@@ -13,6 +13,23 @@ requires_cpo_signoff: true
 
 # ✨ PWA Phase 2 — offline fallback + update/install UX
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-23
+**Sections enhanced:** Architecture rationale, SW fetch handler, client update/install, offline page, Risks.
+**Gates run (all pass):** 4.6 User-Brand Impact (threshold `single-user incident`, valid); 4.7 Observability (5 fields, non-placeholder, no-ssh); 4.8 PAT-shaped halt (no match); 4.4 precedent-diff (no offline-fallback precedent — novel branch, flagged); 4.45 verify-the-negative (all negative claims confirmed against `public/sw.js`).
+
+### Key improvements
+
+1. **Verified the network-only-HTML claim against the live worker** — today `public/sw.js` has exactly one `respondWith` (line 63, the static-asset branch); HTML has none, so network-only HTML is confirmed, and the new `navigate` branch is the *only* HTML interception (passthrough + catch-only). `skipWaiting` is at line 21 (install chain, to remove); `clients.claim` is at line 36 (activate, to keep).
+2. **Confirmed CSP shape makes the offline page constraint concrete** — `script-src … 'strict-dynamic'` means a cache-served page cannot run inline scripts (stale/absent nonce); `style-src 'self' 'unsafe-inline'` allows inline `<style>`. Offline page = zero `<script>`, inline styles, `<a href>` retry.
+3. **Confirmed `/offline.html` reaches middleware** — matcher (`middleware.ts:424`) excludes `sw\.js` and image extensions but NOT `.html`, so the PUBLIC_PATHS entry is load-bearing for correct precache (else `cache.addAll` captures a 307→/login).
+
+### New considerations discovered
+
+- **Sticky-SW recovery is the top risk** — added a kill-switch (self-unregistering recovery worker) note; the `navigate` branch must be catch-only so an online fetch that *resolves with a 4xx/5xx* still returns the network response (only a thrown/rejected fetch → offline shell). Do NOT branch on `response.ok`.
+- **`beforeinstallprompt` requires `preventDefault()` synchronously** or Chromium shows its own mini-infobar; the deferred event is single-use (re-fires only on a later eligibility change).
+
 ## Overview
 
 Builds on PWA Phase 1 (PR #6849, merged 2026-07-23), which shipped a correct
@@ -357,6 +374,51 @@ discoverability_test:
    renders `null`.
 7. **iOS path** — iOS-Safari UA, not standalone → guidance card, no install
    button (no `beforeinstallprompt`).
+
+## Research Insights
+
+**Precedent-diff (Phase 4.4):** the only in-repo SW precedent is the existing
+handwritten `public/sw.js` (push/notification handlers + cache-first static).
+There is **no offline-fallback precedent** — the `navigate`-mode
+`respondWith(fetch().catch(...))` branch is **novel** for this codebase;
+reviewers should scrutinize its redirect/credential handling and the
+catch-only (never `response.ok`) semantics. The update-lifecycle
+(`skipWaiting` via `postMessage` + `controllerchange` reload) and
+`beforeinstallprompt` capture are standard web-platform patterns (MDN /
+web.dev "app-update-notification" and "customize-install"); they are new to
+this repo but not novel to the platform.
+
+**Best practices (grounded):**
+- Update prompt: keep the new worker in `waiting`; only `skipWaiting()` on
+  explicit user action, then reload once on `controllerchange` (guard the
+  reload with a module flag to avoid a loop). This is exactly the mid-session
+  asset-swap fix the ARGUMENTS ask for.
+- Offline navigation: branch on `event.request.mode === "navigate"` (not on
+  `Accept: text/html` sniffing) — it is the canonical navigation predicate and
+  avoids matching `fetch()`/XHR HTML sub-requests.
+- iOS: `beforeinstallprompt` never fires on iOS Safari; detect
+  `display-mode: standalone` / `navigator.standalone` to suppress, and gate the
+  Add-to-Home-Screen card on iOS-Safari UA. Do not show install chrome in an
+  in-app browser (no A2HS support).
+- Offline page a11y: `<html lang="en">`, a visible heading, sufficient
+  contrast in both `prefers-color-scheme` modes, and a real focusable
+  `<a href>` retry (keyboard-reachable, no JS).
+
+**Edge cases:**
+- A navigation that resolves with an HTTP error (500/maintenance page) must
+  return that network response, NOT the offline shell — catch only rejects.
+- First install (no existing controller): a worker with no `skipWaiting` still
+  activates immediately (waiting only occurs when a controller exists), so the
+  update affordance never shows on first install — correct.
+- `CACHE_NAME` bump to `v10` purges old caches on `activate`; with the waiting
+  model that purge now runs only after the user accepts the update — acceptable
+  and safer than mid-session purge.
+
+**References:**
+- <https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation>
+- <https://web.dev/articles/app-update-notification>
+- <https://web.dev/articles/customize-install>
+- <https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent>
 
 ## Risks & Mitigations / Sharp Edges
 

--- a/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
+++ b/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
@@ -1,0 +1,401 @@
+---
+title: "feat: PWA Phase 2 — offline fallback + update/install UX (apps/web-platform)"
+date: 2026-07-23
+status: ready
+type: enhancement
+branch: feat-one-shot-pwa-offline-install-phase-2
+lane: cross-domain
+milestone: "Phase 1: Close the Loop (Mobile-First, PWA)"
+adr: ADR-137
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+---
+
+# ✨ PWA Phase 2 — offline fallback + update/install UX
+
+## Overview
+
+Builds on PWA Phase 1 (PR #6849, merged 2026-07-23), which shipped a correct
+manifest (`start_url:/dashboard`, `scope:/`, shortcuts, `appleWebApp`,
+`viewportFit:cover`) and a handwritten service worker at
+`apps/web-platform/public/sw.js` (`CACHE_NAME "soleur-app-shell-v9"`,
+network-only HTML, cache-first `_next/static`, silent `skipWaiting`, push
+handlers), registered by `apps/web-platform/app/sw-register.tsx`.
+
+Phase 2 adds three capabilities, all by **extending the handwritten worker**
+(architecture decision recorded in **ADR-137** — Serwist rejected as a
+build-toolchain dependency during a broken deploy pipeline that would force a
+rewrite of the security-sensitive push handlers):
+
+1. **Offline fallback** — precache a static, script-free `public/offline.html`
+   and serve it *only when a navigation's network fetch fails*. Online
+   navigations stay network-only (fresh CSP nonce; ADR-067 hard-nav preserved).
+2. **Update UX** — stop silently swapping assets mid-session. New worker
+   versions go to `waiting`; a non-intrusive "Update available — Reload"
+   affordance lets the user opt in, which posts `SKIP_WAITING` and reloads.
+3. **Install UX** — capture `beforeinstallprompt` (Chromium) → "Install app"
+   button; where it is absent (iOS Safari) show Add-to-Home-Screen guidance.
+   Suppress all install chrome when already running standalone.
+
+**Out of scope (do NOT touch):** the deploy pipeline break (PR #6852 /
+decision-challenge #6860) — Phase 2 merges green but will not deploy until that
+clears; Phase 3 (per-surface mobile UX incl. kanban mobile layout).
+
+## Research Reconciliation — Spec vs. Codebase
+
+Premise validation (checked at plan time against `origin/main` + live `gh`):
+
+| Spec / description claim | Reality (verified) | Plan response |
+| --- | --- | --- |
+| SW at `public/sw.js`, `CACHE_NAME "soleur-app-shell-v9"`, network-only HTML, skipWaiting+claim, no prompt | Confirmed verbatim (read the file) | Extend in place; bump `CACHE_NAME` → `v10`. |
+| Registered via `<SwRegister/>` in `app/layout.tsx` | Confirmed; `sw-register.tsx` also chains push subscription; registered with `updateViaCache:"none"` | Leave SwRegister registration+push untouched; add a separate `<PwaControls/>` for update/install chrome. |
+| CSP nonce / network-only HTML constraint | Confirmed: `middleware.ts` mints per-request nonce; `lib/csp.ts` `script-src … 'nonce-…' 'strict-dynamic'` (non-nonce inline scripts blocked); `style-src 'self' 'unsafe-inline'` (inline styles allowed) | Offline page = **script-free** static HTML with inline `<style>` and an `<a href>` retry (no JS). |
+| ADR-067 "Router-Cache hard-nav invariants" | ADR-067 is *SWR client cache*; the Router-Cache `staleTimes` hard-nav (`window.location.assign` at auth boundaries) is the same feat-tab-content-cache line (PR #6252). Invariant holds. | `navigate` branch is a transparent network passthrough — online navigations reach middleware unchanged. |
+| Serwist not currently a dependency | Confirmed: no `serwist`/`workbox`/`next-pwa` in `apps/web-platform/package.json` | Adopting it = new dep + `next.config.ts` wrapper → rejected (ADR-137). |
+| PR #6852 broke deploy; tracked in #6860 | #6860 OPEN ("decision-challenge: inline-vs-import strip.ts …") | Merge green only; no deploy, no pipeline edits. |
+| Highest ADR = 136 | Confirmed (`ADR-136`) | New decision = **ADR-137**. |
+| No toast/sonner library | Confirmed: app uses bespoke `setToast` state (workstream-board) | Update/install affordances are bespoke components — no new dep. |
+
+## Architecture Decision (ADR-137)
+
+**Extend the handwritten `public/sw.js`; do not adopt Serwist.** Full rationale,
+constraints, and alternatives table:
+`knowledge-base/engineering/architecture/decisions/ADR-137-extend-handwritten-service-worker-over-serwist.md`.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a bricked installed PWA — a
+malformed `navigate`-mode `respondWith` (or a bad `activate`) can make every
+navigation fail or serve the offline shell while online, and a service worker
+is *sticky* (survives reloads; recovery needs clearing site data). Secondary:
+an update prompt that reload-loops, or an "Install"/"Add to Home Screen"
+affordance that errors or shows after install.
+
+**If this leaks, the user's data is exposed via:** n/a for confidentiality —
+`public/offline.html` is static, public-by-design, carries no session or PII,
+and the SW never serves cached authenticated HTML (network-only HTML
+preserved). The threshold below is driven by **availability**, not data
+exposure.
+
+**Brand-survival threshold:** `single-user incident` — a sticky bad worker can
+render the installed app unusable for a user until they clear storage, and
+per-user recovery is hard. This mandates: the `navigate` branch stays a
+transparent network passthrough with catch-only fallback; a self-unregistering
+recovery worker remains available as a kill switch; `user-impact-reviewer` runs
+at review time; CPO sign-off before `/work` (see frontmatter
+`requires_cpo_signoff: true`).
+
+## Implementation Phases
+
+Phase order is load-bearing: the offline page + PUBLIC_PATHS entry must exist
+before the SW precaches it; the SW `message` contract must exist before the
+client posts to it.
+
+### Phase 0 — Preconditions (verify, do not code)
+
+- Read `apps/web-platform/middleware.ts:424` matcher — confirms `sw\.js` is
+  excluded but `.html` is **not**, so `/offline.html` reaches middleware and
+  **must** be added to `PUBLIC_PATHS` (else `cache.addAll("/offline.html")`
+  precaches a `307 → /login`). This is the
+  `2026-05-29-nextjs-metadata-routes-need-public-paths-allowlist` class.
+- Confirm CSP: `style-src 'self' 'unsafe-inline'` (inline styles OK),
+  `script-src … 'strict-dynamic'` (non-nonce inline scripts blocked → offline
+  page must be script-free).
+- Run `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` to capture a
+  clean baseline (Phase 1 learning: treat "this compiles" as a precondition to
+  verify, not a fact).
+
+### Phase 1 — Static offline page + route allowlist
+
+- **Create `apps/web-platform/public/offline.html`** — self-contained, static,
+  **script-free**: branded "You're offline" message, inline `<style>`
+  (theme-aware via `prefers-color-scheme`, mirrors `#0a0a0a` forge-dark), and a
+  script-free retry `<a href="/dashboard">Try again</a>`. No `<script>`, no
+  nonce dependency.
+- **Edit `apps/web-platform/lib/routes.ts`** — add `"/offline.html"` to
+  `PUBLIC_PATHS`, adjacent to `/manifest.webmanifest`/`/robots.txt`, with a
+  rationale comment (public-by-design; precached by the SW; must bypass
+  Supabase auth or the precache captures the login redirect). Keeps CSP (public
+  branch still runs `withCspHeaders`).
+
+### Phase 2 — Service worker: offline fallback + update contract (`public/sw.js`)
+
+- Bump `CACHE_NAME` `"soleur-app-shell-v9"` → `"soleur-app-shell-v10"`.
+- Add `"/offline.html"` to `SHELL_ASSETS` (precached on install).
+- **Remove `self.skipWaiting()`** from the `install` handler (new workers now
+  go to `waiting` instead of activating mid-session). Keep `clients.claim()` in
+  `activate` (first-install control is unaffected — with no existing controller
+  a worker still activates immediately).
+- **Add a `message` listener:**
+  `self.addEventListener("message", (e) => { if (e.data?.type === "SKIP_WAITING") self.skipWaiting(); });`
+- **Add a `navigate` branch** to the fetch handler, after the API/ws/health
+  early-return and before/around the static-asset branch:
+  ```js
+  // Navigation: network-first; fall back to the precached static offline
+  // shell ONLY on network failure. Online navigations reach the network
+  // (and middleware) untouched — preserves network-only HTML (fresh CSP
+  // nonce) and the ADR-067 hard-nav boundary.
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match("/offline.html"))
+    );
+    return;
+  }
+  ```
+  Verify `fetch(event.request)` preserves redirect/credential semantics for
+  navigations (pass the original `Request`).
+- **Fold in #3002** (code-review overlap): wrap `cache.put` in the static-asset
+  branch in try/catch (quota-exceeded is non-fatal) and add a top-level
+  `self.addEventListener("error", …)` / `"unhandledrejection"` handler that
+  `console.warn`s without breaking fetch handling. `Closes #3002`.
+- **Do NOT touch** the `push` / `notificationclick` handlers.
+
+### Phase 3 — Client update affordance (`components/pwa/` + `lib/pwa/`)
+
+- **Create `apps/web-platform/lib/pwa/sw-update.ts`** (testable, no JSX):
+  helpers to (a) detect a `waiting` worker on an existing registration and via
+  `updatefound` → new worker `statechange === "installed"` while
+  `navigator.serviceWorker.controller` exists; (b) `postMessage({type:"SKIP_WAITING"})`
+  to the waiting worker; (c) a `controllerchange` one-shot reload guarded by a
+  module-level `reloading` flag (no reload loop).
+- **Create `apps/web-platform/lib/pwa/install.ts`** (testable): `beforeinstallprompt`
+  capture/defer, `appinstalled` handling, and standalone detection
+  (`matchMedia('(display-mode: standalone)').matches || navigator.standalone`),
+  plus iOS-Safari detection (no `beforeinstallprompt`).
+- **Create `apps/web-platform/components/pwa/pwa-controls.tsx`** (`"use client"`):
+  uses the two lib modules. Renders (i) a non-intrusive "Update available —
+  Reload" toast/pill when a worker is waiting; (ii) an "Install app" button when
+  a `beforeinstallprompt` is captured; (iii) an iOS "Add to Home Screen"
+  guidance card (share → Add to Home Screen) when on iOS Safari and not
+  standalone. Renders `null` when standalone / nothing to show. Does **not**
+  register the SW — it reads the existing registration via
+  `navigator.serviceWorker.getRegistration()`.
+- **Mount `<PwaControls/>`** in `apps/web-platform/app/(dashboard)/layout.tsx`
+  (authenticated surface — install/update chrome stays inside the app, not on
+  `/login`).
+
+### Phase 4 — Tests + verification
+
+- Vitest unit tests for `lib/pwa/sw-update.ts` and `lib/pwa/install.ts` under
+  `test/pwa/*.test.ts` (node) with mocked `navigator.serviceWorker` /
+  `beforeinstallprompt` (vitest include glob is `test/**/*.test.ts`; **not**
+  co-located — `bunfig.toml` blocks bun test).
+- Component test for `pwa-controls.tsx` under `test/components/pwa/*.test.tsx`
+  (jsdom/happy-dom; include glob `test/**/*.test.tsx`).
+- Middleware test: `isPublicPath("/offline.html") === true` and prefix-collision
+  negative `isPublicPath("/offline.htmlx") === false` (mirror the robots.txt
+  regression tests).
+- A precache-list assertion test: `SHELL_ASSETS` in `public/sw.js` includes
+  `"/offline.html"` (guards the precache-drift class).
+- Run `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` and
+  `./node_modules/.bin/vitest run test/pwa test/components/pwa` at this phase.
+
+## Files to Edit
+
+- `apps/web-platform/public/sw.js` — CACHE_NAME v10, precache offline.html,
+  drop `skipWaiting` from install, add `message` listener + `navigate` branch,
+  fold in #3002 (cache.put guard + global error handler).
+- `apps/web-platform/lib/routes.ts` — add `/offline.html` to `PUBLIC_PATHS`.
+- `apps/web-platform/app/(dashboard)/layout.tsx` — mount `<PwaControls/>`.
+
+## Files to Create
+
+- `apps/web-platform/public/offline.html` — static, script-free offline shell.
+- `apps/web-platform/lib/pwa/sw-update.ts` — update-lifecycle helpers.
+- `apps/web-platform/lib/pwa/install.ts` — install/standalone/iOS helpers.
+- `apps/web-platform/components/pwa/pwa-controls.tsx` — update + install chrome.
+- `apps/web-platform/test/pwa/sw-update.test.ts`
+- `apps/web-platform/test/pwa/install.test.ts`
+- `apps/web-platform/test/components/pwa/pwa-controls.test.tsx`
+- (middleware/offline allowlist assertions fold into the existing
+  `test/middleware*.test.ts`; add if no suitable file exists.)
+
+## Open Code-Review Overlap
+
+2 open code-review issues touch files this plan edits:
+
+- **#3002** — "add service-worker global error handler for cache.put quota
+  failures" (touches `public/sw.js`). **Fold in** — we are already rewriting
+  the fetch handler; add the `cache.put` try/catch + global error/rejection
+  handler in the same PR. `Closes #3002` in the PR body.
+- **#3564** — "establish Core Web Vitals infrastructure for apps/web-platform"
+  (touches `app/layout.tsx`). **Acknowledge** — a separate perf-instrumentation
+  concern, orthogonal to PWA offline/install/update; leave open, no change here.
+
+## Acceptance Criteria
+
+### Pre-merge (PR)
+
+- [ ] `public/offline.html` exists, contains **no** `<script>` element, and
+      renders a branded offline message + a script-free `<a href>` retry.
+- [ ] `isPublicPath("/offline.html") === true`; `isPublicPath("/offline.htmlx")
+      === false` (regression tests pass).
+- [ ] `public/sw.js`: `CACHE_NAME === "soleur-app-shell-v10"`; `SHELL_ASSETS`
+      includes `"/offline.html"`; the `install` handler contains **no**
+      `skipWaiting`; a `message` listener calls `skipWaiting()` on
+      `{type:"SKIP_WAITING"}`; a `navigate`-mode branch does
+      `fetch(...).catch(() => caches.match("/offline.html"))`; `push` /
+      `notificationclick` handlers are byte-identical to Phase 1.
+- [ ] `lib/pwa/sw-update.ts` reload path is guarded against a `controllerchange`
+      reload loop (unit test asserts a single reload).
+- [ ] `pwa-controls.tsx` renders `null` when
+      `matchMedia('(display-mode: standalone)').matches` (unit/component test).
+- [ ] `beforeinstallprompt` is captured (`preventDefault` called) and drives the
+      "Install app" affordance; iOS-Safari path shows guidance instead
+      (component test).
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean.
+- [ ] `./node_modules/.bin/vitest run test/pwa test/components/pwa` green.
+- [ ] PR body: `Closes #3002`. `Ref #6849` (Phase 1). Do **not** reference
+      #6852/#6860 as closing.
+
+### Post-merge (operator / post-deploy — blocked on #6852)
+
+- [ ] After the deploy pipeline clears (#6852/#6860) and this deploys:
+      `curl -sI https://app.soleur.ai/offline.html` returns `HTTP 200` with
+      `content-type: text/html` (NO ssh). Automation: single `curl`, run by the
+      shipping agent once deploy is unblocked — not operator-manual.
+- [ ] Manual QA (Chromium): install the app, ship a trivial SW change, confirm
+      the "Update available — Reload" affordance appears (not a silent swap) and
+      accepting it reloads once. Automation: not feasible pre-deploy (requires a
+      real second SW version on a deployed origin); e2e navigate-smoke covers
+      the online path pre-merge.
+
+## Domain Review
+
+**Domains relevant:** Product/UX. (Engineering/security carried as plan Risks;
+no Legal/Finance/Growth surface — static public page, no PII, no vendor, no
+schema.)
+
+### Product/UX Gate
+
+**Tier:** blocking — mechanical escalation fires: this plan creates
+`components/pwa/pwa-controls.tsx` (matches `components/**/*.tsx`).
+**Decision:** reviewed (partial) — pipeline subagent has no Task tool, so the
+`ux-design-lead` / `spec-flow-analyzer` / `cpo` agent pipeline could not be
+spawned inline.
+**Agents invoked:** none (Task unavailable in this pipeline planning subagent).
+**Skipped specialists:** ux-design-lead (Task/Pencil unavailable in pipeline —
+see wireframe gate below), spec-flow-analyzer (Task unavailable), cpo (Task
+unavailable; `requires_cpo_signoff` recorded for the operator).
+**Pencil available:** no.
+
+#### Wireframe gate (`wg-ui-feature-requires-pen-wireframe`)
+
+The install/update UI is minor chrome (toast/pill + button + iOS guidance
+card). Per the ARGUMENTS, a wireframe is acceptable but minimal and **the
+operator reviews it before implementation**. A textual wireframe spec is below;
+a `.pen` wireframe + operator sign-off is a **pre-`/work` gate** (do not
+implement Phase 3 UI before the operator approves the chrome).
+
+Textual wireframe (non-intrusive, bottom-anchored, respects safe-area insets):
+
+- **Update pill** — small rounded pill, bottom-center above the composer safe
+  area: `⟳ Update available` + `Reload` text button. Dismissible. Appears only
+  when a worker is `waiting`.
+- **Install button** — subtle secondary button (settings/header overflow or a
+  one-time bottom banner): `⤓ Install app`. Appears only when
+  `beforeinstallprompt` was captured; hidden after `appinstalled`.
+- **iOS guidance card** — small dismissible card: "Install Soleur: tap the
+  Share icon, then *Add to Home Screen*." Appears only on iOS Safari, not
+  standalone, once per session/dismissal.
+- All three render `null` in standalone mode and never overlap the composer
+  (anchor to the composer box per the Phase 1 floating-pill learning, not a
+  fixed offset).
+
+#### Findings
+
+Non-intrusiveness and standalone-suppression are the load-bearing UX
+requirements; both are encoded as ACs. No new user-facing *page* or multi-step
+flow — these are progressive-enhancement affordances.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: SW-registered + offline-fallback-served breadcrumbs (client-side, best-effort progressive enhancement — no server liveness applies to a client SW)
+  cadence: per client session
+  alert_target: none (client-side best-effort; app works without the SW)
+  configured_in: apps/web-platform/app/sw-register.tsx (registration) + apps/web-platform/components/pwa/pwa-controls.tsx (update/install)
+error_reporting:
+  destination: browser console.warn (existing) + Sentry.captureException on SW registration failure (non-fatal)
+  fail_loud: warn-level, non-fatal — registration failure already falls through to "app works without SW"
+failure_modes:
+  - mode: SW registration fails
+    detection: catch in sw-register.tsx
+    alert_route: console.warn + Sentry breadcrumb
+  - mode: offline.html precached as a login redirect (missing PUBLIC_PATHS entry)
+    detection: post-deploy curl 200 + vitest isPublicPath test + SHELL_ASSETS precache-list test
+    alert_route: CI red (pre-merge) / curl (post-deploy)
+  - mode: update prompt reload loop
+    detection: controllerchange reload-guard flag + unit test asserting single reload
+    alert_route: CI red
+  - mode: SW bricks navigation (serves offline while online / respondWith throws)
+    detection: vitest navigate-branch unit test (fetch resolves → passthrough; rejects → offline.html) + manual Chromium QA
+    alert_route: CI red / QA
+logs:
+  where: browser console (client-side only; no server log surface for the SW)
+  retention: n/a (client)
+discoverability_test:
+  command: "cd apps/web-platform && ./node_modules/.bin/vitest run test/pwa test/components/pwa   # plus, post-deploy: curl -sI https://app.soleur.ai/offline.html"
+  expected_output: "vitest: all pass; curl: HTTP 200, content-type: text/html"
+```
+
+## Test Scenarios
+
+1. **Offline navigation** — with `fetch` mocked to reject, the SW `navigate`
+   branch resolves to the cached `/offline.html`.
+2. **Online navigation** — `fetch` resolves; the SW returns the network
+   response untouched (no cached HTML served; nonce/middleware path intact).
+3. **PUBLIC_PATHS** — `isPublicPath("/offline.html")` true; `"/offline.htmlx"`
+   false.
+4. **Update lifecycle** — a `waiting` worker surfaces the affordance; clicking
+   Reload posts `SKIP_WAITING` and triggers exactly one `controllerchange`
+   reload.
+5. **Install capture** — `beforeinstallprompt` `preventDefault`ed and stored;
+   button click calls `prompt()`; `appinstalled` hides the button.
+6. **Standalone suppression** — `display-mode: standalone` → `PwaControls`
+   renders `null`.
+7. **iOS path** — iOS-Safari UA, not standalone → guidance card, no install
+   button (no `beforeinstallprompt`).
+
+## Risks & Mitigations / Sharp Edges
+
+- **Sticky-SW brick (highest risk).** A bad `navigate` `respondWith` can make
+  the installed app fail every navigation, and a SW persists across reloads.
+  *Mitigation:* keep the branch a transparent network passthrough with
+  **catch-only** fallback; unit-test both arms; retain a self-unregistering
+  recovery worker as a kill switch; `updateViaCache:"none"` already ensures the
+  SW script is re-fetched fresh so a fixed worker can supersede a bad one.
+- **Offline page must be script-free** — `script-src … 'strict-dynamic'` blocks
+  non-nonce inline scripts, and a cache-served page cannot rely on a fresh
+  nonce. Use inline `<style>` (allowed by `style-src 'unsafe-inline'`) and an
+  `<a href>` retry. No `<script>`.
+- **PUBLIC_PATHS is load-bearing for precache** — without `/offline.html` in
+  `PUBLIC_PATHS`, `cache.addAll` captures a `307 → /login`
+  (`2026-05-29-nextjs-metadata-routes-need-public-paths-allowlist` class).
+- **ADR-067 hard-nav** — the `navigate` branch must never serve cached HTML
+  online; online navigations must reach middleware. Passthrough-then-catch
+  preserves this.
+- **Do not remove `clients.claim()`** — first-install control depends on it;
+  only `skipWaiting` is removed (that is the mid-session-swap fix).
+- **tsc is a precondition, not an afterthought** (Phase 1 learning): run
+  `./node_modules/.bin/tsc --noEmit` at the phase that lands code; a plan's
+  "this compiles" is a claim to verify.
+- **Bash CWD persists** across tool calls (Phase 1 learning): prefix
+  path-relative commands with `cd apps/web-platform &&` after any `cd <root>`.
+- **Test file paths must match vitest globs** — `test/**/*.test.ts` (node) /
+  `test/**/*.test.tsx` (jsdom); co-located component tests are silently skipped
+  and `bunfig.toml` blocks bun test entirely.
+- **A plan whose `## User-Brand Impact` section is empty, placeholder, or omits
+  the threshold fails `deepen-plan` Phase 4.6.** It is filled above.
+
+## Non-Goals / Out of Scope
+
+- **Deploy pipeline fix** (PR #6852 / #6860) — tracked; do not touch. Phase 2
+  merges green, deploys later.
+- **Phase 3** — per-surface mobile UX incl. kanban mobile layout — separate.
+- **Full offline data mode** — agents require network; only the app-shell
+  fallback + static offline page are in scope (no offline reads/writes).
+- **Serwist adoption** — rejected in ADR-137; the ADR is the tracking record
+  (revisit only if the precache surface grows to need build-time revisioning).
+- **Background sync / periodic sync / push changes** — not in Phase 2.

--- a/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
+++ b/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
@@ -304,6 +304,19 @@ operator reviews it before implementation**. A textual wireframe spec is below;
 a `.pen` wireframe + operator sign-off is a **pre-`/work` gate** (do not
 implement Phase 3 UI before the operator approves the chrome).
 
+**OPERATOR OVERRIDE (2026-07-23): `.pen` wireframe WAIVED for this minor
+chrome.** The operator reviewed the textual UX spec below and approved building
+directly, explicitly waiving the Pencil wireframe for these three
+progressive-enhancement surfaces: (1) the "Update available — Reload" pill in
+`components/pwa/pwa-controls.tsx`, (2) the "Install app" button in the same
+component, and (3) the iOS "Add to Home Screen" guidance card in the same
+component. All three are null-in-standalone, composer-anchored, dismissible
+affordances — no new page or multi-step flow. This override satisfies the
+`wg-ui-feature-requires-pen-wireframe` UX-skip-on-UI-plan gate for
+`components/pwa/pwa-controls.tsx`. `ux-design-lead` remains recorded as skipped
+(Task/Pencil unavailable in the pipeline subagent) with this operator override
+as the sign-off of record.
+
 Textual wireframe (non-intrusive, bottom-anchored, respects safe-area insets):
 
 - **Update pill** — small rounded pill, bottom-center above the composer safe

--- a/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
+++ b/knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
@@ -97,8 +97,10 @@ exposure.
 **Brand-survival threshold:** `single-user incident` — a sticky bad worker can
 render the installed app unusable for a user until they clear storage, and
 per-user recovery is hard. This mandates: the `navigate` branch stays a
-transparent network passthrough with catch-only fallback; a self-unregistering
-recovery worker remains available as a kill switch; `user-impact-reviewer` runs
+transparent network passthrough with catch-only fallback; a client-side kill
+switch (`?sw-reset` in `lib/pwa/sw-reset.ts`, wired into `<SwRegister/>`)
+unregisters every worker + clears all caches and reloads clean, as the
+brick-recovery escape hatch (implemented in this PR); `user-impact-reviewer` runs
 at review time; CPO sign-off before `/work` (see frontmatter
 `requires_cpo_signoff: true`).
 
@@ -438,8 +440,9 @@ this repo but not novel to the platform.
 - **Sticky-SW brick (highest risk).** A bad `navigate` `respondWith` can make
   the installed app fail every navigation, and a SW persists across reloads.
   *Mitigation:* keep the branch a transparent network passthrough with
-  **catch-only** fallback; unit-test both arms; retain a self-unregistering
-  recovery worker as a kill switch; `updateViaCache:"none"` already ensures the
+  **catch-only** fallback; unit-test both arms; ship the `?sw-reset` client-side
+  kill switch (`lib/pwa/sw-reset.ts` → `<SwRegister/>`) that unregisters all
+  workers + clears caches and reloads clean; `updateViaCache:"none"` already ensures the
   SW script is re-fetched fresh so a fixed worker can supersede a bad one.
 - **Offline page must be script-free** — `script-src … 'strict-dynamic'` blocks
   non-nonce inline scripts, and a cache-served page cannot rely on a fresh

--- a/knowledge-base/project/specs/feat-one-shot-pwa-offline-install-phase-2/session-state.md
+++ b/knowledge-base/project/specs/feat-one-shot-pwa-offline-install-phase-2/session-state.md
@@ -1,0 +1,24 @@
+# Session State
+
+## Plan Phase
+- Plan file: knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
+- ADR: knowledge-base/engineering/architecture/decisions/ADR-137-extend-handwritten-service-worker-over-serwist.md
+- Status: complete
+
+### Errors
+None. Planning subagent had no Task tool → ux-design-lead/spec-flow/cpo not spawned inline; recorded as pre-/work operator gates. Operator waived the .pen wireframe for the minor install/update chrome (override recorded in plan Product/UX Gate).
+
+### Decisions
+- ADR-137: extend handwritten public/sw.js, reject Serwist (lower risk, zero deps, preserves network-only-HTML/CSP-nonce + ADR-067 hard-nav + CACHE_NAME versioning + push handlers).
+- Offline page = static script-free public/offline.html, added to PUBLIC_PATHS + precached, served only on navigate fetch().catch(). CACHE_NAME → v10.
+- Update UX: drop silent skipWaiting, keep clients.claim; bespoke "Update available — Reload" pill posts SKIP_WAITING, reload once on controllerchange (loop-guarded).
+- Install UX: capture beforeinstallprompt → "Install app" button; iOS A2HS guidance card; all null in standalone, composer-anchored.
+- Brand-survival = single-user incident (requires_cpo_signoff): a sticky bad worker can brick the installed app. Mitigations: catch-only navigate branch (never branch on response.ok), self-unregistering recovery worker kill switch.
+- Fold in #3002 (SW cache.put quota guard + global error handler; Closes #3002). Acknowledge #3564 (CWV infra, orthogonal).
+- OPERATOR OVERRIDE: .pen wireframe waived for the 3 minor-chrome surfaces in components/pwa/pwa-controls.tsx (approved 2026-07-23).
+
+### Components Invoked
+- skill: soleur:plan, skill: soleur:deepen-plan (planning subagent)
+
+## Deploy caveat
+Repo-wide deploy broken by unrelated #6852 (tracked #6860). This PR will merge green but not deploy until #6860 resolves. Do NOT fix #6860 here.

--- a/knowledge-base/project/specs/feat-one-shot-pwa-offline-install-phase-2/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-pwa-offline-install-phase-2/tasks.md
@@ -1,0 +1,48 @@
+---
+title: "Tasks — PWA Phase 2 (offline + update/install UX)"
+lane: cross-domain
+plan: knowledge-base/project/plans/2026-07-23-feat-pwa-offline-install-update-phase-2-plan.md
+adr: ADR-137
+---
+
+# Tasks — PWA Phase 2
+
+> Derived from the plan. Lane defaulted to `cross-domain` (no spec.md on branch;
+> TR2 fail-closed).
+
+## Phase 0 — Preconditions (verify only)
+
+- 0.1 Read `apps/web-platform/middleware.ts:424` matcher; confirm `.html` reaches middleware (→ needs PUBLIC_PATHS).
+- 0.2 Confirm CSP: inline styles allowed (`style-src 'unsafe-inline'`), non-nonce inline scripts blocked (`strict-dynamic`).
+- 0.3 `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` — clean baseline.
+
+## Phase 1 — Offline page + allowlist
+
+- 1.1 Create `apps/web-platform/public/offline.html` — static, script-free, inline-styled, theme-aware, `<a href>` retry.
+- 1.2 Edit `apps/web-platform/lib/routes.ts` — add `/offline.html` to `PUBLIC_PATHS` with rationale comment.
+
+## Phase 2 — Service worker (`public/sw.js`)
+
+- 2.1 Bump `CACHE_NAME` → `soleur-app-shell-v10`.
+- 2.2 Add `/offline.html` to `SHELL_ASSETS`.
+- 2.3 Remove `self.skipWaiting()` from `install` (keep `clients.claim()` in `activate`).
+- 2.4 Add `message` listener: `SKIP_WAITING` → `self.skipWaiting()`.
+- 2.5 Add `navigate`-mode fetch branch: `fetch(req).catch(() => caches.match("/offline.html"))`.
+- 2.6 Fold in #3002: `cache.put` try/catch + top-level `error`/`unhandledrejection` handler. `Closes #3002`.
+- 2.7 Leave `push`/`notificationclick` byte-identical.
+
+## Phase 3 — Client update + install UX
+
+- 3.1 Create `apps/web-platform/lib/pwa/sw-update.ts` (waiting detection, SKIP_WAITING post, guarded controllerchange reload).
+- 3.2 Create `apps/web-platform/lib/pwa/install.ts` (beforeinstallprompt capture, standalone + iOS detection).
+- 3.3 Create `apps/web-platform/components/pwa/pwa-controls.tsx` (`"use client"`) — update pill + install button + iOS guidance; `null` in standalone.
+- 3.4 Mount `<PwaControls/>` in `apps/web-platform/app/(dashboard)/layout.tsx`.
+- 3.5 GATE: operator reviews the `.pen` wireframe / chrome before implementing Phase 3 UI.
+
+## Phase 4 — Tests + verification
+
+- 4.1 `test/pwa/sw-update.test.ts`, `test/pwa/install.test.ts` (node, mocked SW/beforeinstallprompt).
+- 4.2 `test/components/pwa/pwa-controls.test.tsx` (jsdom).
+- 4.3 Middleware: `isPublicPath("/offline.html")` true / `"/offline.htmlx"` false.
+- 4.4 Precache-list test: `SHELL_ASSETS` includes `/offline.html`.
+- 4.5 `./node_modules/.bin/tsc --noEmit` + `./node_modules/.bin/vitest run test/pwa test/components/pwa` green.


### PR DESCRIPTION
## Summary

PWA Phase 2 — offline support + install/update UX for `apps/web-platform`, building on Phase 1's installable manifest. **ADR-137: extend the handwritten `public/sw.js`** rather than adopt Serwist (lower risk on an already-strained deploy pipeline, zero new deps, preserves the network-only-HTML/CSP-nonce, ADR-067 hard-nav, `CACHE_NAME` versioning, and push-handler invariants by construction).

Closes #3002

## Changelog

### Web Platform — offline
- New static, **script-free** `public/offline.html` (CSP-safe: no `<script>`, inline `<style>` only; theme-aware via `prefers-color-scheme`), added to `PUBLIC_PATHS` and precached. Served **only** on a navigation `fetch().catch()` (catch-only — a live origin 4xx/5xx is never masked).
- `public/sw.js`: `CACHE_NAME` v9→v10 (activate purges old caches), navigate-mode offline fallback, folded in **#3002** (cache.put quota guard + global `error`/`unhandledrejection` handlers). Push/notificationclick handlers byte-identical.

### Web Platform — update UX
- Dropped the silent `install`-time `skipWaiting()`; a new worker now **waits**. The "Update available — Reload" pill posts `SKIP_WAITING` and reloads exactly once on `controllerchange` (guarded so the initial `clients.claim()` on a first visit never triggers a spurious reload).

### Web Platform — install UX
- `beforeinstallprompt` captured → "Install app" button; iOS Safari gets an "Add to Home Screen" guidance card (positively gated on the `Version/` UA token so iOS in-app webviews don't get a dead-end card). All affordances render `null` in standalone and are dismissible; wrapped in an `aria-live="polite"` region so they're announced.

### Web Platform — brand-survival recovery
- `?sw-reset` **kill switch** (`lib/pwa/sw-reset.ts` → `<SwRegister/>`): unregisters every worker + clears all caches and reloads clean — the recovery escape hatch for the `single-user incident` threshold (a bad worker can otherwise brick the installed app).

## Review

7-agent review incl. `user-impact-reviewer` (brand-survival = single-user incident): 7 findings, **all pr-introduced, all fixed inline (0 scope-out)** — the blocking kill-switch gap (now implemented), a HIGH first-visit spurious-reload bug, an iOS in-app-webview mis-detection, and a11y/target-size polish. Clean verdicts on SW security (offline.html inert, navigate catch-only, push handlers intact, middleware 307 flows natively via `redirect:"manual"`), ADR-137 invariants, and performance.

## Deploy note (out of scope)

The repo-wide Web Platform Release is currently broken by **unrelated PR #6852** (an out-of-`apps/web-platform`-context import; tracked in decision-challenge **#6860**). This PR merges green but its release will fail at the Docker `next build` until #6860 is resolved — that specific failure is the known pre-existing outage, **not** a regression from this PR.

## Test plan
- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` clean
- [x] `./node_modules/.bin/vitest run test/pwa test/components/pwa test/middleware.test.ts` — 64 green (sw-update, install, sw-reset, sw-source invariants, pwa-controls, middleware)
- [x] full `scripts/test-all.sh` green
- [ ] Recommended: manual offline + install QA on a real device (offline navigation → offline.html; update pill on a new deploy; iOS A2HS card only in real Safari)

Generated with [Claude Code](https://claude.com/claude-code)
