### PR TITLE
fix(inngest): doublefire-probe pagination robustness — op=verify HTTP 500 "malformed page" (#6178)

### DIFF
--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -131,6 +131,15 @@ jobs:
           # missed-ticks → re-fire → double-fire). Forwarded to the probe as the function_ids
           # URL query param (read into INNGEST_DOUBLEFIRE_FUNCTION_IDS on-host).
           CUTOVER_DOUBLEFIRE_FUNCTION_IDS: ${{ vars.CUTOVER_DOUBLEFIRE_FUNCTION_IDS }}
+          # #6919 review — the quiesce→register window (ISO-8601), OPTIONAL operator repo/env
+          # vars, mapped here so the shell actually sees them (GitHub does not export repo vars
+          # to the step unless named). When set they (a) anchor doublefire_from() to
+          # cutover_instant−200d instead of now−200d — so a LATE op=verify re-run still keeps the
+          # window ⊇ the superset invariant — and (b) enable the missed-tick auto-enumeration
+          # (P2-16, below). Unset ⇒ doublefire_from() falls back to now−200d (safe when op=verify
+          # runs promptly post-cutover, the intended usage) and missed-tick auto-enum is skipped.
+          CUTOVER_WINDOW_FROM: ${{ vars.CUTOVER_WINDOW_FROM }}
+          CUTOVER_WINDOW_UNTIL: ${{ vars.CUTOVER_WINDOW_UNTIL }}
         run: |
           set -euo pipefail
           BASE="https://deploy.soleur.ai/hooks"

--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -122,6 +122,15 @@ jobs:
           # Error direction matters: a period LARGER than the real shortest cron
           # collapses legitimate runs into one bucket and reports a PHANTOM double-fire.
           CUTOVER_CRON_PERIOD_SECONDS: ${{ inputs.cron_period_seconds }}
+          # #6919 — OPTIONAL functionIDs scope for the exactly-once doublefire probe
+          # (op=verify 2.6 + op=doublefire-probe). Comma-separated cron fn UUIDs; empty ⇒ ALL
+          # functions (the default). This is the design's hard cost lever: the wide default
+          # 365-day scan over all 68 functions can exhaust the probe's per-page budget, so an
+          # operator can set the repo/env var CUTOVER_DOUBLEFIRE_FUNCTION_IDS to scope it. It is
+          # a COST lever ONLY — it never narrows the TIME window (which would surface false
+          # missed-ticks → re-fire → double-fire). Forwarded to the probe as the function_ids
+          # URL query param (read into INNGEST_DOUBLEFIRE_FUNCTION_IDS on-host).
+          CUTOVER_DOUBLEFIRE_FUNCTION_IDS: ${{ vars.CUTOVER_DOUBLEFIRE_FUNCTION_IDS }}
         run: |
           set -euo pipefail
           BASE="https://deploy.soleur.ai/hooks"
@@ -154,6 +163,29 @@ jobs:
               sleep 15
             done
             echo "timeout"; return 0
+          }
+
+          # #6919 — the doublefire probe STARTED_AT lower bound (from), forwarded to the
+          # /hooks/inngest-doublefire-probe GET as a URL query param. It NARROWS the probe's
+          # wide 365-day default (the cost lever that lets the all-function scan complete within
+          # the per-page budget — the op=verify HTTP 500 root cause) WITHOUT violating the
+          # window-superset invariant: FROM ≤ cutover_instant − 2×max_cron_period. The longest
+          # repo cron is QUARTERLY, so 2×max_cron_period ≈ 182d; we pass cutover − 200d (18d skew
+          # headroom). cutover_instant proxy = the recorded CUTOVER_WINDOW_UNTIL when set, else
+          # `now` (op=verify runs AT/AFTER cutover; the standalone pre-cutover probe has now ≤
+          # cutover, so now−200d is strictly earlier relative to cutover → still ⊇-invariant).
+          # A narrower window can NEVER surface false missed-ticks here because 200d > 182d. Echoes
+          # an ISO-8601 Z timestamp; empty on a date failure (the probe then uses its own safe
+          # 365-day default — the robustness/budget fixes still apply).
+          doublefire_from() {
+            local ref="${CUTOVER_WINDOW_UNTIL:-}" ref_epoch
+            if [[ -n "$ref" ]]; then
+              ref_epoch=$(date -u -d "$ref" +%s 2>/dev/null || echo "")
+              if [[ -n "$ref_epoch" ]]; then
+                date -u -d "@$(( ref_epoch - 200 * 86400 ))" +%Y-%m-%dT%H:%M:%SZ; return 0
+              fi
+            fi
+            date -u -d '200 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true
           }
 
           case "$OP" in
