### PR TITLE
fix(web-platform): mobile layout polish round 2 (drawer switcher, KB empty-state, overlaps)

### DIFF
--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -246,12 +246,16 @@ export default function DashboardLayout({
   useEffect(() => {
     function handleExpandRequest() {
       // An "expand request" must always yield a VISIBLE nav surface. On desktop
-      // that means un-collapsing the rail; on mobile the nav is the hamburger
-      // drawer, so also open it (a no-op on desktop, where the aside is the
-      // always-visible rail). The KB mobile empty-state "Browse files" button
-      // relies on the drawer-open half.
+      // that means un-collapsing the rail. On mobile the nav is the hamburger
+      // drawer, so open it too. Guard the open to mobile: `drawerOpen` also
+      // drives `<main inert>` + body scroll-lock (both viewport-independent), and
+      // this event has desktop dispatchers (the guided tour's startTour, the
+      // desktop collapsed-rail "Browse files" button) — opening the drawer on
+      // desktop would freeze the content pane until the next route change.
       if (collapsed) toggleCollapsed();
-      setDrawerOpen(true);
+      if (!window.matchMedia("(min-width: 768px)").matches) {
+        setDrawerOpen(true);
+      }
     }
     window.addEventListener(RAIL_EXPAND_EVENT, handleExpandRequest);
     return () =>

--- a/apps/web-platform/app/(dashboard)/layout.tsx
+++ b/apps/web-platform/app/(dashboard)/layout.tsx
@@ -245,10 +245,13 @@ export default function DashboardLayout({
   // collapses), so a stray dispatch while expanded is a no-op.
   useEffect(() => {
     function handleExpandRequest() {
-      // An "expand request" must always yield a VISIBLE (expanded) rail. The only
-      // dispatcher today is the KB "Browse files" button; this keeps any future
-      // out-of-aside dispatcher (command palette, deep link) working too.
+      // An "expand request" must always yield a VISIBLE nav surface. On desktop
+      // that means un-collapsing the rail; on mobile the nav is the hamburger
+      // drawer, so also open it (a no-op on desktop, where the aside is the
+      // always-visible rail). The KB mobile empty-state "Browse files" button
+      // relies on the drawer-open half.
       if (collapsed) toggleCollapsed();
+      setDrawerOpen(true);
     }
     window.addEventListener(RAIL_EXPAND_EVENT, handleExpandRequest);
     return () =>
@@ -319,21 +322,9 @@ export default function DashboardLayout({
         >
           <MenuIcon className="h-5 w-5" />
         </button>
-        {/* Mobile band — placed via CSS (this bar is `md:hidden`), NOT a JS
-            viewport gate, so workspace identity + the back chevron paint on the
-            FIRST frame (no SSR/hydration tick where identity is absent). */}
-        <WorkspaceContextBand
-          pathname={pathname}
-          variant="mobile"
-          // On mobile the "Back to menu" affordance lives INSIDE the hamburger
-          // drawer's drilled branch (below), so the band never renders its own —
-          // avoids a redundant top-level chrome row when drilled.
-          suppressBack={drill !== null}
-          // KB owns its "Knowledge Base" title in the page body, and the chat
-          // surface owns its own mobile header (back + Approve/Connected), so
-          // both drop the duplicate band section title (was 3 stacked bars).
-          suppressSectionTitle={drill === "kb" || drill === "chat"}
-        />
+        {/* Workspace identity now lives at the TOP of the hamburger drawer (the
+            switcher belongs in the sidebar), so the top bar stays minimal:
+            hamburger on the left, palette trigger on the right. */}
         {/* The only non-keyboard way to open the command palette. `ml-auto`
             pins it to the trailing edge; self-hides when the flag is off. */}
         <MobilePaletteTrigger />
@@ -397,6 +388,21 @@ export default function DashboardLayout({
           >
             <XIcon className="h-5 w-5" />
           </button>
+        </div>
+
+        {/* Workspace switcher at the top of the mobile drawer. CSS-exclusive
+            with the desktop rail band below (`hidden md:block`), so the
+            OrgSwitcher/LiveRepoBadge single-mount (AC4b) is preserved — exactly
+            one band renders per breakpoint. The drawer owns its own "Back to
+            menu" (drilled branch) and needs no section title, so both are
+            suppressed here. */}
+        <div className="px-3 pb-1 md:hidden">
+          <WorkspaceContextBand
+            pathname={pathname}
+            variant="mobile"
+            suppressBack
+            suppressSectionTitle
+          />
         </div>
 
         {/* Collapse/expand toggle — the floated « chevron. Collapses the rail to

--- a/apps/web-platform/components/analytics/analytics-dashboard.tsx
+++ b/apps/web-platform/components/analytics/analytics-dashboard.tsx
@@ -146,9 +146,12 @@ function FunnelSection({ funnel }: { funnel: FunnelResult }) {
               <div className="w-24 shrink-0 text-sm text-soleur-text-secondary flex items-center gap-1.5 sm:w-36">
                 {stage.label}
                 {isActivated && (
+                  // Hidden on mobile: the narrow label column can't fit the
+                  // badge without overlapping the funnel bar. The gold bar + the
+                  // activation-definition text below already convey it.
                   <span
                     title={funnel.activationDef}
-                    className="text-[10px] font-semibold text-soleur-accent-gold-fg border border-soleur-accent-gold-fg/50 rounded px-1 cursor-help"
+                    className="hidden text-[10px] font-semibold text-soleur-accent-gold-fg border border-soleur-accent-gold-fg/50 rounded px-1 cursor-help sm:inline"
                   >
                     SUCCESS METRIC
                   </span>

--- a/apps/web-platform/components/kb/kb-doc-shell.tsx
+++ b/apps/web-platform/components/kb/kb-doc-shell.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import { DesktopPlaceholder, KbErrorBoundary } from "@/components/kb";
+import { RAIL_EXPAND_EVENT } from "@/components/dashboard/rail-slot";
 
 interface KbDocShellProps {
   children: ReactNode;
@@ -18,7 +19,35 @@ export function KbDocShell({ children, isContentView }: KbDocShellProps) {
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
       <KbErrorBoundary>
-        {isContentView ? children : <DesktopPlaceholder />}
+        {isContentView ? (
+          children
+        ) : (
+          <>
+            {/* Desktop: the tree is in the always-visible rail, so a passive
+                placeholder suffices. Mobile: the tree lives in the hamburger
+                drawer, so the content pane would be BLANK — show a visible
+                empty state with a button that opens the drawer to the file
+                tree (via RAIL_EXPAND_EVENT, handled in the dashboard layout). */}
+            <DesktopPlaceholder />
+            <div className="flex h-full flex-col items-center justify-center px-6 text-center md:hidden">
+              <p className="text-sm text-soleur-text-secondary">
+                Open a file to see it here
+              </p>
+              <p className="mt-1 text-xs text-soleur-text-muted">
+                Browse the Knowledge Base directory to pick a file.
+              </p>
+              <button
+                type="button"
+                onClick={() =>
+                  window.dispatchEvent(new CustomEvent(RAIL_EXPAND_EVENT))
+                }
+                className="mt-4 min-h-11 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-2 text-sm text-soleur-text-primary hover:bg-soleur-bg-surface-2"
+              >
+                Browse files
+              </button>
+            </div>
+          </>
+        )}
       </KbErrorBoundary>
     </div>
   );

--- a/apps/web-platform/components/routines/routines-surface.tsx
+++ b/apps/web-platform/components/routines/routines-surface.tsx
@@ -385,7 +385,7 @@ function RoutinesTab() {
             {domain}{" "}
             <span className="ml-1 text-soleur-text-muted/70">{items.length}</span>
           </h2>
-          <ul className="divide-y divide-soleur-border-default rounded-lg border border-soleur-border-default">
+          <ul className="space-y-2 sm:space-y-0 sm:divide-y sm:divide-soleur-border-default sm:rounded-lg sm:border sm:border-soleur-border-default">
             {items.map((item) => (
               <RoutineRow
                 key={item.fnId}
@@ -436,7 +436,7 @@ function RoutineRow({
 }) {
   const last = item.lastRun;
   return (
-    <li className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:gap-4">
+    <li className="flex flex-col gap-2 rounded-lg border border-soleur-border-default bg-soleur-bg-surface-1 px-4 py-3 sm:flex-row sm:items-center sm:gap-4 sm:rounded-none sm:border-0 sm:bg-transparent">
       <div className="min-w-0 flex-1">
         <button
           type="button"

--- a/apps/web-platform/components/workstream/mobile-status-selector.tsx
+++ b/apps/web-platform/components/workstream/mobile-status-selector.tsx
@@ -47,7 +47,7 @@ export function MobileStatusSelector({
       role="tablist"
       aria-label="Workstream status"
       aria-orientation="horizontal"
-      className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1 [mask-image:linear-gradient(to_right,black_calc(100%_-_28px),transparent)]"
+      className="-mx-1 flex gap-2 overflow-x-auto px-1 py-1.5 [mask-image:linear-gradient(to_right,black_calc(100%_-_28px),transparent)]"
       onKeyDown={(e) => {
         if (e.key === "ArrowRight") {
           e.preventDefault();

--- a/apps/web-platform/components/workstream/new-issue-dialog.tsx
+++ b/apps/web-platform/components/workstream/new-issue-dialog.tsx
@@ -81,7 +81,7 @@ export function NewIssueDialog({
       onClose={() => {
         if (!inFlight.current) onClose();
       }}
-      closeOnBackdrop={false}
+      closeOnBackdrop={true}
       desktopMaxWidth="max-w-md"
       aria-label="New issue"
     >

--- a/apps/web-platform/test/nav-rail-drill.test.tsx
+++ b/apps/web-platform/test/nav-rail-drill.test.tsx
@@ -291,7 +291,10 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
     expect(within(rail).getByTestId("nav-section-title")).toBeInTheDocument();
   });
 
-  it("Settings: the mobile band section title is NOT suppressed (KB-scoped)", () => {
+  it("Settings: the mobile band is switcher-only — no section title in any state (page body owns it); rail band keeps it", () => {
+    // The mobile band moved into the hamburger drawer as a workspace-switcher-
+    // only band (suppressBack + suppressSectionTitle), so it no longer carries a
+    // section title for ANY drill; the page body's own title provides context.
     mockPathname = "/dashboard/settings";
     render(
       <Wrap>
@@ -300,10 +303,11 @@ describe("Single nav rail — URL-derived drill swap (AC3/AC4c)", () => {
         </DashboardLayout>
       </Wrap>,
     );
-    const { mobile } = bandsByVariant();
+    const { mobile, rail } = bandsByVariant();
     expect(
-      within(mobile).getByTestId("nav-section-title"),
-    ).toBeInTheDocument();
+      within(mobile).queryByTestId("nav-section-title"),
+    ).not.toBeInTheDocument();
+    expect(within(rail).getByTestId("nav-section-title")).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

Mobile layout polish round 2, from operator device-mode re-testing of #6915 on prod. Presentation-only; desktop unchanged. `brand_survival_threshold: aggregate pattern`.

- **Workspace switcher → top of the hamburger drawer** (mobile). Top bar is now minimal (hamburger + palette). The band is switcher-only in the drawer (suppresses back + section title; page H1 owns the section name, drilled branch owns "Back to menu"). CSS-exclusive with the desktop rail band → OrgSwitcher single-mount (AC4b) preserved. `nav-rail-drill` contract tests updated.
- **KB mobile blank pane** → visible empty state ("Open a file to see it here") + a **"Browse files"** button that opens the drawer to the file tree (`RAIL_EXPAND_EVENT` now also opens the mobile drawer).
- **New issue** → tap-outside-to-close re-enabled (`closeOnBackdrop`), plus the round-1 sheet ✕.
- **Workstream** → status-selector selected-pill ring was clipped by `overflow-x-auto` (forces `overflow-y:auto`); `pb-1` → `py-1.5`.
- **Routines** → distinct bordered card per routine on mobile (was blended divide-y rows).
- **Analytics** → "SUCCESS METRIC" badge overflowed the narrow funnel label into the bar → hidden on mobile.

## Deferred (own careful pass)
- KB full inline drill-in tree (ADR-047 single-mount) — this PR does the "open the drawer to the tree" fallback the operator explicitly accepted.
- Guided tour mobile IA (needs a wireframe).

## Test plan
- [x] `tsc --noEmit` clean
- [x] Full web-platform suite: **12612 passed, 0 failed** (1043 files)
- [ ] Operator device-mode re-test on prod

## Changelog
fix(web-platform): mobile polish — workspace switcher in drawer, KB empty-state, new-issue tap-close, selector/routines/analytics fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
