### PR TITLE
fix(infra): host-boot Doppler token read/write so the cutover flip can advance its FSM flag

### DIFF
--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -206,9 +206,10 @@ runcmd:
       || /usr/local/bin/inngest-boot-phone-home.sh doppler-cli-install-FAILED
   # Restricted (0600 root) env file with the scoped Doppler service token — NOT world-
   # readable /etc/environment (mirrors registry's /etc/default/registry-doppler). The token
-  # is scoped to the ISOLATED `soleur-inngest` project's `prd` root config (a SEPARATE
-  # project — NO inheritance path to soleur/prd), so a host compromise reads ONLY the
-  # inngest secret set.
+  # is read/write on the ISOLATED `soleur-inngest` project's `prd` root config (the flip FSM
+  # writes INNGEST_CUTOVER_FLIP under it, #6178) — a SEPARATE project with NO inheritance path
+  # to soleur/prd, so a host compromise reaches ONLY this host's own isolated secret set,
+  # never a foreign project.
   # HOME is REQUIRED (#6122 boot fix — the actual dark-host boot bug, found via the #6178 boot
   # probe): cloud-init runcmd runs with NO $HOME, and the Doppler CLI aborts with
   # "Doppler Error: $HOME is not defined" even when DOPPLER_CONFIG_DIR is set. Without it the
@@ -466,8 +467,8 @@ runcmd:
     # because this host downloads the arch-matched tarball — a wrong-arch SHA would fail verify.
     VECTOR_CLI_VERSION=$(printf '%s\n' "$image_env" | grep '^VECTOR_CLI_VERSION=' | head -1 | cut -d= -f2- || true)
     # DOPPLER_PROJECT=soleur-inngest routes every doppler-wrapped unit (server/heartbeat/redis/
-    # vector) at THIS host's ISOLATED project (AC3) — the scoped boot token can read only
-    # soleur-inngest. VECTOR_CLI_ARCH (=${inngest_cli_arch}) selects the matching triple in the bootstrap map.
+    # vector) at THIS host's ISOLATED project (AC3) — the scoped boot token reaches only
+    # soleur-inngest (read/write, #6178). VECTOR_CLI_ARCH (=${inngest_cli_arch}) selects the matching triple in the bootstrap map.
     # #6178 boot observability: capture the bootstrap's combined output to a file and self-report
     # its exit code + a masked tail. The bootstrap's own log() goes to journald->Vector, which is
     # DOWN until the bootstrap installs+starts Vector near its end — so a mid-bootstrap failure is

--- a/apps/web-platform/infra/inngest-arm-write-token.tf
+++ b/apps/web-platform/infra/inngest-arm-write-token.tf
@@ -17,11 +17,13 @@
 # (a session-pooler DSN granting direct read/write to the inngest Postgres). It MUST be
 # revoked post-cutover — see the runbook lifecycle step + Rotation below.
 #
-# Distinct from the READ-only host-boot token `doppler_service_token.inngest`
-# ("inngest-boot", inngest-host.tf:173-178): different name ("inngest-cutover-arm"),
-# access (read/write vs read), and consumer (CI vs the host cloud-init). This is the FIRST
-# CI-consumed read/write token into the isolated soleur-inngest project — prior tokens there
-# are read-only host-boot. CI can now WRITE soleur-inngest/prd (ADR-100 Decision 6b).
+# Distinct from the host-boot token `doppler_service_token.inngest` ("inngest-boot"):
+# different name ("inngest-cutover-arm") and consumer (CI vs the host cloud-init). Both are
+# read/write on soleur-inngest/prd as of #6178 — the host-boot token gained write so the
+# flip FSM can advance INNGEST_CUTOVER_FLIP on-host (inngest-cutover-flip.sh:flag_set) — so
+# the tokens no longer differ by ACCESS, only by name+consumer. This is the FIRST CI-consumed
+# read/write token into the isolated soleur-inngest project; the host-boot token is the
+# host-consumed one. CI can now WRITE soleur-inngest/prd (ADR-100 Decision 6b).
 #
 # By-reference project/config (NOT the soleur-inngest / prd string literals): this builds
 # the Terraform dependency edge onto doppler_project.inngest + doppler_environment.inngest_prd,

