### PR TITLE
fix(inngest): op=rearm registry precondition — jq // on boolean registry_empty always reads EMPTY

### DIFF
--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -325,7 +325,15 @@ jobs:
                 echo "::error::re-arm precondition: registry-probe returned HTTP $RCODE: ${CAUSE:-<empty body>}"; exit 1
               fi
               RCOUNT=$(echo "$RPROBE" | jq -r '.function_count // 0')
-              if [[ "$(echo "$RPROBE" | jq -r '.registry_empty // "true"')" != "false" ]]; then
+              # registry_empty is a BOOLEAN. Do NOT use `.registry_empty // "true"`: jq's `//`
+              # treats boolean `false` as empty and returns the RHS, so `false // "true"` = "true"
+              # — i.e. a HEALTHY non-empty registry (registry_empty:false) reads as EMPTY and this
+              # precondition can never pass against the real post-2.4 backend (#6178). Read the
+              # boolean directly, behind a has() presence guard (fail-closed on a malformed body).
+              # This is the exact shape op=verify already uses (:1062-1063) — the comment there
+              # calls this "mirror of the op=rearm guard"; the two had drifted.
+              if ! echo "$RPROBE" | jq -e 'type=="object" and has("registry_empty")' >/dev/null 2>&1 \
+                 || [[ "$(echo "$RPROBE" | jq -r '.registry_empty')" != "false" ]]; then
                 echo "::error::re-arm precondition FAILED (P1-9/P2-17): dedicated registry is EMPTY (function_count=$RCOUNT). 2.4 app-repoint has not landed — refusing to re-arm against a backend with no registered functions. Complete 2.4 (repoint INNGEST_BASE_URL → 10.0.1.40 + redeploy) then re-run op=rearm."
                 exit 1
               fi

--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -330,8 +330,8 @@ jobs:
               # — i.e. a HEALTHY non-empty registry (registry_empty:false) reads as EMPTY and this
               # precondition can never pass against the real post-2.4 backend (#6178). Read the
               # boolean directly, behind a has() presence guard (fail-closed on a malformed body).
-              # This is the exact shape op=verify already uses (:1062-1063) — the comment there
-              # calls this "mirror of the op=rearm guard"; the two had drifted.
+              # This is the exact shape op=verify's own `has("registry_empty")` precondition uses —
+              # the two guards are meant to mirror each other and had drifted (op=verify's was correct).
               if ! echo "$RPROBE" | jq -e 'type=="object" and has("registry_empty")' >/dev/null 2>&1 \
                  || [[ "$(echo "$RPROBE" | jq -r '.registry_empty')" != "false" ]]; then
                 echo "::error::re-arm precondition FAILED (P1-9/P2-17): dedicated registry is EMPTY (function_count=$RCOUNT). 2.4 app-repoint has not landed — refusing to re-arm against a backend with no registered functions. Complete 2.4 (repoint INNGEST_BASE_URL → 10.0.1.40 + redeploy) then re-run op=rearm."

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -500,9 +500,13 @@ assert "#6617 doublefire-probe carries the 2.6 scope caveat" "grep -qF 'NOT a we
 # boolean directly behind a has() guard. Assert the anti-pattern is absent anywhere in the WF. ---
 # Strip shell-comment lines first — the fix's own explanatory comment quotes the anti-pattern
 # as the thing NOT to do (cq-assert-anchor-not-bare-token), so a raw file-wide grep false-matches
-# the documentation. Anchor on the actual `jq ... '.registry_empty //` invocation shape.
+# the documentation. Then match `.registry_empty` immediately followed by jq `//` ANYWHERE on a
+# real line — quote-style-agnostic and leading-whitespace-tolerant (a narrower `jq...'` anchor is
+# evaded by ` .registry_empty`, a double-quoted program, or a pipe prefix). No legitimate line
+# reads this boolean with `//`; the only correct read is bare `.registry_empty`. (Single-line
+# only — a jq program split across lines is an accepted residual gap, not a realistic hand-edit.)
 assert "no jq '//'-on-boolean read of registry_empty (false // x == x bug, #6178)" \