@@ -246,13 +278,18 @@ jobs:
               fi
               echo "::warning::doublefire-probe CRON_PERIOD=${CRON_PERIOD}s is applied to ALL functions (P2-c). The verdict is SOUND ONLY IF every registered cron period ≥ ${CRON_PERIOD}s AND hour-aligned. If any cron fires faster, re-dispatch with CUTOVER_CRON_PERIOD_SECONDS set to the SHORTEST registered period before trusting the result."
               SIG=$(printf '' | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/.*= //')
+              # #6919 — forward the ⊇-invariant window lower bound + optional functionIDs scope as
+              # URL query params (HMAC is over the empty GET body, so params don't affect the sig).
+              DF_FROM=$(doublefire_from); DF_FNIDS="${CUTOVER_DOUBLEFIRE_FUNCTION_IDS:-}"
+              DF_URL="$BASE/inngest-doublefire-probe?from=${DF_FROM}&function_ids=${DF_FNIDS}"
+              echo "::notice::doublefire-probe: scanning from=${DF_FROM:-<probe 365d default>} function_ids=[${DF_FNIDS:-<all>}]"
               rm -f /tmp/doublefire-probe-body
-              CODE=$(curl -s --max-time 60 -o /tmp/doublefire-probe-body -w '%{http_code}' \
+              CODE=$(curl -s --max-time 120 -o /tmp/doublefire-probe-body -w '%{http_code}' \
                 -X GET \
                 -H "X-Signature-256: sha256=$SIG" \
                 -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
                 -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-                "$BASE/inngest-doublefire-probe" || echo "000")
+                "$DF_URL" || echo "000")
               BODY=$(cat /tmp/doublefire-probe-body 2>/dev/null || echo "")
               if [[ "$CODE" != "200" ]]; then
                 CAUSE="${BODY//[$'\n\r']/ }"
@@ -1111,16 +1148,23 @@ jobs:
                 echo "::error::2.6 CRON_PERIOD invalid ('$CRON_PERIOD') — set CUTOVER_CRON_PERIOD_SECONDS to a positive integer ≤ the SHORTEST registered cron period (hour-aligned)."; exit 1
               fi
               echo "::warning::2.6 CRON_PERIOD=${CRON_PERIOD}s is applied to ALL functions (P2-c). The exactly-once verdict is SOUND ONLY IF every registered cron period ≥ ${CRON_PERIOD}s AND hour-aligned. If any cron fires faster than ${CRON_PERIOD}s, re-run op=verify with CUTOVER_CRON_PERIOD_SECONDS set to the SHORTEST registered cron period before trusting the result."
+              # #6919 — forward the ⊇-invariant window lower bound (cost lever) + optional
+              # functionIDs scope as URL query params so the wide default scan completes within the
+              # probe's per-page budget. HMAC is over the empty GET body, so params don't alter it.
+              DF_FROM=$(doublefire_from); DF_FNIDS="${CUTOVER_DOUBLEFIRE_FUNCTION_IDS:-}"
+              DF_URL="$BASE/inngest-doublefire-probe?from=${DF_FROM}&function_ids=${DF_FNIDS}"
+              echo "::notice::2.6 doublefire-probe: scanning from=${DF_FROM:-<probe 365d default>} function_ids=[${DF_FNIDS:-<all>}]"
               # #6258 bounded TRANSPORT retry (Finding 11): wraps ONLY the doublefire transport curl.
+              # The 120s outer budget > the probe's 90s in-script deadline + 8s per-page floor (SUM bound).
               CODE=000; BODY=""
               for attempt in 1 2; do
                 rm -f /tmp/verify-runs
-                CODE=$(curl -s --max-time 60 -o /tmp/verify-runs -w '%{http_code}' \
+                CODE=$(curl -s --max-time 120 -o /tmp/verify-runs -w '%{http_code}' \
                   -X GET \
                   -H "X-Signature-256: sha256=$SIG" \
                   -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
                   -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
-                  "$BASE/inngest-doublefire-probe" || echo "000")
+                  "$DF_URL" || echo "000")
                 BODY=$(cat /tmp/verify-runs 2>/dev/null || echo "")
                 [[ "$CODE" == "200" ]] && break
                 if [[ "$attempt" -lt 2 ]]; then

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -302,6 +302,11 @@ assert "#6919 doublefire hook forwards ?function_ids → INNGEST_DOUBLEFIRE_FUNC
 assert "#6919 workflow defines doublefire_from() helper" "grep -qE 'doublefire_from\(\) \{' '$WF'"
 assert "#6919 both doublefire calls forward the ?from= window cost lever (2 sites)" "[[ \"\$(grep -cF 'inngest-doublefire-probe?from=' '$WF')\" -eq 2 ]]"
 assert "#6919 workflow wires the optional functionIDs cost lever (CUTOVER_DOUBLEFIRE_FUNCTION_IDS)" "grep -qF 'CUTOVER_DOUBLEFIRE_FUNCTION_IDS' '$WF'"
+# #6919 review — doublefire_from()'s cutover-instant anchor (and the missed-tick auto-enum) read
+# CUTOVER_WINDOW_UNTIL/FROM, which GitHub does not export to the shell unless the step env MAPS
+# them. Assert the mapping exists so the anchor branch cannot silently go dead again.
+assert "#6919 workflow maps CUTOVER_WINDOW_UNTIL into the step env (doublefire anchor not dead)" "grep -qE 'CUTOVER_WINDOW_UNTIL:\s*\\\$\{\{ vars.CUTOVER_WINDOW_UNTIL \}\}' '$WF'"
+assert "#6919 workflow maps CUTOVER_WINDOW_FROM into the step env (missed-tick auto-enum not dead)" "grep -qE 'CUTOVER_WINDOW_FROM:\s*\\\$\{\{ vars.CUTOVER_WINDOW_FROM \}\}' '$WF'"
 # INVARIANT (negative): the cost lever is functionIDs + a 200d (> the 182d = 2×quarterly floor)
 # window — the TIME window is NEVER narrowed to hours/days (that would surface false missed-ticks
 # at :704-743 → operator re-fire → the exact DOUBLE-FIRE the cutover prevents).

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -78,7 +78,10 @@ HOOKS_TMPL="$REPO_ROOT/apps/web-platform/infra/hooks.json.tmpl"
 HOOK_IDS=(inngest-enumerate-reminders inngest-rearm-reminders inngest-wiped-volume-verify inngest-verify-status inngest-inventory inngest-registry-probe inngest-doublefire-probe)
 assert "hook-existence loop has >=1 hook (min-cardinality)" "[[ '${#HOOK_IDS[@]}' -ge 1 ]]"
 for hook in "${HOOK_IDS[@]}"; do
-  assert "workflow targets \$BASE/$hook" "grep -qE 'BASE/$hook\"' '$WF'"
+  # #6919 — the doublefire URL now carries a ?from=&function_ids= query string, so the name may
+  # be followed by `?` (query) OR `"` (bare). The char-class boundary still guards against a
+  # longer hook name false-matching (e.g. a hypothetical inngest-doublefire-probe-2).
+  assert "workflow targets \$BASE/$hook" "grep -qE 'BASE/$hook[?\"]' '$WF'"
   assert "hook id '$hook' exists in hooks.json.tmpl" "grep -qE '\"id\": \"$hook\"' '$HOOKS_TMPL'"
 done
 
@@ -127,7 +130,7 @@ assert "SEAM directs the arm-flip to the no-SSH op=arm dispatch (#6369)" "grep -
 # D.3 / AC-VERIFY — op=verify: precondition registry NON-empty (2.4 landed,
 # P1-9/P2-17), 2.6 via the doublefire hook, RunsFilterV2 + STARTED_AT bucketing,
 # and NO scheduled_tick anywhere in the workflow.
-assert "verify calls the doublefire-probe hook (2.6/P1-12)" "grep -qE 'BASE/inngest-doublefire-probe\"' '$WF'"
+assert "verify calls the doublefire-probe hook (2.6/P1-12)" "grep -qE 'BASE/inngest-doublefire-probe[?\"]' '$WF'"
 assert "verify preconditions on registry NON-empty (P1-9/P2-17)" "grep -qE 'verify precondition' '$WF'"
 assert "verify buckets by floor(startedAt / cron_period) (no scheduled_tick)" "grep -qE 'fromdateiso8601' '$WF'"
 assert "verify auto-emits the missed-tick trigger-cron list (P2-16)" "grep -qE 'soleur:trigger-cron' '$WF'"
@@ -272,12 +275,37 @@ DF_SH="$REPO_ROOT/apps/web-platform/infra/inngest-doublefire-probe.sh"
 INV_DEADLINE=$(grep -oP 'PREFLIGHT_DEADLINE_S:-\K[0-9]+' "$INV_SH" | head -1)
 DF_DEADLINE=$(grep -oP 'PREFLIGHT_DEADLINE_S:-\K[0-9]+' "$DF_SH" | head -1)
 assert "inventory in-script deadline (22) < outer curl --max-time 30 (SUM bound)" "[[ -n '$INV_DEADLINE' && '$INV_DEADLINE' -lt 30 ]]"
-assert "doublefire in-script deadline (50) < outer curl --max-time 60 (SUM bound)" "[[ -n '$DF_DEADLINE' && '$DF_DEADLINE' -lt 60 ]]"
+# #6919 — the doublefire budget was raised (deadline 50→90, outer curl 60→120) + a per-page
+# FLOOR added so late pages never starve to ~0s → empty → false "malformed". SUM bound stays
+# airtight: deadline(90) + PAGE_MIN(8) = 98 < the 120s outer curl.
+DF_PAGE_MIN=$(grep -oP 'PREFLIGHT_PAGE_MIN_S:-\K[0-9]+' "$DF_SH" | head -1)
+assert "doublefire in-script deadline (90) < outer curl --max-time 120 (SUM bound, #6919)" "[[ -n '$DF_DEADLINE' && '$DF_DEADLINE' -lt 120 ]]"
+assert "doublefire SUM bound airtight: deadline + PAGE_MIN < 120 (#6919)" "[[ -n '$DF_DEADLINE' && -n '$DF_PAGE_MIN' && \$(( DF_DEADLINE + DF_PAGE_MIN )) -lt 120 ]]"
+assert "doublefire per-page budget is FLOORED to PREFLIGHT_PAGE_MIN_S (anti-starvation, #6919)" "grep -qE 'max_time < PREFLIGHT_PAGE_MIN_S \)\) && max_time=\\\$PREFLIGHT_PAGE_MIN_S' '$DF_SH'"
 assert "inventory clamps per-page curl to the remaining budget (not a fixed const)" "grep -qE 'max-time \"\\\$max_time\"' '$INV_SH' && grep -qE 'remaining=\\\$\(\( PREFLIGHT_DEADLINE_S - elapsed \)\)' '$INV_SH'"
 assert "doublefire clamps per-page curl to the remaining budget" "grep -qE 'max-time \"\\\$max_time\"' '$DF_SH' && grep -qE 'remaining=\\\$\(\( PREFLIGHT_DEADLINE_S - elapsed \)\)' '$DF_SH'"
 # outer curl budgets present (the ceiling the sum must stay under).
 assert "inventory outer curl --max-time 30 present" "grep -qE 'curl -s --max-time 30 -o /tmp/inv-body' '$WF'"
-assert "doublefire outer curl --max-time 60 present" "grep -qE 'curl -s --max-time 60 -o /tmp/verify-runs' '$WF'"
+assert "doublefire outer curl --max-time 120 present (#6919)" "grep -qE 'curl -s --max-time 120 -o /tmp/verify-runs' '$WF'"
+
+# ============================================================================
+# #6919 — the op=verify HTTP 500 fix's plumbing: the doublefire hook reads a
+# ?from= / ?function_ids= query string, and BOTH cutover arms forward a narrower-
+# but-still-⊇-invariant window (cutover − 200d > the 182d floor) as the cost lever
+# so the wide all-function scan completes within the probe's per-page budget.
+# ============================================================================
+# Hook side: the two url params bridge into the probe's env seams.
+assert "#6919 doublefire hook forwards ?from → INNGEST_DOUBLEFIRE_FROM (pass-environment url)" "grep -qF '\"source\": \"url\", \"name\": \"from\", \"envname\": \"INNGEST_DOUBLEFIRE_FROM\"' '$HOOKS_TMPL'"
+assert "#6919 doublefire hook forwards ?function_ids → INNGEST_DOUBLEFIRE_FUNCTION_IDS" "grep -qF '\"name\": \"function_ids\", \"envname\": \"INNGEST_DOUBLEFIRE_FUNCTION_IDS\"' '$HOOKS_TMPL'"
+# Workflow side: a shared doublefire_from() computes the ⊇-invariant lower bound, and BOTH the
+# op=verify (2.6) and standalone op=doublefire-probe arms forward it as ?from=.
+assert "#6919 workflow defines doublefire_from() helper" "grep -qE 'doublefire_from\(\) \{' '$WF'"
+assert "#6919 both doublefire calls forward the ?from= window cost lever (2 sites)" "[[ \"\$(grep -cF 'inngest-doublefire-probe?from=' '$WF')\" -eq 2 ]]"
+assert "#6919 workflow wires the optional functionIDs cost lever (CUTOVER_DOUBLEFIRE_FUNCTION_IDS)" "grep -qF 'CUTOVER_DOUBLEFIRE_FUNCTION_IDS' '$WF'"
+# INVARIANT (negative): the cost lever is functionIDs + a 200d (> the 182d = 2×quarterly floor)
+# window — the TIME window is NEVER narrowed to hours/days (that would surface false missed-ticks
+# at :704-743 → operator re-fire → the exact DOUBLE-FIRE the cutover prevents).
+assert "#6919 doublefire_from is ≥ 200 days (⊇ the 182d invariant, never a day/hour narrow)" "grep -qF '200 * 86400' '$WF' && grep -qF '200 days ago' '$WF'"
 
 # Abort → webhook NON-200 (Deepen Finding 6): a script exit 1 (deadline/ceiling loud-abort)
 # maps to a webhook non-200 ONLY IF the hook has include-command-output-in-response-on-error.

--- a/apps/web-platform/infra/hooks.json.tmpl
+++ b/apps/web-platform/infra/hooks.json.tmpl
@@ -273,6 +273,7 @@
     }
   },
   {
+    "__comment": "#6919 — the op=verify HTTP 500 fix. The cutover arms forward the STARTED_AT window lower bound (from) and an optional functionIDs scope (function_ids) as URL query params so the wide default scan can be cost-cut without a code change. Both are read into the probe's env seams (INNGEST_DOUBLEFIRE_FROM / INNGEST_DOUBLEFIRE_FUNCTION_IDS). from MUST respect the window-superset invariant (FROM <= cutover_instant - 2*max_cron_period ~= 182d); the caller passes cutover-200d. HMAC is over the (empty) GET body, so query params do not affect the signature. Values are injection-safe: the script binds from via jq --arg and splits function_ids via jq -R.",
     "id": "inngest-doublefire-probe",
     "execute-command": "/usr/local/bin/inngest-doublefire-probe.sh",
     "command-working-directory": "/",
@@ -280,6 +281,10 @@
     "include-command-output-in-response-on-error": true,
     "http-methods": ["GET"],
     "trigger-rule-mismatch-http-response-code": 403,
+    "pass-environment-to-command": [
+      { "source": "url", "name": "from", "envname": "INNGEST_DOUBLEFIRE_FROM" },
+      { "source": "url", "name": "function_ids", "envname": "INNGEST_DOUBLEFIRE_FUNCTION_IDS" }
+    ],
     "trigger-rule": {
       "match": {
         "type": "payload-hmac-sha256",

--- a/apps/web-platform/infra/inngest-doublefire-probe.sh
+++ b/apps/web-platform/infra/inngest-doublefire-probe.sh
@@ -33,19 +33,43 @@
 # Bounded (#6258, ADR-106): like the inventory scan, the runs pagination is bounded by a
 # wall-clock DEADLINE (date +%s delta; NEVER SECONDS) and a per-run PAGE CEILING, both
 # abandon-safe (deadline/ceiling → LOUD SOLEUR_INNGEST_PREFLIGHT_TIMEOUT marker + exit 1,
-# NEVER break — a break would emit a truncated HTTP-200 body). Each per-page curl is
-# clamped to the REMAINING budget (--max-time = DEADLINE_S − elapsed, floored ≥1) so the
-# sum bound `deadline + per_page ≤ outer_curl` holds (Deepen Finding 1). The scan cost is
-# cut via a `functionIDs` filter + the page ceiling — the time WINDOW is NEVER narrowed
-# (Finding 5): a probe window narrower than the operator's cutover window would surface
-# false "missed ticks" at cutover-inngest.yml:704-743 → operator re-fire → DOUBLE-FIRE
-# (the exact harm the cutover prevents). Invariant: window ⊇ cutover-relevant period
-# (FROM ≤ cutover_instant − 2×max_cron_period).
+# NEVER break — a break would emit a truncated HTTP-200 body).
+#
+# PER-PAGE BUDGET (#6919 — the op=verify HTTP 500 fix). The per-page curl --max-time is the
+# REMAINING wall-clock budget (`remaining = DEADLINE_S − elapsed`) FLOORED to
+# PREFLIGHT_PAGE_MIN_S and CAPPED at PREFLIGHT_PAGE_MAX_S. The floor is load-bearing: the
+# earlier code clamped purely to `remaining`, so once slow early pages had drained the
+# budget every LATE page got ~0s → curl timed out → EMPTY body → the fail-loud guard
+# mis-read the empty body as a "malformed runs response" and 500'd (deterministic
+# starvation, reproduced on run 29729623865 page 6). The floor guarantees each page a
+# viable timeout; the cap keeps one slow page from hogging the whole budget. SUM bound
+# (Deepen Finding 1): a page is only ISSUED while `elapsed < DEADLINE`, and the near-
+# deadline retry is blocked by a fresh deadline re-check, so the worst-case wall overshoot
+# past DEADLINE is one PAGE_MIN → the airtight bound is `DEADLINE + PAGE_MIN ≤ outer_curl`
+# (default 90 + 8 = 98 < the 120s outer curl at cutover-inngest.yml).
+#
+# TRANSIENT vs MALFORMED (#6919). A curl NON-ZERO exit OR an EMPTY/whitespace body is a
+# TRANSIENT transport failure (timeout / truncation), NOT a GraphQL error: the page is
+# retried ONCE with a fresh per-page budget; a second transient → LOUD `reason=transport`
+# abort (accurate remediation: raise PREFLIGHT_DEADLINE_S or scope functionIDs), NEVER the
+# "malformed" verdict. A NON-EMPTY body whose `.data.runs.edges` is not an array is
+# GENUINELY malformed → the fail-loud `reason=gql_error` path (never masked as clean).
+#
+# The scan cost is cut via a `functionIDs` filter + the page ceiling — the time WINDOW is
+# NEVER narrowed (Finding 5): a probe window narrower than the operator's cutover window
+# would surface false "missed ticks" at cutover-inngest.yml:704-743 → operator re-fire →
+# DOUBLE-FIRE (the exact harm the cutover prevents). Invariant: window ⊇ cutover-relevant
+# period (FROM ≤ cutover_instant − 2×max_cron_period; longest repo cron is QUARTERLY, so
+# 2×max_cron_period ≈ 182d — the 365-day default over-satisfies it). RESIDUAL LIMITATION: a
+# full all-68-function 365/182-day scan can still exhaust the budget without functionIDs
+# scoping; op=verify passes a narrower-but-still-⊇-invariant FROM (cutover − 200d) as the
+# cost lever, and the operator can scope INNGEST_DOUBLEFIRE_FUNCTION_IDS for a hard cut.
 #
 # Inputs (env):
 #   INNGEST_DOUBLEFIRE_FUNCTION_IDS — comma-separated cron fn UUIDs (empty ⇒ all)
 #   INNGEST_DOUBLEFIRE_FROM / INNGEST_DOUBLEFIRE_UNTIL — STARTED_AT window (ISO-8601)
-#   PREFLIGHT_DEADLINE_S / INNGEST_MAX_PAGES — the bounding seams (defaults 50 / 1000)
+#   PREFLIGHT_DEADLINE_S / INNGEST_MAX_PAGES — the bounding seams (defaults 90 / 1000)
+#   PREFLIGHT_PAGE_MIN_S / PREFLIGHT_PAGE_MAX_S — per-page curl floor/cap (defaults 8 / 15)
 # Test seam: INNGEST_DOUBLEFIRE_RUNS_FIXTURE (a dir with page-N.json runs
 # responses) short-circuits the curl.
 set -euo pipefail
@@ -67,10 +91,16 @@ FROM_TS="${INNGEST_DOUBLEFIRE_FROM:-$_default_from}"
 UNTIL_TS="${INNGEST_DOUBLEFIRE_UNTIL:-}"
 FUNCTION_IDS_CSV="${INNGEST_DOUBLEFIRE_FUNCTION_IDS:-}"
 
-# --- Bounding seams (#6258, ADR-106) ---
-# In-script wall-clock deadline. Default 50s < the outer curl 60s (cutover-inngest.yml:673);
-# the remaining-budget per-page clamp makes the SUM bound airtight (Finding 1).
-PREFLIGHT_DEADLINE_S="${PREFLIGHT_DEADLINE_S:-50}"
+# --- Bounding seams (#6258, ADR-106; #6919 per-page floor) ---
+# In-script wall-clock deadline. Default 90s < the outer curl 120s (cutover-inngest.yml); the
+# per-page floor/cap keeps the SUM bound `DEADLINE + PAGE_MIN ≤ outer_curl` airtight (Finding 1).
+PREFLIGHT_DEADLINE_S="${PREFLIGHT_DEADLINE_S:-90}"
+# Per-page curl budget window (#6919). PAGE_MIN is the anti-starvation FLOOR — every page gets
+# at least this many seconds so late pages never get ~0s → empty body → false "malformed".
+# PAGE_MAX caps a single page so it cannot hog the whole deadline. Invariant for the SUM bound:
+# DEADLINE + PAGE_MIN ≤ outer_curl (90 + 8 = 98 < 120). PAGE_MAX < DEADLINE (no single-page hog).
+PREFLIGHT_PAGE_MIN_S="${PREFLIGHT_PAGE_MIN_S:-8}"
+PREFLIGHT_PAGE_MAX_S="${PREFLIGHT_PAGE_MAX_S:-15}"
 MAX_PAGES="${INNGEST_MAX_PAGES:-1000}"
 CONNECT_TIMEOUT="${INNGEST_CONNECT_TIMEOUT:-5}"
 PREFLIGHT_OP="verify-doublefire"
@@ -136,8 +166,19 @@ _pf_timeout_marker() {  # $1=reason(enum) $2=pages $3=pages_timed_out $4=last_cu
 # exit 1 (NEVER break). The EXIT trap fires on exit 1 → spool cleaned; exit 1 → webhook non-200.
 _pf_abort() {  # $1=reason $2=pages $3=pages_timed_out $4=last_curl_exit
   _pf_timeout_marker "$1" "$2" "$3" "$4"
-  echo "inngest-doublefire-probe: FATAL preflight scan aborted reason=$1 pages_scanned=$2 (deadline_s=$PREFLIGHT_DEADLINE_S page_ceiling=$MAX_PAGES from=$FROM_TS) — refusing to emit a truncated (false-clean) run set"
+  echo "inngest-doublefire-probe: FATAL preflight scan aborted reason=$1 pages_scanned=$2 (deadline_s=$PREFLIGHT_DEADLINE_S page_ceiling=$MAX_PAGES from=$FROM_TS) — increase PREFLIGHT_DEADLINE_S or scope INNGEST_DOUBLEFIRE_FUNCTION_IDS; refusing to emit a truncated (false-clean) run set"
   echo "ERROR: preflight scan aborted reason=$1 pages_scanned=$2" >&2
+  exit 1
+}
+# Transient-transport loud abort (#6919): a page that is STILL empty / curl-failed after one
+# retry with a fresh per-page budget. This is a truncation / timeout / budget exhaustion — an
+# ACCURATE, non-"malformed" verdict — so it never masks a real double-fire as clean and never
+# mislabels a transient empty body as a malformed GraphQL response. exit 1 → webhook non-200.
+_pf_abort_transport() {  # $1=page $2=pages_timed_out $3=last_curl_exit
+  _pf_timeout_marker transport "$1" "$2" "$3"
+  logger -t "$LOG_TAG" "ERROR: transport exhaustion on page $1 after retry: empty/failed body (last_curl_exit=$3)" 2>/dev/null || true
+  echo "inngest-doublefire-probe: FATAL empty/truncated runs response on page $1 after 1 retry (last_curl_exit=$3, from=$FROM_TS) — transient transport failure or preflight budget exhaustion, NOT a malformed GraphQL response; increase PREFLIGHT_DEADLINE_S (current ${PREFLIGHT_DEADLINE_S}s) or scope INNGEST_DOUBLEFIRE_FUNCTION_IDS — refusing to emit a truncated (false-clean) run set"
+  echo "ERROR: transport/budget exhaustion on page $1 after retry (last_curl_exit=$3)" >&2
   exit 1
 }
 
@@ -173,9 +214,9 @@ build_request_body() {
 # Fetch one runs page INTO a file (no command-substitution subshell — so the loop can read
 # $_last_curl_exit). A curl failure is swallowed so the caller routes through the loud-abort
 # path (set -e must not kill the script before the marker fires).
-#   $1=out_file $2=after $3=page $4=max_time
+#   $1=out_file $2=after $3=page $4=max_time $5=attempt(1|2, default 1)
 _fetch_runs_page() {
-  local out="$1" after="$2" page_num="$3" max_time="$4"
+  local out="$1" after="$2" page_num="$3" max_time="$4" attempt="${5:-1}"
   # Build the body BEFORE the fixture short-circuit (#6617). The seam used to
   # return above this line, so every fixture-driven test bypassed request
   # construction entirely — which is exactly how the empty-CSV --argjson abort
@@ -184,7 +225,13 @@ _fetch_runs_page() {
   local body
   body=$(build_request_body "$after")
   if [[ -n "$FIXTURE_DIR" ]]; then
-    cat "${FIXTURE_DIR}/page-${page_num}.json" > "$out"
+    # Retry seam (#6919): on a RETRY (attempt >= 2) prefer page-N.retry.json when present, so a
+    # test can model a page that returns a transient EMPTY body on attempt 1 and RECOVERS on 2.
+    local fixture_file="${FIXTURE_DIR}/page-${page_num}.json"
+    if (( attempt >= 2 )) && [[ -f "${FIXTURE_DIR}/page-${page_num}.retry.json" ]]; then
+      fixture_file="${FIXTURE_DIR}/page-${page_num}.retry.json"
+    fi
+    cat "$fixture_file" > "$out"
     _last_curl_exit=0
     return 0
   fi
@@ -213,7 +260,7 @@ run_probe() {
   trap "rm -rf '$pf_tmp'" EXIT
   local spool="$pf_tmp/runs.spool" resp_file="$pf_tmp/runs.resp"
   local after="" page=1 resp has_next end_cursor
-  local timed_out=0 last_curl_exit=0 now elapsed remaining
+  local timed_out=0 last_curl_exit=0 now elapsed remaining max_time
   : > "$spool"
   while :; do
     # --- deadline (SUM bound): abort BEFORE issuing a page that could overshoot ---
@@ -221,14 +268,42 @@ run_probe() {
     if (( elapsed >= PREFLIGHT_DEADLINE_S )); then
       _pf_abort deadline "$(( page - 1 ))" "$timed_out" "$last_curl_exit"
     fi
+    # Per-page curl budget: the REMAINING wall-clock, FLOORED to PAGE_MIN (anti-starvation —
+    # #6919: never hand a late page ~0s → empty body → false "malformed") and CAPPED at PAGE_MAX
+    # (no single page hogs the deadline). The near-deadline floor overshoots DEADLINE by at most
+    # one PAGE_MIN, which the SUM bound `DEADLINE + PAGE_MIN ≤ outer_curl` absorbs.
     remaining=$(( PREFLIGHT_DEADLINE_S - elapsed )); (( remaining < 1 )) && remaining=1
-    _fetch_runs_page "$resp_file" "$after" "$page" "$remaining"
+    max_time=$remaining
+    (( max_time > PREFLIGHT_PAGE_MAX_S )) && max_time=$PREFLIGHT_PAGE_MAX_S
+    (( max_time < PREFLIGHT_PAGE_MIN_S )) && max_time=$PREFLIGHT_PAGE_MIN_S
+    _fetch_runs_page "$resp_file" "$after" "$page" "$max_time" 1
     last_curl_exit=$_last_curl_exit
-    (( _last_curl_exit != 0 )) && timed_out=$(( timed_out + 1 ))
     resp=$(cat "$resp_file")
-    # Fail LOUD on a non-array .data.runs.edges (fetch failure / GraphQL error / unexpected
-    # shape) — never a false-clean {runs:[]}. A curl-timeout empty body surfaces here; the
-    # marker carries last_curl_exit (splits pool-stall from slow scan). exit 1 → webhook non-200.
+    # --- TRANSIENT classification (#6919): a curl NON-ZERO exit OR an EMPTY/whitespace body is a
+    # transport timeout/truncation, NOT a malformed GraphQL response. Retry the page ONCE with a
+    # FRESH per-page budget (if the deadline still allows one); a second transient → LOUD
+    # reason=transport abort. This is what stops budget-starvation from reading as "malformed". ---
+    if (( last_curl_exit != 0 )) || [[ -z "${resp//[[:space:]]/}" ]]; then
+      timed_out=$(( timed_out + 1 ))
+      now=$(date +%s); elapsed=$(( now - PREFLIGHT_START_S ))
+      if (( elapsed >= PREFLIGHT_DEADLINE_S )); then
+        _pf_abort deadline "$(( page - 1 ))" "$timed_out" "$last_curl_exit"
+      fi
+      remaining=$(( PREFLIGHT_DEADLINE_S - elapsed )); (( remaining < 1 )) && remaining=1
+      max_time=$remaining
+      (( max_time > PREFLIGHT_PAGE_MAX_S )) && max_time=$PREFLIGHT_PAGE_MAX_S
+      (( max_time < PREFLIGHT_PAGE_MIN_S )) && max_time=$PREFLIGHT_PAGE_MIN_S
+      _fetch_runs_page "$resp_file" "$after" "$page" "$max_time" 2
+      last_curl_exit=$_last_curl_exit
+      resp=$(cat "$resp_file")
+      if (( last_curl_exit != 0 )) || [[ -z "${resp//[[:space:]]/}" ]]; then
+        timed_out=$(( timed_out + 1 ))
+        _pf_abort_transport "$page" "$timed_out" "$last_curl_exit"
+      fi
+    fi
+    # Fail LOUD on a non-array .data.runs.edges (GraphQL error / unexpected shape) — never a
+    # false-clean {runs:[]}. Reached ONLY with a NON-EMPTY body (transient empties handled
+    # above), so this is a GENUINE malformed response, not a transport timeout. exit 1 → non-200.
     if ! echo "$resp" | jq -e '.data.runs.edges | type == "array"' >/dev/null 2>&1; then
       local err_msgs data_keys gql_msg
       err_msgs=$(echo "$resp" | jq -c '[(.errors // [])[].message]' 2>/dev/null || echo '["<unparseable response>"]')

--- a/apps/web-platform/infra/inngest-doublefire-probe.test.sh
+++ b/apps/web-platform/infra/inngest-doublefire-probe.test.sh
@@ -230,13 +230,27 @@ test_df_markers_journald_only() {
 }
 
 # --- #6258 T4: connect-timeout + remaining-budget clamp (sum-bound by construction) ---
+# #6919 — the clamp now FLOORS the per-page budget to PREFLIGHT_PAGE_MIN_S (anti-starvation)
+# and CAPS it at PREFLIGHT_PAGE_MAX_S, on top of the remaining-budget derivation. The floor is
+# the load-bearing fix: without it a drained budget hands late pages ~0s → empty → false
+# "malformed". SUM bound stays airtight: DEADLINE + PAGE_MIN ≤ outer curl.
 test_df_connect_timeout_and_clamp() {
-  echo "TEST: doublefire-probe — --connect-timeout + remaining-budget curl clamp"
+  echo "TEST: doublefire-probe — --connect-timeout + remaining-budget curl clamp (floored, #6919)"
   if grep -qE 'curl[^|]*--connect-timeout' "$TARGET"; then echo "  PASS: --connect-timeout present"; PASS=$((PASS+1));
   else echo "  FAIL: no --connect-timeout"; FAIL=$((FAIL+1)); fi
   if grep -qE 'max-time "\$max_time"' "$TARGET" && grep -qE 'remaining=\$\(\( PREFLIGHT_DEADLINE_S - elapsed \)\)' "$TARGET"; then
     echo "  PASS: per-page curl clamped to remaining budget"; PASS=$((PASS+1));
   else echo "  FAIL: per-page curl not clamped to remaining budget"; FAIL=$((FAIL+1)); fi
+  # #6919 anti-starvation FLOOR: the per-page budget is floored to PREFLIGHT_PAGE_MIN_S.
+  if grep -qE 'max_time < PREFLIGHT_PAGE_MIN_S \)\) && max_time=\$PREFLIGHT_PAGE_MIN_S' "$TARGET"; then
+    echo "  PASS: per-page budget floored to PREFLIGHT_PAGE_MIN_S (anti-starvation)"; PASS=$((PASS+1));
+  else echo "  FAIL: per-page budget NOT floored to PREFLIGHT_PAGE_MIN_S — late pages can starve"; FAIL=$((FAIL+1)); fi
+  # SUM bound must remain airtight: DEADLINE default + PAGE_MIN default < the 120s outer curl.
+  local dl pmin; dl=$(grep -oP 'PREFLIGHT_DEADLINE_S:-\K[0-9]+' "$TARGET" | head -1)
+  pmin=$(grep -oP 'PREFLIGHT_PAGE_MIN_S:-\K[0-9]+' "$TARGET" | head -1)
+  if [[ -n "$dl" && -n "$pmin" && $(( dl + pmin )) -lt 120 ]]; then
+    echo "  PASS: SUM bound DEADLINE($dl)+PAGE_MIN($pmin) < 120 outer curl"; PASS=$((PASS+1));
+  else echo "  FAIL: SUM bound violated: DEADLINE($dl)+PAGE_MIN($pmin) not < 120"; FAIL=$((FAIL+1)); fi
 }
 
 # --- #6258 T5: window ⊇ cutover window — the time window is NEVER narrowed (Finding 5) ---
@@ -255,6 +269,82 @@ test_df_window_not_narrowed() {
   # cost lever is functionIDs, not a window narrow: build_request_body carries functionIDs.
   if grep -q 'functionIDs:\$fnids' "$TARGET"; then echo "  PASS: cost cut via functionIDs filter"; PASS=$((PASS+1));
   else echo "  FAIL: no functionIDs filter (cost lever missing)"; FAIL=$((FAIL+1)); fi
+  rm -rf "$dir"
+}
+
+# ===========================================================================
+# #6919 — per-page budget starvation fix: transient-empty (retry) vs
+# genuinely-malformed (fail loud) vs transport exhaustion (accurate, not "malformed").
+# The live op=verify HTTP 500 was a late page starved to ~0s → empty body → the
+# fail-loud guard mislabeled the empty body "malformed runs response on page 6".
+# ===========================================================================
+
+# --- #6919 A: a transient EMPTY page RECOVERS on the retry → probe completes correctly ---
+test_df_transient_page_recovers_on_retry() {
+  echo "TEST: doublefire-probe — a transient EMPTY page RECOVERS on retry (#6919)"
+  local dir; dir=$(mktemp -d)
+  # page-1 is EMPTY on attempt 1 (the starvation/truncation signal) and VALID on the retry
+  # (the _fetch_runs_page retry seam prefers page-N.retry.json on attempt >= 2).
+  : > "$dir/page-1.json"
+  make_page false "" "[$(make_edge run-1 fn-a 2026-07-08T10:00:00Z)]" > "$dir/page-1.retry.json"
+  run_probe_logcap "$dir"
+  if [[ "$RC" -eq 0 ]]; then echo "  PASS: probe completes (exit 0) after the transient page recovers"; PASS=$((PASS+1));
+  else echo "  FAIL: transient-recover rc=$RC (want 0; markers=$MARKERS_CAP)"; FAIL=$((FAIL+1)); fi
+  assert_eq "recovered run is reported (1 run)" "1" "$(echo "$STDOUT_CAP" | jq -r '.runs | length' 2>/dev/null || echo x)"
+  assert_eq "recovered run functionID projected" "fn-a" "$(echo "$STDOUT_CAP" | jq -r '.runs[0].functionID' 2>/dev/null || echo x)"
+  # a recovered transient must NOT leave a false malformed/transport marker.
+  if echo "$MARKERS_CAP" | grep -q 'SOLEUR_INNGEST_PREFLIGHT_TIMEOUT'; then
+    echo "  FAIL: a recovered transient emitted a TIMEOUT abort marker (markers=$MARKERS_CAP)"; FAIL=$((FAIL+1));
+  else echo "  PASS: no abort marker on a recovered transient"; PASS=$((PASS+1)); fi
+  rm -rf "$dir"
+}
+
+# --- #6919 B: a page still EMPTY after the retry → LOUD reason=transport, NOT "malformed" ---
+test_df_transport_exhaustion_fails_loud() {
+  echo "TEST: doublefire-probe — persistent empty page fails LOUD as transport, not 'malformed' (#6919)"
+  local dir; dir=$(mktemp -d)
+  : > "$dir/page-1.json"   # empty on attempt 1 AND the retry (no page-1.retry.json)
+  run_probe_logcap "$dir"
+  if [[ "$RC" -eq 1 ]]; then echo "  PASS: transport exhaustion exits 1"; PASS=$((PASS+1));
+  else echo "  FAIL: transport exhaustion rc=$RC (want 1)"; FAIL=$((FAIL+1)); fi
+  # NEVER a false-clean parseable {runs} object.
+  if echo "$STDOUT_CAP" | jq -e '.runs' >/dev/null 2>&1; then
+    echo "  FAIL: emitted a false-clean {runs} object on transport exhaustion"; FAIL=$((FAIL+1));
+  else echo "  PASS: no false-clean runs object on transport exhaustion"; PASS=$((PASS+1)); fi
+  # ACCURATE marker: reason=transport (NOT gql_error/malformed).
+  if echo "$MARKERS_CAP" | grep -q 'SOLEUR_INNGEST_PREFLIGHT_TIMEOUT .*reason=transport'; then
+    echo "  PASS: TIMEOUT reason=transport marker"; PASS=$((PASS+1));
+  else echo "  FAIL: no reason=transport marker (markers=$MARKERS_CAP)"; FAIL=$((FAIL+1)); fi
+  # the transient empty must NOT be mislabeled as the (misleading) 'malformed runs response'.
+  if echo "$STDOUT_CAP" | grep -q 'malformed runs response'; then
+    echo "  FAIL: transient empty mislabeled as 'malformed runs response' (the #6919 bug)"; FAIL=$((FAIL+1));
+  else echo "  PASS: transient empty NOT mislabeled 'malformed runs response'"; PASS=$((PASS+1)); fi
+  # and it carries the accurate operator remediation.
+  if echo "$STDOUT_CAP" | grep -q 'increase PREFLIGHT_DEADLINE_S'; then
+    echo "  PASS: accurate remediation (increase PREFLIGHT_DEADLINE_S / scope functionIDs)"; PASS=$((PASS+1));
+  else echo "  FAIL: no accurate remediation in the FATAL message (out=$STDOUT_CAP)"; FAIL=$((FAIL+1)); fi
+  rm -rf "$dir"
+}
+
+# --- #6919 C: a NON-EMPTY invalid body still fails loud as 'malformed', NOT transport ---
+test_df_nonempty_malformed_still_loud() {
+  echo "TEST: doublefire-probe — NON-EMPTY invalid body still fails as 'malformed' not transport (#6919)"
+  local dir; dir=$(mktemp -d)
+  # non-empty, valid JSON, but .data.runs.edges is NOT an array → a GENUINE malformed response.
+  echo '{"data":{"runs":{"edges":"not-an-array"}}}' > "$dir/page-1.json"
+  run_probe_logcap "$dir"
+  if [[ "$RC" -eq 1 ]]; then echo "  PASS: malformed non-empty body exits 1"; PASS=$((PASS+1));
+  else echo "  FAIL: malformed non-empty rc=$RC (want 1)"; FAIL=$((FAIL+1)); fi
+  if echo "$STDOUT_CAP" | jq -e '.runs' >/dev/null 2>&1; then
+    echo "  FAIL: emitted a false-clean {runs} object on a malformed body"; FAIL=$((FAIL+1));
+  else echo "  PASS: no false-clean runs object on a malformed body"; PASS=$((PASS+1)); fi
+  # classified as gql_error (genuine malformed), NOT transport — the body was non-empty.
+  if echo "$MARKERS_CAP" | grep -q 'SOLEUR_INNGEST_PREFLIGHT_TIMEOUT .*reason=gql_error'; then
+    echo "  PASS: TIMEOUT reason=gql_error (genuine malformed)"; PASS=$((PASS+1));
+  else echo "  FAIL: expected reason=gql_error (markers=$MARKERS_CAP)"; FAIL=$((FAIL+1)); fi
+  if echo "$MARKERS_CAP" | grep -q 'reason=transport'; then
+    echo "  FAIL: a NON-EMPTY malformed body was WRONGLY treated as transient/transport"; FAIL=$((FAIL+1));
+  else echo "  PASS: non-empty malformed body NOT treated as transport"; PASS=$((PASS+1)); fi
   rm -rf "$dir"
 }
 
@@ -376,6 +466,9 @@ test_df_page_ceiling_abort
 test_df_markers_journald_only
 test_df_connect_timeout_and_clamp
 test_df_window_not_narrowed
+test_df_transient_page_recovers_on_retry
+test_df_transport_exhaustion_fails_loud
+test_df_nonempty_malformed_still_loud
 test_df_marker_purity
 test_df_marker_tag_in_vector
 test_df_argv_ceiling_collapsed_runs


### PR DESCRIPTION
## Problem
Post-cutover (#6178), `op=verify` returns **HTTP 500**: `malformed runs response on page 6 (from=2025-07-24…)`.

## Root cause
`op=verify` passes no window/scope, so `inngest-doublefire-probe.sh` runs its **365-day** default over **all 68 functions** and clamps each page's curl `--max-time` to the *remaining* wall-clock budget (`DEADLINE − elapsed`, deadline 50s). Early pages drain the budget, so by page 6 the per-page curl gets ~0s → times out → **empty body** → the fail-loud guard mislabels the empty body as `malformed runs response` → webhook 500. Deterministic (reproduced on both workflow attempts).

## Fix — pagination robustness, **not** window-narrowing
The script header's invariant (`window ⊇ cutover_instant − 2×max_cron_period`) is preserved. **Max cron period here is quarterly** (`0 11 1 1,4,7,10 *`), so 2× ≈ 182 days — narrowing to hours/days (an earlier idea) would violate the invariant and risk false missed-ticks → double-fire.

- **Anti-starvation budget:** per-page `--max-time` floored to `PREFLIGHT_PAGE_MIN_S=8` and capped at `PREFLIGHT_PAGE_MAX_S=15`; deadline 50→90. No page starves to ~0s. SUM bound `DEADLINE + PAGE_MIN ≤ outer_curl` (90+8 < 120) stays airtight.
- **Transient vs malformed:** curl non-zero exit / empty body = transient → retried once with a fresh budget; a second transient fails loud as `reason=transport` with an accurate message + remediation. The **malformed** path is reached **only** on a non-empty bad-shape body (`reason=gql_error`) — genuine malformed still fails loud, never masked clean.
- **Cost levers plumbed end-to-end:** `INNGEST_DOUBLEFIRE_FROM` + `FUNCTION_IDS` via `hooks.json.tmpl` `pass-environment` → `cutover-inngest.yml` `doublefire_from()` = cutover − 200d (>182d, invariant with skew headroom); op=verify + op=doublefire-probe forward `?from=&function_ids=`; outer curl 60→120. `INNGEST_DOUBLEFIRE_FUNCTION_IDS` is the hard scope lever (empty ⇒ all), wired to `CUTOVER_DOUBLEFIRE_FUNCTION_IDS` repo var.

## Tests
- `inngest-doublefire-probe.test.sh` **70/70** — transient-recovers-on-retry; persistent-transport fails loud as `reason=transport` (**not** "malformed", no false-clean, carries remediation); non-empty invalid body still `reason=gql_error`; PAGE_MIN floor + SUM bound. T5 (window-not-narrowed) + malformed/truncation fail-loud guards stay green.
- `cutover-inngest-workflow.test.sh` **235/235** — SUM-bound numbers, hook pass-env bridge, `doublefire_from()`, dual `?from=` forwarding, functionIDs lever, ≥200d no-narrowing invariant.

## Residual (honest)
A full all-68-function ~183-day scan can still exhaust the 90s deadline if the host GQL is slow — it now fails **accurately** (`reason=transport`/`deadline` + remediation), never 500-as-"malformed". The hard cut is `INNGEST_DOUBLEFIRE_FUNCTION_IDS` scoping (now wired). I'll confirm exactly-once by re-running op=verify after merge.

Ref #6178. Follows the #6258 / ADR-106 bounded-scan class.