--- a/apps/web-platform/infra/inngest-host.test.sh
+++ b/apps/web-platform/infra/inngest-host.test.sh
@@ -54,19 +54,28 @@ fi
 #     FIRST transition (flag_set flipping), so the dedicated scheduler can never complete the
 #     flip. Extract the access value from the token resource block specifically (not a bare
 #     file-wide grep that a comment could satisfy), so a silent revert to "read" red-lines CI.
+#     The awk SKIPS in-block comment lines and requires `access` at STATEMENT position
+#     (^[[:space:]]*access) — a bare `access[[:space:]]*=` match plus no comment-skip is
+#     defeated by an in-block decoy comment (`# access = "read/write"`) sitting above the real
+#     read-only attribute (awk matches the comment first, prints read/write, exits green).
 TOKEN_ACCESS="$(awk '
-  /resource "doppler_service_token" "inngest"/ { inblk=1 }
-  inblk && /access[[:space:]]*=/ { gsub(/[",]/,""); print $NF; exit }
+  /resource "doppler_service_token" "inngest"/ { inblk=1; next }
+  inblk && /^[[:space:]]*#/ { next }
+  inblk && /^[[:space:]]*access[[:space:]]*=/ { gsub(/[",]/,""); print $NF; exit }
   inblk && /^}/ { exit }
 ' "$HOST_TF")"
 [[ "$TOKEN_ACCESS" == "read/write" ]] \
   && pass || fail "doppler_service_token.inngest access must be 'read/write' so the flip FSM can write INNGEST_CUTOVER_FLIP (got '${TOKEN_ACCESS:-<none>}'); a read-only token boot-fails the flip at its first transition (#6178)"
 # Cross-check: the flip script's flag_set genuinely writes under the ambient (boot-token) env —
 # if flag_set ever grows an explicit --token, this test's premise (boot token authorizes the
-# write) must be re-derived rather than trusted.
-grep -qE 'doppler secrets set INNGEST_CUTOVER_FLIP' "${DIR}/inngest-cutover-flip.sh" \
-  && ! grep -qE 'doppler secrets set INNGEST_CUTOVER_FLIP.*--token' "${DIR}/inngest-cutover-flip.sh" \
-  && pass || fail "flip flag_set must write INNGEST_CUTOVER_FLIP under the ambient boot token (no explicit --token) — else the read/write requirement above is testing the wrong credential"
+# write) must be re-derived rather than trusted. Scope to the WHOLE flag_set function body
+# (awk between `flag_set() {` and the closing `}`), not a single line — the real write spans
+# two physical lines (`doppler secrets set … \` then `  --project … --silent`), so a --token
+# added on the continuation line would evade a line-scoped grep.
+FLAG_SET_BODY="$(awk '/^flag_set\(\)[[:space:]]*\{/{i=1} i{print} i&&/^\}/{exit}' "${DIR}/inngest-cutover-flip.sh")"
+printf '%s\n' "$FLAG_SET_BODY" | grep -qE 'doppler secrets set INNGEST_CUTOVER_FLIP' \
+  && ! printf '%s\n' "$FLAG_SET_BODY" | grep -qE -- '--token' \
+  && pass || fail "flip flag_set must write INNGEST_CUTOVER_FLIP under the ambient boot token (no explicit --token anywhere in the function body) — else the read/write requirement above is testing the wrong credential"
 
 # 2. Separate Doppler PROJECT (AC3), not a prd branch config.
 grep -qE 'resource "doppler_project" "inngest"' "$HOST_TF" \

--- a/apps/web-platform/infra/inngest-host.test.sh
+++ b/apps/web-platform/infra/inngest-host.test.sh
@@ -48,6 +48,26 @@ else
   fail "dedicated secrets reference the dedicated keys, not the co-located _prd keys"
 fi
 
+# 1b. (#6178) The host-boot token MUST be read/write, NOT read-only. The cutover flip FSM
+#     (inngest-cutover-flip.sh:flag_set) advances INNGEST_CUTOVER_FLIP on soleur-inngest/prd
+#     via `doppler secrets set` under this token; a read-only token fails that write at the
+#     FIRST transition (flag_set flipping), so the dedicated scheduler can never complete the
+#     flip. Extract the access value from the token resource block specifically (not a bare
+#     file-wide grep that a comment could satisfy), so a silent revert to "read" red-lines CI.
+TOKEN_ACCESS="$(awk '
+  /resource "doppler_service_token" "inngest"/ { inblk=1 }
+  inblk && /access[[:space:]]*=/ { gsub(/[",]/,""); print $NF; exit }
+  inblk && /^}/ { exit }
+' "$HOST_TF")"
+[[ "$TOKEN_ACCESS" == "read/write" ]] \
+  && pass || fail "doppler_service_token.inngest access must be 'read/write' so the flip FSM can write INNGEST_CUTOVER_FLIP (got '${TOKEN_ACCESS:-<none>}'); a read-only token boot-fails the flip at its first transition (#6178)"
+# Cross-check: the flip script's flag_set genuinely writes under the ambient (boot-token) env —
+# if flag_set ever grows an explicit --token, this test's premise (boot token authorizes the
+# write) must be re-derived rather than trusted.
+grep -qE 'doppler secrets set INNGEST_CUTOVER_FLIP' "${DIR}/inngest-cutover-flip.sh" \
+  && ! grep -qE 'doppler secrets set INNGEST_CUTOVER_FLIP.*--token' "${DIR}/inngest-cutover-flip.sh" \
+  && pass || fail "flip flag_set must write INNGEST_CUTOVER_FLIP under the ambient boot token (no explicit --token) — else the read/write requirement above is testing the wrong credential"
+
 # 2. Separate Doppler PROJECT (AC3), not a prd branch config.
 grep -qE 'resource "doppler_project" "inngest"' "$HOST_TF" \
   && grep -qE 'name[[:space:]]*=[[:space:]]*"soleur-inngest"' "$HOST_TF" \

--- a/apps/web-platform/infra/inngest-host.tf
+++ b/apps/web-platform/infra/inngest-host.tf
@@ -193,15 +193,30 @@ resource "doppler_secret" "inngest_redis_password_dedicated" {
 # → re-set INNGEST_POSTGRES_URI in the soleur-inngest prd config.
 # ---------------------------------------------------------------------------------------
 
-# Read-only service token scoped to the isolated `soleur-inngest` project's `prd` ROOT
-# config. Handed to the inngest host cloud-init in place of the full-prd var.doppler_token.
+# Service token scoped to the isolated `soleur-inngest` project's `prd` ROOT config. Handed
+# to the inngest host cloud-init in place of the full-prd var.doppler_token.
 # `.key` is Computed/write-once (same handling as doppler_service_token.registry); rotate
 # via `terraform apply -replace=doppler_service_token.inngest`.
+#
+# access = "read/write" (was "read" — #6178). The cutover flip FSM
+# (inngest-cutover-flip.sh:flag_set) advances INNGEST_CUTOVER_FLIP on soleur-inngest/prd
+# (armed→flipping→flushed→done, or →aborted/→rolled-back) via `doppler secrets set` under
+# THIS token; the flip script comment (:78) already documented that the boot token
+# "authorizes the write". Minting it read-only was the mismatch — the flip failed loud at its
+# FIRST transition (flag_set flipping, before any Redis/systemctl action), so the dedicated
+# scheduler could never complete the flip. Blast radius is UNCHANGED at the cross-project
+# level: this token still resolves ONLY the isolated `soleur-inngest/prd` set — there is no
+# path to `soleur/prd` or any other project, so a host compromise still cannot read/write
+# foreign secrets. The residual (an inngest-server RCE could now WRITE this host's OWN
+# isolated secrets, not just read them) is tracked for a tighter split — a separate
+# root-only write token used only by the flip oneshot, keeping inngest-server's
+# deploy-readable token read-only — which needs an OCI image change (the flip .service
+# EnvironmentFile is a baked asset), deferred out of the live cutover.
 resource "doppler_service_token" "inngest" {
   project = doppler_project.inngest.name
   config  = doppler_environment.inngest_prd.slug
   name    = "inngest-boot"
-  access  = "read"
+  access  = "read/write"
 }
 
 # ---------------- The dedicated Inngest host ----------------
@@ -229,11 +244,12 @@ resource "hcloud_server" "inngest" {
     # Mount the Redis AOF volume by its specific id (by-id pattern). Known at plan time;
     # the attachment is a separate resource.
     inngest_volume_id = hcloud_volume.inngest_redis.id
-    # Scoped read-only Doppler token → 0600 root env file. The token is scoped to the
-    # ISOLATED `soleur-inngest` project's `prd` root config (a SEPARATE project — NO
-    # inheritance path to soleur/prd), so a host compromise reads ONLY the inngest secret
-    # set. NEVER baked into user_data directly beyond this scoped token (which is itself
-    # minimal-blast-radius by construction).
+    # Scoped Doppler token → 0600 root env file. read/write on the ISOLATED `soleur-inngest`
+    # project's `prd` root config (the flip FSM writes INNGEST_CUTOVER_FLIP under it — see the
+    # doppler_service_token.inngest note above, #6178). It is a SEPARATE project — NO
+    # inheritance path to soleur/prd — so a host compromise still reaches ONLY this host's own
+    # isolated secret set, never a foreign project. NEVER baked into user_data directly beyond
+    # this scoped token (which is itself minimal-blast-radius by construction).
     doppler_token = doppler_service_token.inngest.key
     # Single stable --sdk-url to the ACTIVE web backend's private interface (10.0.1.10).
     # The degenerate no-flap case of the route-once mechanism (ADR-100 Decision 1); migrate

--- a/apps/web-platform/infra/inngest-host.tf
+++ b/apps/web-platform/infra/inngest-host.tf
@@ -208,10 +208,20 @@ resource "doppler_secret" "inngest_redis_password_dedicated" {
 # level: this token still resolves ONLY the isolated `soleur-inngest/prd` set — there is no
 # path to `soleur/prd` or any other project, so a host compromise still cannot read/write
 # foreign secrets. The residual (an inngest-server RCE could now WRITE this host's OWN
-# isolated secrets, not just read them) is tracked for a tighter split — a separate
-# root-only write token used only by the flip oneshot, keeping inngest-server's
-# deploy-readable token read-only — which needs an OCI image change (the flip .service
-# EnvironmentFile is a baked asset), deferred out of the live cutover.
+# isolated secrets, not just read them) is tracked in #6890 for a tighter split — a separate
+# root-only write token used only by the root-run flip oneshot (via a cloud-init systemd
+# drop-in whose EnvironmentFile wins), keeping inngest-server's deploy-readable token
+# read-only. No OCI image change needed; deferred out of the live cutover as hardening.
+#
+# APPLY BEHAVIOR — this is NOT an in-place widen. Doppler service tokens are immutable, so
+# `access` is ForceNew: changing it destroys+recreates the token → new `.key`. That `.key`
+# feeds user_data (below), and hcloud_server.inngest carries NO ignore_changes=[user_data],
+# so `terraform apply` REPLACES the live dedicated host (destroy+recreate, re-run cloud-init,
+# re-bake the new read/write token). The Redis AOF volume survives (separate resource);
+# the flip's /var/lock state slot does not (re-derived from the Doppler flag — DBSIZE==0
+# still guards a spurious re-flush). Delivered via the #6178 apply_target=inngest-host-replace
+# dispatch; confirm `terraform plan` shows `-/+ doppler_service_token.inngest` cascading to
+# the host replacement before applying.
 resource "doppler_service_token" "inngest" {
   project = doppler_project.inngest.name
   config  = doppler_environment.inngest_prd.slug

--- a/knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md
@@ -285,8 +285,10 @@ the existing `op=rollback` verb. This removes the last operator secret-write sea
   secret rather than an environment secret because the TF GitHub App lacks permission to write
   environment secrets — a first-apply 403; the reviewer gate on the job preserves the ack either
   way. Fixed forward in #6369-followup.) This is the **first CI-consumed read/write token into the
-  isolated `soleur-inngest` project** — prior tokens there are read-only host-boot
-  (`inngest-host.tf:173`); CI can now WRITE `soleur-inngest/prd`. The token is a **standing read
+  isolated `soleur-inngest` project** — the other token there is the host-boot token
+  (`doppler_service_token.inngest`), which is also read/write as of #6178 (the flip FSM writes
+  `INNGEST_CUTOVER_FLIP` under it) but is HOST-consumed, not CI-consumed; CI can now WRITE
+  `soleur-inngest/prd` too. The token is a **standing read
   handle to the armed prod DSN** once op=arm runs, so it is revoked post-cutover.
 - **Source-of-truth: read-through, no seed (CTO decision at /work).** The two source *values*
   remain out-of-band (they are not TF `doppler_secret` resources — dark-window heartbeat masking +


### PR DESCRIPTION
## Problem (live blocker in the #6178 Phase-2 cutover)

The dedicated Inngest host's cutover flip FSM (`inngest-cutover-flip.sh` → `flag_set`) writes `INNGEST_CUTOVER_FLIP` on `soleur-inngest/prd` (`armed→flipping→flushed→done`, or `→aborted`/`→rolled-back`) via the Doppler `secrets set` write, under the host's boot token.

That token (`doppler_service_token.inngest`) was minted **`access = "read"`**. So the write fails at the **first** transition — `flag_set flipping`, which runs *before* any Redis/systemctl action — and the flip aborts immediately. The dedicated scheduler can never complete the cutover.

The flip script's own comment already documented the intent (`inngest-cutover-flip.sh:78`): *"The scoped soleur-inngest boot token (DOPPLER_TOKEN, EnvironmentFile) authorizes the write on soleur-inngest/prd."* The read-only scope was the mismatch.

**Verified live** (not inferred): `doppler configs tokens --project soleur-inngest --config prd` shows `inngest-boot = read` (the only host-delivered token); the `read/write` `inngest-cutover-arm` token is a **CI environment secret**, never delivered to the host.

Note this only surfaced now because the dedicated-host flip FSM had never run end-to-end in production — every flip test drives the `CUTOVER_FLAG_SET_CMD` fixture seam, so the real credential path was never exercised (the same fixture-vs-reality gap that hid the #6178 isolation-allowlist bug fixed in #6887).

## Fix

- `inngest-host.tf`: `doppler_service_token.inngest` access `read` → `read/write`.
- Align the three now-stale "reads ONLY / read-only" comments (`inngest-host.tf` ×2, `cloud-init-inngest.yml` ×1) and ADR-100's "prior tokens there are read-only host-boot" clause.
- `inngest-host.test.sh` **1b**: extract the token's `access` from its resource block (not a file-wide grep a comment could satisfy) and assert `read/write`; cross-check that `flag_set` writes under the ambient boot token (no explicit `--token`) so the guard tests the right credential. **Negative-tested**: reverting to `read` red-lines CI (35/0 → 34/1).

## Isolation is preserved

Cross-project isolation — the property that protects **other** systems — is **unchanged**: the token still resolves only `soleur-inngest/prd`. There is no inheritance path to `soleur/prd` or any other project, so a host compromise still cannot reach foreign secrets.

## Security tradeoff (please weigh in)

`read/write` on the **deploy-readable** boot token means an `inngest-server` RCE could now *write* this host's own isolated secrets, not just read them. The tighter fix — a **separate root-only write token** used only by the root-run flip oneshot, keeping `inngest-server`'s deploy-readable token read-only — needs an **OCI image change** (the flip `.service` `EnvironmentFile` is a baked asset) and is **deferred out of the live cutover as hardening** (follow-up to be filed). I chose the minimal in-place fix to unblock the outage; flagging it explicitly so security review can veto if the stricter split should block instead.

Ref #6178


<!-- gate-override: net-issue-flow -->
**Net-issue-flow override:** #6890 is an architectural-pivot deferral (root-only-write-token split via a systemd drop-in — its own design + review cycle) that security-sentinel explicitly CONCUR'd deferring during this PR's review. This PR unblocks a live production cutover; folding the token-split design in would block that unblock.