-  "! grep -vE '^[[:space:]]*#' '$WF' | grep -qE \"jq[^']*'\.registry_empty[[:space:]]*//\""
+  "! grep -vE '^[[:space:]]*#' '$WF' | grep -qE '\.registry_empty[[:space:]]*//'"
 # And assert BOTH consumer preconditions read the boolean directly (parity — they had drifted).
 assert "registry_empty read directly (bare, no //) at least twice (op=rearm + op=verify)" \
   "[[ \"\$(grep -cE \"jq -r '\.registry_empty'\" '$WF')\" -ge 2 ]]"

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -493,6 +493,20 @@ assert "#6617 neither probe op appears in the environment: expression" "! grep -
 # --- Scope caveat carried verbatim from op=verify 2.6 (B-AC7) ---
 assert "#6617 doublefire-probe carries the 2.6 scope caveat" "grep -qF 'NOT a web-2 double-fire detector' '$PROBE_ARMS_FILE'"
 
+# --- (#6178) registry_empty is a BOOLEAN — never read it with jq `//`. `false // "true"` = "true"
+# in jq (it treats boolean false as empty), so `.registry_empty // "<default>"` makes a HEALTHY
+# non-empty registry (registry_empty:false) read as EMPTY, and the op=rearm/op=verify
+# precondition can NEVER pass against the real post-2.4 backend. The correct shape reads the
+# boolean directly behind a has() guard. Assert the anti-pattern is absent anywhere in the WF. ---
+# Strip shell-comment lines first — the fix's own explanatory comment quotes the anti-pattern
+# as the thing NOT to do (cq-assert-anchor-not-bare-token), so a raw file-wide grep false-matches
+# the documentation. Anchor on the actual `jq ... '.registry_empty //` invocation shape.
+assert "no jq '//'-on-boolean read of registry_empty (false // x == x bug, #6178)" \
+  "! grep -vE '^[[:space:]]*#' '$WF' | grep -qE \"jq[^']*'\.registry_empty[[:space:]]*//\""
+# And assert BOTH consumer preconditions read the boolean directly (parity — they had drifted).
+assert "registry_empty read directly (bare, no //) at least twice (op=rearm + op=verify)" \
+  "[[ \"\$(grep -cE \"jq -r '\.registry_empty'\" '$WF')\" -ge 2 ]]"
+
 rm -f "$ARM_FILE" "$ROLLBACK_FILE" "$CONFIRM_FILE" "$FWD_ARM_FILE" "$TAIL_FILE" "$PROBE_ARMS_FILE"
 
 echo ""


### PR DESCRIPTION
## Problem (blocks the final #6178 cutover step)

`op=rearm`'s registry-non-empty precondition read:

```
if [[ "$(echo "$RPROBE" | jq -r '.registry_empty // "true"')" != "false" ]]; then  # FAILED
```

In jq the `//` operator treats boolean **`false` as empty** and returns the RHS, so `false // "true"` = `"true"`. `registry_empty:false` is the **healthy, non-empty** state (the exact post-2.4 backend), so the precondition read it as `"true"` (empty) and **could never pass**. Live symptom during the cutover: `op=rearm` failed-loud with the self-contradictory `dedicated registry is EMPTY (function_count=68)`, and the 1 captured reminder could not be re-armed onto `10.0.1.40`.

```
$ echo '{"registry_empty": false}' | jq -r '.registry_empty // "true"'
true      # ← the bug
```

The standalone `op=registry-probe` (`:221`) reads `.registry_empty` bare and correctly returns `false` — which is why manual probes looked healthy while `op=rearm` failed.

## Fix

Match `op=verify`'s mirror precondition (`:1062-1063`), which already reads the boolean correctly (`has("registry_empty")` presence guard + bare `.registry_empty`, no `//`). A comment there even calls it *"mirror of the op=rearm guard"* — the two had drifted. Now `registry_empty:false` → PASS, `true` → FAIL, missing/malformed → FAIL (fail-closed).

This is the **5th** break in the #6178 cutover that surfaced only by running the mechanism end-to-end — every cutover test uses fixtures/seams that bypass the real path.

## Guard

`cutover-inngest-workflow.test.sh`: asserts (a) no `jq … '.registry_empty //` anti-pattern anywhere (comment-stripped so the fix's own explanatory prose doesn't false-match — `cq-assert-anchor-not-bare-token`), and (b) `registry_empty` is read bare ≥2× (rearm + verify parity). **Negative-tested**: reintroducing the bug on a real line red-lines. 227 passed / 0 failed.

Ref #6178
