### PR TITLE
fix(web-platform): mobile layout polish round 1 (Phase 3 follow-up)

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -591,6 +591,7 @@ export default function DashboardLayout({
                 navigates to /dashboard, which auto-closes the drawer. */}
             <Link
               href="/dashboard"
+              data-testid="drawer-back-to-menu"
               className="mx-3 mt-3 flex min-h-[44px] shrink-0 items-center gap-3 rounded-lg px-3 py-2 text-sm text-soleur-text-muted hover:bg-soleur-bg-surface-2/60 hover:text-soleur-text-secondary md:hidden"
             >
               <svg

--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -325,11 +325,14 @@ export default function DashboardLayout({
         <WorkspaceContextBand
           pathname={pathname}
           variant="mobile"
-          suppressBack={inKbDocView}
-          // KB owns its "Knowledge Base" title in the page body on mobile
-          // (kb/layout fullWidth header), so the mobile band drops the duplicate
-          // section title. Settings/Chat keep theirs (KB-scoped).
-          suppressSectionTitle={drill === "kb"}
+          // On mobile the "Back to menu" affordance lives INSIDE the hamburger
+          // drawer's drilled branch (below), so the band never renders its own —
+          // avoids a redundant top-level chrome row when drilled.
+          suppressBack={drill !== null}
+          // KB owns its "Knowledge Base" title in the page body, and the chat
+          // surface owns its own mobile header (back + Approve/Connected), so
+          // both drop the duplicate band section title (was 3 stacked bars).
+          suppressSectionTitle={drill === "kb" || drill === "chat"}
         />
         {/* The only non-keyboard way to open the command palette. `ml-auto`
             pins it to the trailing edge; self-hides when the flag is off. */}
@@ -581,11 +584,37 @@ export default function DashboardLayout({
             </div>
           </>
         ) : (
-          <div
-            ref={setRailSlotEl}
-            data-testid="rail-secondary-slot"
-            className="flex min-h-0 flex-1 flex-col overflow-y-auto"
-          />
+          <>
+            {/* Mobile-only "Back to menu": the mobile band suppresses its own
+                back when drilled, so the drawer owns it here. Hidden on desktop
+                (the desktop rail band renders the back affordance). Tapping it
+                navigates to /dashboard, which auto-closes the drawer. */}
+            <Link
+              href="/dashboard"
+              className="mx-3 mt-3 flex min-h-[44px] shrink-0 items-center gap-3 rounded-lg px-3 py-2 text-sm text-soleur-text-muted hover:bg-soleur-bg-surface-2/60 hover:text-soleur-text-secondary md:hidden"
+            >
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                className="shrink-0"
+              >
+                <polyline points="15 18 9 12 15 6" />
+              </svg>
+              Back to menu
+            </Link>
+            <div
+              ref={setRailSlotEl}
+              data-testid="rail-secondary-slot"
+              className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+            />
+          </>
         )}
 
         {/* Widenable rail: a right-edge drag handle rendered in EVERY state —

--- a/apps/web-platform/components/analytics/analytics-dashboard.tsx
+++ b/apps/web-platform/components/analytics/analytics-dashboard.tsx
@@ -133,7 +133,7 @@ function FunnelSection({ funnel }: { funnel: FunnelResult }) {
   const maxCount = Math.max(...funnel.stages.map((s) => s.count), 1);
 
   return (
-    <section className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-6 space-y-3">
+    <section className="rounded-xl border border-soleur-border-default bg-soleur-bg-surface-1/50 p-4 space-y-3 sm:p-6">
       <h2 className="text-sm font-medium text-soleur-text-muted uppercase tracking-wider">
         Activation funnel
       </h2>
@@ -143,7 +143,7 @@ function FunnelSection({ funnel }: { funnel: FunnelResult }) {
           const widthPct = Math.round((stage.count / maxCount) * 100);
           return (
             <div key={stage.key} className="flex items-center gap-3">
-              <div className="w-36 shrink-0 text-sm text-soleur-text-secondary flex items-center gap-1.5">
+              <div className="w-24 shrink-0 text-sm text-soleur-text-secondary flex items-center gap-1.5 sm:w-36">
                 {stage.label}
                 {isActivated && (
                   <span
@@ -165,7 +165,7 @@ function FunnelSection({ funnel }: { funnel: FunnelResult }) {
               <div className="w-12 shrink-0 text-right text-sm text-soleur-text-primary tabular-nums">
                 {stage.count}
               </div>
-              <div className="w-16 shrink-0 text-right text-xs text-soleur-text-muted tabular-nums">
+              <div className="w-12 shrink-0 text-right text-xs text-soleur-text-muted tabular-nums sm:w-16">
                 {/* Only a percentage drop gets a leading minus; the zero-prior
                     "—" sentinel and the first stage (null) stand alone. */}
                 {stage.dropoffLabel === null
@@ -307,7 +307,7 @@ export function AnalyticsDashboard({
 
   if (metrics.length === 0) {
     return (
-      <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
+      <div className="mx-auto max-w-6xl px-4 py-6 space-y-6 sm:px-6 sm:py-8">
         <h1 className="text-2xl font-semibold text-soleur-text-primary">Analytics</h1>
         <FunnelSection funnel={funnel} />
       </div>
@@ -315,7 +315,7 @@ export function AnalyticsDashboard({
   }
 
   return (
-    <div className="mx-auto max-w-6xl px-6 py-8 space-y-6">
+    <div className="mx-auto max-w-6xl px-4 py-6 space-y-6 sm:px-6 sm:py-8">
       <h1 className="text-2xl font-semibold text-soleur-text-primary">Analytics</h1>
       <p className="text-sm text-soleur-text-muted">
         P4 validation metrics — {metrics.length} user{metrics.length !== 1 ? "s" : ""}

--- a/apps/web-platform/components/chat/chat-surface.tsx
+++ b/apps/web-platform/components/chat/chat-surface.tsx
@@ -741,11 +741,11 @@ export function ChatSurface({
     <div className={rootClass}>
       {isFull && (
         <header className="flex shrink-0 items-center justify-between border-b border-soleur-border-default px-4 py-3 md:px-6">
-          <div className="flex items-center gap-3">
+          <div className="flex min-w-0 items-center gap-3">
             <a
               href="/dashboard"
               aria-label="Back to dashboard"
-              className="flex items-center text-soleur-text-secondary hover:text-soleur-text-primary md:hidden"
+              className="flex shrink-0 items-center text-soleur-text-secondary hover:text-soleur-text-primary md:hidden"
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="15 18 9 12 15 6" />
@@ -753,7 +753,7 @@ export function ChatSurface({
             </a>
 
             {activeLeaderIds.length > 0 && (
-              <span className="text-sm text-soleur-text-secondary md:hidden">
+              <span className="min-w-0 truncate text-sm text-soleur-text-secondary md:hidden">
                 {activeLeaderIds.map((id) => getDisplayName(id)).join(", ")} responding
               </span>
             )}
@@ -762,7 +762,7 @@ export function ChatSurface({
               Dashboard
             </span>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex shrink-0 items-center gap-3">
             <AutoRunChip autonomous={autonomousPosture} />
             <StatusIndicator status={status} disconnectReason={disconnectReason} />
           </div>

--- a/apps/web-platform/components/routines/routines-surface.tsx
+++ b/apps/web-platform/components/routines/routines-surface.tsx
@@ -244,7 +244,7 @@ function DraftRoutineTab() {
           it, and shows you the result — then opens a PR you approve. It can also
           run and verify routines you already have.
         </p>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        <div className="mt-3 hidden gap-3 sm:grid sm:grid-cols-2">
           <div className="rounded border border-soleur-border-default bg-soleur-bg-surface-1 p-3">
             <div className="text-xs font-medium text-soleur-text-primary">
               Draft a new routine
@@ -274,7 +274,7 @@ function DraftRoutineTab() {
             </span>
           ))}
         </div>
-        <p className="mt-2 text-[11px] text-soleur-text-muted">
+        <p className="mt-2 hidden text-[11px] text-soleur-text-muted sm:block">
           New routines ship as code — the Concierge drafts and tests; you approve
           the PR; it goes live on merge + deploy.
         </p>
@@ -284,6 +284,7 @@ function DraftRoutineTab() {
           variant="sidebar"
           conversationId="new"
           initialContext={{ type: "routine-authoring" }}
+          sidebarProps={{ placeholder: "Describe a routine…" }}
         />
       </div>
     </div>
@@ -435,7 +436,7 @@ function RoutineRow({
 }) {
   const last = item.lastRun;
   return (
-    <li className="flex items-center gap-4 px-4 py-3">
+    <li className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
       <div className="min-w-0 flex-1">
         <button
           type="button"
@@ -463,7 +464,7 @@ function RoutineRow({
           )}
         </div>
       </div>
-      <div className="w-40 text-right text-xs">
+      <div className="w-full text-left text-xs sm:w-40 sm:text-right">
         {last ? (
           <>
             <StatusPill status={last.status} />

--- a/apps/web-platform/components/settings/connected-services-content.tsx
+++ b/apps/web-platform/components/settings/connected-services-content.tsx
@@ -86,14 +86,14 @@ function ProviderCard({
           : "border-soleur-border-default"
       }`}
     >
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
           <div
-            className={`h-2 w-2 rounded-full ${
+            className={`h-2 w-2 shrink-0 rounded-full ${
               connected ? "bg-green-400" : "bg-soleur-bg-surface-2"
             }`}
           />
-          <div>
+          <div className="min-w-0">
             <span className="text-sm font-medium text-soleur-text-primary">{config.label}</span>
             {connected && validatedAt && (
               <span className="ml-2 text-xs text-soleur-text-muted">
@@ -102,7 +102,7 @@ function ProviderCard({
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {connected ? (
             <>
               <button

--- a/apps/web-platform/components/settings/conversation-names-settings.tsx
+++ b/apps/web-platform/components/settings/conversation-names-settings.tsx
@@ -199,7 +199,7 @@ function LeaderRow({
         </button>
       )}
       <span className="min-w-0 flex-1 text-sm text-soleur-text-secondary">{title}</span>
-      <div className="w-48">
+      <div className="w-full max-w-[12rem]">
         <input
           type="text"
           value={value}

--- a/apps/web-platform/components/settings/settings-shell.tsx
+++ b/apps/web-platform/components/settings/settings-shell.tsx
@@ -135,7 +135,7 @@ export function SettingsShell({
       </RailSlotPortal>
 
       {/* Content area */}
-      <div className="relative flex-1 px-4 py-10 md:px-10">
+      <div className="relative min-w-0 flex-1 overflow-x-hidden px-4 py-10 md:px-10">
         <div className="mx-auto max-w-2xl">{children}</div>
       </div>
     </div>

--- a/apps/web-platform/components/ui/responsive-modal.tsx
+++ b/apps/web-platform/components/ui/responsive-modal.tsx
@@ -125,7 +125,7 @@ export function ResponsiveModal({
 
   const panelClasses = isDesktop
     ? `w-full ${desktopMaxWidth} rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 p-6 shadow-xl`
-    : "max-h-[90vh] w-full overflow-y-auto rounded-t-2xl border-t border-soleur-border-default bg-soleur-bg-surface-1 px-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-3 shadow-2xl";
+    : "relative max-h-[90vh] w-full overflow-y-auto rounded-t-2xl border-t border-soleur-border-default bg-soleur-bg-surface-1 px-5 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-3 shadow-2xl";
 
   const node = (
     <div
@@ -151,10 +151,39 @@ export function ResponsiveModal({
         className={`${panelClasses} ${panelClassName} focus:outline-none`.trim()}
       >
         {!isDesktop && (
-          <div
-            aria-hidden="true"
-            className="mx-auto mb-3 h-1.5 w-10 shrink-0 rounded-full bg-soleur-bg-surface-2"
-          />
+          // Sticky sheet header: drag-handle affordance + an always-reachable
+          // Close button (pinned as the sheet scrolls). Without this a sheet
+          // with `closeOnBackdrop={false}` and no in-body X (e.g. new-issue) is
+          // undismissable on touch.
+          <div className="sticky top-0 z-10 -mx-5 mb-2 flex items-center justify-center bg-soleur-bg-surface-1 px-5 pb-2 pt-1">
+            <div
+              aria-hidden="true"
+              className="h-1.5 w-10 rounded-full bg-soleur-bg-surface-2"
+            />
+            {onClose && (
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="absolute right-1 top-0 inline-flex h-11 w-11 items-center justify-center rounded-full text-soleur-text-muted transition-colors hover:text-soleur-text-primary"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            )}
+          </div>
         )}
         {children}
       </div>

--- a/apps/web-platform/components/workstream/issue-card.tsx
+++ b/apps/web-platform/components/workstream/issue-card.tsx
@@ -30,7 +30,7 @@ export function IssueCard({
       <p className="mt-1 line-clamp-2 text-sm text-soleur-text-primary">
         {issue.title}
       </p>
-      <div className="mt-3 flex items-center justify-between gap-2">
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-2">
           {live && (
             <span className="inline-flex items-center gap-1 text-[11px] font-medium text-green-400">

--- a/apps/web-platform/components/workstream/issue-detail-sheet.tsx
+++ b/apps/web-platform/components/workstream/issue-detail-sheet.tsx
@@ -391,7 +391,7 @@ export function IssueDetailSheet({
             </div>
 
             <div className="min-h-0 flex-1 overflow-y-auto p-4">
-              <dl className="space-y-3 text-sm">
+              <dl className="space-y-4 text-sm">
                 <Row label="Status">
                   {statusDisabled ? (
                     <span className={statusPillClass(issue.status)}>
@@ -704,7 +704,7 @@ export function IssueDetailSheet({
 
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-3">
+    <div className="flex items-center justify-between gap-3 py-0.5">
       <dt className="text-soleur-text-tertiary">{label}</dt>
       <dd className="text-right">{children}</dd>
     </div>

--- a/apps/web-platform/components/workstream/mobile-status-selector.tsx
+++ b/apps/web-platform/components/workstream/mobile-status-selector.tsx
@@ -47,7 +47,7 @@ export function MobileStatusSelector({
       role="tablist"
       aria-label="Workstream status"
       aria-orientation="horizontal"
-      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1"
+      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-28px),transparent)]"
       onKeyDown={(e) => {
         if (e.key === "ArrowRight") {
           e.preventDefault();

--- a/apps/web-platform/components/workstream/mobile-status-selector.tsx
+++ b/apps/web-platform/components/workstream/mobile-status-selector.tsx
@@ -47,7 +47,7 @@ export function MobileStatusSelector({
       role="tablist"
       aria-label="Workstream status"
       aria-orientation="horizontal"
-      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [mask-image:linear-gradient(to_right,black_calc(100%-28px),transparent)]"
+      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [mask-image:linear-gradient(to_right,black_calc(100%_-_28px),transparent)]"
       onKeyDown={(e) => {
         if (e.key === "ArrowRight") {
           e.preventDefault();

--- a/apps/web-platform/test/nav-rail-drill.test.tsx
+++ b/apps/web-platform/test/nav-rail-drill.test.tsx
@@ -251,7 +251,10 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
     expect(within(rail).getByTestId("nav-back-chevron")).toBeInTheDocument();
   });
 
-  it("KB landing (not doc view): the mobile band STILL shows 'Back to menu' (it is the only back there)", () => {
+  it("KB landing: mobile band back is suppressed — 'Back to menu' moved into the hamburger drawer", () => {
+    // The mobile band no longer renders its own back in any drilled state; the
+    // drilled drawer branch owns a single mobile-only "Back to menu" link, and
+    // the desktop rail band keeps its back affordance.
     mockPathname = "/dashboard/kb";
     render(
       <Wrap>
@@ -260,10 +263,13 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
         </DashboardLayout>
       </Wrap>,
     );
-    const { mobile } = bandsByVariant();
+    const { mobile, rail } = bandsByVariant();
     expect(
-      within(mobile).getByTestId("nav-back-chevron"),
-    ).toBeInTheDocument();
+      within(mobile).queryByTestId("nav-back-chevron"),
+    ).not.toBeInTheDocument();
+    expect(within(rail).getByTestId("nav-back-chevron")).toBeInTheDocument();
+    // The drilled drawer branch owns a mobile-only "Back to menu" link.
+    expect(screen.getByTestId("drawer-back-to-menu")).toBeInTheDocument();
   });
 
   // Phase 4 (#4915): on mobile KB the page body owns the "Knowledge Base" title,


### PR DESCRIPTION
## Summary

Mobile layout polish from device-mode testing of the Phase 3 surfaces (#6903) on prod. Presentation-only; desktop unchanged. `brand_survival_threshold: aggregate pattern`.

Fixes reported issues:
- **New-issue modal undismissable on touch** → `ResponsiveModal` now renders an always-reachable **Close (X)** in a sticky sheet header (benefits all 7 sheet modals).
- **Workstream** — issue-card footer chips overlapping → `flex-wrap`; status selector "cut off" → right-edge fade affordance.
- **Routines** — routine-list row text overlapping → stacks vertically on mobile; Concierge draft tab explainer hidden below `sm` + short composer placeholder.
- **Analytics** — funnel bar/cards crushed → reduced mobile padding + narrower funnel label.
- **Settings** — horizontal page scroll → `min-w-0 overflow-x-hidden` on the shell + fixes to the fixed-width name input and connected-services rows.
- **Chat** — 3 stacked header bars → drop the redundant band back/title on mobile (chat owns its header); header text clipping → `min-w-0`/`truncate`/`shrink-0`.
- **Chrome** — "Back to menu" moved **into the hamburger drawer** (mobile-only); band suppresses its own back when drilled.

## Deferred (own careful pass)
- **KB mobile drill-in nav** — collides with ADR-047 single-mount (tree is portaled to the rail); needs a single-mount-safe design + visual verification.
- **Guided tour mobile** — spotlight is disabled <768px and step copy references drawer-hidden UI; an IA rethink that warrants a wireframe pass.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 99 affected tests green (dashboard-layout, workstream, routines, analytics, settings, modals)
- [ ] Operator device-mode re-test on prod

## Changelog
fix(web-platform): mobile layout polish — modal dismiss control, overlap/overflow fixes, chat/nav chrome (desktop unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
