### PR TITLE
feat(encryption-posture): guest-side LUKS for the registry (zot) volume + posture-ledger flip

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -548,6 +548,12 @@ jobs:
       - name: Run registry boot-guard + disk-observability tests (#6240/#6244)
         run: bash apps/web-platform/infra/registry-boot-guard.test.sh
 
+      # #6895 registry guest-side LUKS-at-rest guard suite (mutation-tested). Registered explicitly
+      # (this job runs named steps, not a glob — an unregistered infra suite gates NOTHING and fails
+      # silently green, #3366/#6520).
+      - name: Run registry LUKS-at-rest guard suite (#6895)
+        run: bash apps/web-platform/infra/registry-luks.test.sh
+
       - name: Run registry private-NIC boot-converger tests (#6415)
         run: bash apps/web-platform/infra/private-nic-guard.test.sh
 

--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -433,7 +433,12 @@ write_files:
         mountpoint -q /var/lib/zot || mount /dev/mapper/registry /var/lib/zot || true
         exit 0
       fi
-      [ -b "$DEV" ] || { echo "[zot] registry-luks-open: $DEV absent — cannot open mapper" >&2; exit 0; }
+      # Device-wait: on a reboot the volume node can reattach AFTER this oneshot fires — mirror the
+      # provision block's own wait (~30 x 2s) so a slow reattach is not misread as a genuinely-absent
+      # device. If the device is still absent after the wait, no-op (exit 0) like the provision block's
+      # device-absent path: fresh-provision formatting is the mount block's job, not this reopen path.
+      for i in $(seq 1 30); do [ -b "$DEV" ] && break; sleep 2; done
+      [ -b "$DEV" ] || { echo "[zot] registry-luks-open: $DEV absent after 60s wait — cannot open mapper" >&2; exit 0; }
       # Only reopen a device that is actually LUKS. First-provision (blkid TYPE empty) is the LUKS
       # mount block's job (it luksFormats), not this reopen path — refuse anything not crypto_LUKS.
       BLKTYPE=$(blkid -o value -s TYPE "$DEV" 2>/dev/null || true)
@@ -559,6 +564,12 @@ write_files:
       if mountpoint -q /var/lib/zot 2>/dev/null; then
         ZOT_STORE_MOUNTED=true
       else
+        # #6895 D2: the store is /dev/mapper/registry, and a reboot (incl. THIS guard's own self-
+        # reboot) leaves the mapper CLOSED — so `mount -a` on the nofail fstab line would fail with
+        # nothing to remount. Re-open it FIRST (idempotent: registry-luks-open.sh no-ops if the
+        # mapper is already open), so the 5-min cron self-heals a closed mapper instead of waiting
+        # for the next reboot's registry-luks-open.service.
+        /usr/local/bin/registry-luks-open.sh >/dev/null 2>&1 || true
         mount -a >/dev/null 2>&1 || true
         if mountpoint -q /var/lib/zot 2>/dev/null; then
           # The mount landed — but zot is STILL bound to the old (empty) dir: bind mounts are
@@ -758,7 +769,7 @@ runcmd:
     doppler run --project soleur-registry --config prd -- bash -s <<'REGLUKSEOF'
     set -uo pipefail
     DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}
-    [ -n "$REGISTRY_LUKS_KEY" ] || { echo "[zot] FATAL: REGISTRY_LUKS_KEY empty — refusing unencrypted registry mount"; exit 1; }
+    [ -n "$REGISTRY_LUKS_KEY" ] || { echo "[zot] FATAL: REGISTRY_LUKS_KEY empty — refusing unencrypted registry mount" >&2; exit 1; }
     # Device-wait: the volume attach can land AFTER cloud-init's disk stage (~30 x 2s).
     for i in $(seq 1 30); do [ -b "$DEV" ] && break; sleep 2; done
     RESIZE_OK=false; BLK_GB=0; DF_BEFORE=0; DF_AFTER=0
@@ -861,6 +872,13 @@ runcmd:
     # Node zombie-reaping idiom buys nothing here. Env-overridable const (mirrors PROD_MEMORY_CAP);
     # the template-derived value is the default, so an operator override still wins for a one-off.
     ZOT_MEMORY_CAP="$${ZOT_MEMORY_CAP:-${zot_memory_cap_mb}m}"
+    # #6895 P1: GATE the launch on the LUKS mount. The LUKS mount block and this zot launch are
+    # SEPARATE runcmd entries and cloud-init continues past a failed entry — so on ANY LUKS failure
+    # (empty key, wrong-TYPE FATAL refuse, closed mapper) /var/lib/zot would stay an empty root-disk
+    # dir and zot would serve an empty/unencrypted store that answers 401, keeping the liveness
+    # heartbeat GREEN with no alert. Refuse unless /var/lib/zot is backed by /dev/mapper/registry:
+    # fail-loud here => zot never starts => the liveness-absence alarm fires (git-data's precedent).
+    findmnt -no SOURCE /var/lib/zot | grep -qx /dev/mapper/registry || { echo "[zot] FATAL: /var/lib/zot not backed by /dev/mapper/registry — refusing to serve an empty/unencrypted store" >&2; exit 1; }
     docker run -d --name zot --restart unless-stopped \
       --log-driver journald \
       --memory "$ZOT_MEMORY_CAP" --memory-swap "$ZOT_MEMORY_CAP" \

--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -20,6 +20,7 @@ packages:
   - jq # parse `doppler secrets --only-names --json` for the boot-time isolation self-check (runcmd)
   - e2fsprogs # resize2fs — grow the ext4 fs to fill the 60 GB volume (#6240/#6247). The packages: stage
     # is NON-FATAL (failures logged, boot continues), so a runcmd dpkg-guard re-ensures it below.
+  - cryptsetup # #6895 — guest-side LUKS-at-rest for the raw registry store volume (luksFormat/luksOpen).
 
 groups:
   - docker
@@ -409,6 +410,71 @@ write_files:
     owner: root:root
     permissions: '0644'
 
+  # --- #6895 (D2): idempotent boot-time LUKS open of the registry store mapper ------------
+  # runcmd is PER-INSTANCE and does NOT re-run on reboot — and THIS host self-reboots as a
+  # convergence primitive (soleur-private-nic-guard.sh calls `reboot`, see the NIC-guard block
+  # below). Without a boot-time reopen the /dev/mapper/registry mapper stays CLOSED after a
+  # reboot, the nofail fstab line cannot mount, the NIC guard's `mount -a` self-heal fails, and
+  # zot binds an empty root-disk dir and 404s every image while nic_ok=true. This oneshot reopens
+  # the mapper (if closed) after network-online (Doppler egress) and BEFORE docker + cron, so the
+  # fstab mount / the NIC-guard `mount -a` self-heal remount /dev/mapper/registry. Reject
+  # /etc/crypttab-with-keyfile: it would write the passphrase in cleartext on the host disk,
+  # defeating the Doppler-only custody property. Reads REGISTRY_LUKS_KEY via the persisted
+  # /etc/default/registry-doppler (survives reboot on the root disk) under the scoped
+  # soleur-registry/prd token. `${registry_volume_id}` is terraform-interpolated; $REGISTRY_LUKS_KEY
+  # / $DEV (no braces) stay literal for the doppler shell.
+  - path: /usr/local/bin/registry-luks-open.sh
+    content: |
+      #!/usr/bin/env bash
+      set -uo pipefail
+      DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}
+      # Already open? just ensure the mount is present (idempotent) and exit.
+      if [ -e /dev/mapper/registry ]; then
+        mountpoint -q /var/lib/zot || mount /dev/mapper/registry /var/lib/zot || true
+        exit 0
+      fi
+      [ -b "$DEV" ] || { echo "[zot] registry-luks-open: $DEV absent — cannot open mapper" >&2; exit 0; }
+      # Only reopen a device that is actually LUKS. First-provision (blkid TYPE empty) is the LUKS
+      # mount block's job (it luksFormats), not this reopen path — refuse anything not crypto_LUKS.
+      BLKTYPE=$(blkid -o value -s TYPE "$DEV" 2>/dev/null || true)
+      if [ "$BLKTYPE" != crypto_LUKS ]; then
+        echo "[zot] registry-luks-open: $DEV TYPE=$BLKTYPE not crypto_LUKS — first-provision handles luksFormat; not reopening" >&2
+        exit 0
+      fi
+      set -a
+      . /etc/default/registry-doppler
+      set +a
+      doppler run --project soleur-registry --config prd -- bash -s <<'REGOPENEOF'
+      set -uo pipefail
+      DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}
+      [ -n "$REGISTRY_LUKS_KEY" ] || { echo "[zot] registry-luks-open FATAL: REGISTRY_LUKS_KEY empty — cannot open mapper" >&2; exit 1; }
+      [ -e /dev/mapper/registry ] || printf '%s' "$REGISTRY_LUKS_KEY" | cryptsetup luksOpen --key-file - "$DEV" registry
+      mountpoint -q /var/lib/zot || mount /dev/mapper/registry /var/lib/zot || true
+      REGOPENEOF
+    owner: root:root
+    permissions: '0755'
+
+  # The oneshot that runs the reopen on EVERY boot (unlike per-instance runcmd). Ordered after
+  # network-online (Doppler egress) and BEFORE docker.service + cron.service, so the mapper is
+  # open before zot launches and before the NIC-guard self-heal's `mount -a` fires (D2).
+  - path: /etc/systemd/system/registry-luks-open.service
+    content: |
+      [Unit]
+      Description=Reopen the registry LUKS store mapper on boot (#6895, D2) — before docker + the NIC-guard self-heal
+      After=network-online.target
+      Wants=network-online.target
+      Before=docker.service cron.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/local/bin/registry-luks-open.sh
+
+      [Install]
+      WantedBy=multi-user.target
+    owner: root:root
+    permissions: '0644'
+
   # --- #6415 / ADR-115: private-NIC boot converger ----------------------------------------
   # Root cause of the 2026-07-14 outage (#6400). hcloud_server_network is an ADDITIVE ONLINE
   # ATTACH (network.tf:9-13) — it needs a created server, and a created server is already
@@ -639,54 +705,15 @@ runcmd:
   # Apply SSH hardening immediately.
   - systemctl restart sshd
 
-  # Mount + grow the zot storage volume, FAIL-LOUD (#6240). The old `mount ... || true` +
-  # `resize2fs ... || true` SILENTLY SWALLOWED failure: the ext4 fs on the 30 GB block device
-  # never grew past its original size, filled, and zot 500'd every blob push with ENOSPC while
-  # the disk heartbeat (which pings only <85%) never fired — and the volume API reported the
-  # BLOCK-device size (30 GB), never the FILESYSTEM size, so the blind spot survived a fresh
-  # host on the preserved volume. This block: (1) waits for the volume device node (attach
-  # race the bare `mount` hid); (2) re-ensures e2fsprogs (packages: stage is non-fatal); (3)
-  # asserts the ext4-on-raw-device (no-partition) invariant so `resize2fs <device>` is correct
-  # and growpart is NOT used; (4) PERSISTS the boot resize record to /var/lib/zot/.resize-result —
-  # the Phase-1 SOLEUR_ZOT_DISK reporter reads resize_ok + block_size_gb from it (fs_size_gb it
-  # recomputes live; df_before_gb/df_after_gb are an on-host forensic breadcrumb, not shipped); (5)
-  # is LOUD in telemetry on failure (resize_ok=false) but does NOT wedge the boot — zot still
-  # launches on the existing fs so the host stays reachable to self-report (fail-loud, NOT
-  # fail-dark). A persistent fs_size_gb << block_size_gb is the #6240 smoking gun.
-  - mkdir -p /var/lib/zot
-  - |
-    DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}
-    # Device-wait: the volume attach can land AFTER cloud-init's disk stage (~30 x 2s).
-    for i in $(seq 1 30); do [ -b "$DEV" ] && break; sleep 2; done
-    RESIZE_OK=false; BLK_GB=0; DF_BEFORE=0; DF_AFTER=0
-    if [ ! -b "$DEV" ]; then
-      echo "[zot] SOLEUR_ZOT_DISK resize_ok=false reason=device-absent dev=$DEV — volume node never appeared after 60s; launching zot on whatever /var/lib/zot resolves to" >&2
-    elif lsblk -no TYPE "$DEV" 2>/dev/null | grep -q '^part$'; then
-      # ext4-on-raw-device invariant broken: a partition unexpectedly appeared. Refuse to
-      # resize the wrong node (growpart would be needed) — fail LOUD, do not guess.
-      echo "[zot] SOLEUR_ZOT_DISK resize_ok=false reason=unexpected-partition dev=$DEV — expected raw ext4 (Hetzner format=ext4), refusing to resize a partitioned device" >&2
-    else
-      dpkg -s e2fsprogs >/dev/null 2>&1 || apt-get install -y e2fsprogs || echo "[zot] WARN: e2fsprogs install failed — resize2fs may be missing" >&2
-      mount "$DEV" /var/lib/zot || echo "[zot] WARN: mount $DEV /var/lib/zot failed (may already be mounted)" >&2
-      DF_BEFORE=$(df -B1G --output=size /var/lib/zot 2>/dev/null | tail -1 | tr -dc '0-9'); [ -n "$DF_BEFORE" ] || DF_BEFORE=0
-      # NO `|| true` here — the resize2fs exit code is CAPTURED (not swallowed) and shipped.
-      if resize2fs "$DEV"; then
-        RESIZE_OK=true
-      else
-        echo "[zot] SOLEUR_ZOT_DISK resize_ok=false reason=resize2fs-failed dev=$DEV — ext4 not grown; launching zot on the existing fs (telemetry stays loud)" >&2
-      fi
-      DF_AFTER=$(df -B1G --output=size /var/lib/zot 2>/dev/null | tail -1 | tr -dc '0-9'); [ -n "$DF_AFTER" ] || DF_AFTER=0
-    fi
-    BLK_GB=$(lsblk -bno SIZE "$DEV" 2>/dev/null | head -1 | awk '{printf "%d", $1/1024/1024/1024}'); [ -n "$BLK_GB" ] || BLK_GB=0
-    printf 'resize_ok=%s\nfs_size_gb=%s\nblock_size_gb=%s\ndf_before_gb=%s\ndf_after_gb=%s\n' \
-      "$RESIZE_OK" "$DF_AFTER" "$BLK_GB" "$DF_BEFORE" "$DF_AFTER" > /var/lib/zot/.resize-result
-    # Assert the fs reached ~ the block device (within 2 GB). Loud WARN only — never wedge boot.
-    if [ "$BLK_GB" -gt 0 ] && [ "$DF_AFTER" -gt 0 ] && [ "$(( BLK_GB - DF_AFTER ))" -gt 2 ]; then
-      echo "[zot] SOLEUR_ZOT_DISK resize_ok=$RESIZE_OK WARN fs_size_gb=$DF_AFTER lags block_size_gb=$BLK_GB — ext4 did not fill the device (#6240 hypothesis a)" >&2
-    fi
-  - echo '/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id} /var/lib/zot ext4 defaults,nofail 0 2' >> /etc/fstab
+  # #6895: the zot store volume mount + resize is now the guest-side LUKS block, and it needs the
+  # Doppler CLI + /etc/default/registry-doppler in place to read REGISTRY_LUKS_KEY (P1-B). So the
+  # Doppler CLI install + env-file write below run FIRST, and the LUKS format/open/mount/resize
+  # block runs right after them (before `systemctl enable --now docker`). The plaintext by-id
+  # `mount $DEV /var/lib/zot` + its by-id fstab line are DELETED — the store is mounted from
+  # /dev/mapper/registry only (a stale by-id fstab line would reboot-double-mount /var/lib/zot and
+  # attempt a raw-ext4 mount of a now-crypto_LUKS device).
 
-  # --- Doppler CLI (${doppler_arch}) — the ONLY channel for the ZOT_* tokens ------------
+  # --- Doppler CLI (${doppler_arch}) — the ONLY channel for the ZOT_* tokens + LUKS key --
   # The tokens are NEVER baked into user_data (retrievable via the hcloud metadata API). They
   # arrive ONLY as the Doppler-injected env at boot. Arch (arm64/amd64) + its checksum are
   # terraform-interpolated from local.registry_arch (derived from registry_server_type), so the
@@ -710,6 +737,73 @@ runcmd:
   - printf 'HOME=/root\nDOPPLER_TOKEN=%s\nDOPPLER_CONFIG_DIR=/tmp/.doppler\nDOPPLER_ENABLE_VERSION_CHECK=false\n' '${doppler_token}' > /etc/default/registry-doppler
   - chmod 600 /etc/default/registry-doppler
 
+  # --- #6895: guest-side LUKS-at-rest mount + resize of the zot store volume ------------
+  # Replaces the old plaintext `mount $DEV /var/lib/zot`. The volume is a RAW block device
+  # (zot-registry.tf hcloud_volume.registry has no `format`); cryptsetup luksFormats it luks2 in
+  # the guest, unlocked by REGISTRY_LUKS_KEY delivered ONLY as the Doppler-injected env (never an
+  # argv positional, never baked into user_data). Runs UNDER `doppler run` scoped to the isolated
+  # soleur-registry/prd config. D1/Option B `blkid TYPE` discriminator: "" (fresh) -> luksFormat;
+  # crypto_LUKS -> reuse (idempotent re-provision); ANY OTHER TYPE (e.g. a populated plaintext
+  # ext4 the registry-host-replace preserve-path kept) -> FATAL refuse, NEVER a silent wipe
+  # (ADR-096 footgun). FAIL LOUD on an empty key — never an unencrypted fallback. Resize targets
+  # the MAPPER (cryptsetup resize + resize2fs /dev/mapper/registry), not the raw device, and
+  # PERSISTS /var/lib/zot/.resize-result for the SOLEUR_ZOT_DISK reporter (fail-loud, not
+  # fail-dark: resize2fs's exit code is captured, not swallowed). `${registry_volume_id}` is
+  # terraform-interpolated; $REGISTRY_LUKS_KEY / $DEV (no braces) stay literal for the doppler shell.
+  - mkdir -p /var/lib/zot
+  - |
+    set -a
+    . /etc/default/registry-doppler
+    set +a
+    doppler run --project soleur-registry --config prd -- bash -s <<'REGLUKSEOF'
+    set -uo pipefail
+    DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}
+    [ -n "$REGISTRY_LUKS_KEY" ] || { echo "[zot] FATAL: REGISTRY_LUKS_KEY empty — refusing unencrypted registry mount"; exit 1; }
+    # Device-wait: the volume attach can land AFTER cloud-init's disk stage (~30 x 2s).
+    for i in $(seq 1 30); do [ -b "$DEV" ] && break; sleep 2; done
+    RESIZE_OK=false; BLK_GB=0; DF_BEFORE=0; DF_AFTER=0
+    if [ ! -b "$DEV" ]; then
+      echo "[zot] SOLEUR_ZOT_DISK resize_ok=false reason=device-absent dev=$DEV — volume node never appeared after 60s; refusing to luksFormat/mount a missing device" >&2
+    else
+      # D1/Option B — blkid TYPE discriminator on the RAW device (replaces the old lsblk ^part
+      # ext4-on-raw invariant). Only "" (fresh) or crypto_LUKS (already-LUKS) are admitted; any
+      # other TYPE FATALs (a plaintext volume must be RECUT, not wiped — ADR-096 footgun).
+      TYPE=$(blkid -o value -s TYPE "$DEV" 2>/dev/null || true)
+      case "$TYPE" in
+        "")          printf '%s' "$REGISTRY_LUKS_KEY" | cryptsetup luksFormat --batch-mode --type luks2 --key-file - "$DEV" ;;
+        crypto_LUKS) : ;; # already LUKS — skip format (idempotent re-provision), luksOpen below
+        *)           echo "[zot] SOLEUR_ZOT_DISK resize_ok=false reason=refusing-non-luks-device dev=$DEV TYPE=$TYPE — expected empty (fresh raw) or crypto_LUKS; a plaintext volume must be recut, not wiped (ADR-096)" >&2; exit 1 ;;
+      esac
+      # Open the mapper if closed, then lay/reuse the ext4 fs INSIDE it.
+      [ -e /dev/mapper/registry ] || printf '%s' "$REGISTRY_LUKS_KEY" | cryptsetup luksOpen --key-file - "$DEV" registry
+      blkid /dev/mapper/registry >/dev/null 2>&1 || mkfs.ext4 -q /dev/mapper/registry
+      dpkg -s e2fsprogs >/dev/null 2>&1 || apt-get install -y e2fsprogs || echo "[zot] WARN: e2fsprogs install failed — resize2fs may be missing" >&2
+      mountpoint -q /var/lib/zot || mount /dev/mapper/registry /var/lib/zot || echo "[zot] WARN: mount /dev/mapper/registry /var/lib/zot failed (may already be mounted)" >&2
+      DF_BEFORE=$(df -B1G --output=size /var/lib/zot 2>/dev/null | tail -1 | tr -dc '0-9'); [ -n "$DF_BEFORE" ] || DF_BEFORE=0
+      # Grow the LUKS mapper to fill a grown underlying volume FIRST, then the ext4 inside it.
+      # resize2fs targets the MAPPER, not the raw $DEV (a raw resize2fs would hit the LUKS header).
+      cryptsetup resize registry || echo "[zot] WARN: cryptsetup resize registry failed — mapper not grown" >&2
+      # NO `|| true` here — the resize2fs exit code is CAPTURED (not swallowed) and shipped.
+      if resize2fs /dev/mapper/registry; then
+        RESIZE_OK=true
+      else
+        echo "[zot] SOLEUR_ZOT_DISK resize_ok=false reason=resize2fs-failed dev=/dev/mapper/registry — ext4 not grown; launching zot on the existing fs (telemetry stays loud)" >&2
+      fi
+      DF_AFTER=$(df -B1G --output=size /var/lib/zot 2>/dev/null | tail -1 | tr -dc '0-9'); [ -n "$DF_AFTER" ] || DF_AFTER=0
+    fi
+    BLK_GB=$(lsblk -bno SIZE /dev/mapper/registry 2>/dev/null | head -1 | awk '{printf "%d", $1/1024/1024/1024}'); [ -n "$BLK_GB" ] || BLK_GB=0
+    printf 'resize_ok=%s\nfs_size_gb=%s\nblock_size_gb=%s\ndf_before_gb=%s\ndf_after_gb=%s\n' \
+      "$RESIZE_OK" "$DF_AFTER" "$BLK_GB" "$DF_BEFORE" "$DF_AFTER" > /var/lib/zot/.resize-result
+    # Assert the fs reached ~ the mapper size (within 2 GB). Loud WARN only — never wedge boot.
+    if [ "$BLK_GB" -gt 0 ] && [ "$DF_AFTER" -gt 0 ] && [ "$(( BLK_GB - DF_AFTER ))" -gt 2 ]; then
+      echo "[zot] SOLEUR_ZOT_DISK resize_ok=$RESIZE_OK WARN fs_size_gb=$DF_AFTER lags block_size_gb=$BLK_GB — ext4 did not fill the mapper (#6240 hypothesis a)" >&2
+    fi
+    # fstab: mount the MAPPER (NOT the raw by-id device). nofail so a volume hiccup never wedges
+    # boot; the D2 boot-open oneshot (registry-luks-open.service) reopens the mapper on reboot so
+    # this line can remount /dev/mapper/registry. Append-if-absent (idempotent re-provision).
+    grep -q '/dev/mapper/registry' /etc/fstab || echo '/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2' >> /etc/fstab
+    REGLUKSEOF
+
   # Ensure docker is up before the container launch.
   - systemctl enable --now docker
 
@@ -726,23 +820,26 @@ runcmd:
     doppler run --project soleur-registry --config prd -- bash -s <<'ZOTEOF'
     set -euo pipefail
     # Isolation self-check — the load-bearing, fail-CLOSED defense, run under the host's OWN
-    # shipped boot token: the credential MUST resolve EXACTLY the THREE admitted secrets
-    # {ZOT_PULL_TOKEN, ZOT_PUSH_TOKEN, BETTERSTACK_LOGS_TOKEN}. Every other boot signal (the
-    # empty-token guard below, the heartbeat, `terraform apply`) fails OPEN on an over-scoped
-    # credential — a 116-secret token still populates the ZOT tokens non-empty. This asserts
-    # cardinality (==3) AND identity (the exact admitted set), on the shipped token, before any
-    # docker run. `grep -v '^DOPPLER_'` strips the DOPPLER_PROJECT/CONFIG/ENVIRONMENT built-ins.
+    # shipped boot token: the credential MUST resolve EXACTLY the FOUR admitted secrets
+    # {ZOT_PULL_TOKEN, ZOT_PUSH_TOKEN, BETTERSTACK_LOGS_TOKEN, REGISTRY_LUKS_KEY}. Every other boot
+    # signal (the empty-token guard below, the heartbeat, `terraform apply`) fails OPEN on an
+    # over-scoped credential — a 116-secret token still populates the ZOT tokens non-empty. This
+    # asserts cardinality (==4) AND identity (the exact admitted set), on the shipped token, before
+    # any docker run. `grep -v '^DOPPLER_'` strips the DOPPLER_PROJECT/CONFIG/ENVIRONMENT built-ins.
     # BETTERSTACK_LOGS_TOKEN is admitted BY NAME (#6244): the disk-report reporter ships
     # SOLEUR_ZOT_DISK under `doppler run` from this same isolated config, mirroring the
-    # cloud-init-inngest.yml precedent (ADR-100). DELETING it post-cutover FATALs the bootstrap
-    # (loud fail > silent observability blind spot); the check keys on the NAME, so a value
-    # rotation is safe. The secret MUST be applied (doppler_secret.registry_betterstack_logs_token)
-    # in the SAME registry-host-replace dispatch as the host replace — a 2-secret config now FATALs.
+    # cloud-init-inngest.yml precedent (ADR-100). REGISTRY_LUKS_KEY is admitted BY NAME (#6895): it
+    # is the guest-side LUKS passphrase this same isolated config now holds (doppler_secret.
+    # registry_luks_key) and the LUKS mount block above reads it under `doppler run`; it is a
+    # registry-scoped secret, so the #6122 isolation property is preserved. DELETING either admitted
+    # secret post-cutover FATALs the bootstrap (loud fail > silent observability/at-rest blind spot);
+    # the check keys on the NAME, so a value rotation is safe. All four MUST be applied in the SAME
+    # apply as the host — a 3-secret config now FATALs.
     names="$(doppler secrets --only-names --json | jq -r 'keys[]' | grep -v '^DOPPLER_' || true)"
     n_total="$(printf '%s\n' "$names" | grep -c . || true)"
-    n_admitted="$(printf '%s\n' "$names" | grep -Ec '^(ZOT_(PULL|PUSH)_TOKEN|BETTERSTACK_LOGS_TOKEN)$' || true)"
-    if [ "$n_total" -ne 3 ] || [ "$n_admitted" -ne 3 ]; then
-      echo "[zot] FATAL: boot credential is not isolated (sees $n_total non-DOPPLER secrets, $n_admitted admitted {ZOT_PULL_TOKEN,ZOT_PUSH_TOKEN,BETTERSTACK_LOGS_TOKEN}) — refusing to launch"; exit 1
+    n_admitted="$(printf '%s\n' "$names" | grep -Ec '^(ZOT_(PULL|PUSH)_TOKEN|BETTERSTACK_LOGS_TOKEN|REGISTRY_LUKS_KEY)$' || true)"
+    if [ "$n_total" -ne 4 ] || [ "$n_admitted" -ne 4 ]; then
+      echo "[zot] FATAL: boot credential is not isolated (sees $n_total non-DOPPLER secrets, $n_admitted admitted {ZOT_PULL_TOKEN,ZOT_PUSH_TOKEN,BETTERSTACK_LOGS_TOKEN,REGISTRY_LUKS_KEY}) — refusing to launch"; exit 1
     fi
     [ -n "$ZOT_PULL_TOKEN" ] || { echo "[zot] FATAL: ZOT_PULL_TOKEN empty — refusing to build htpasswd"; exit 1; }
     [ -n "$ZOT_PUSH_TOKEN" ] || { echo "[zot] FATAL: ZOT_PUSH_TOKEN empty — refusing to build htpasswd"; exit 1; }
@@ -811,3 +908,8 @@ runcmd:
   # passing silently. This is the one place where fail-open and fail-loud agree.
   - systemctl daemon-reload || true
   - systemctl enable --now zot-liveness-heartbeat.timer || true
+  # #6895 (D2): ARM the boot-time LUKS reopen so a reboot (the NIC guard self-`reboot`s the host)
+  # reopens /dev/mapper/registry before docker + the self-heal. `enable` persists it for the next
+  # boot; the mapper is already open+mounted on THIS provision boot (the LUKS mount block above),
+  # so `--now` is an idempotent no-op that also validates the unit loudly at provision time.
+  - systemctl enable --now registry-luks-open.service || true

--- a/apps/web-platform/infra/registry-boot-guard.test.sh
+++ b/apps/web-platform/infra/registry-boot-guard.test.sh
@@ -99,6 +99,7 @@ echo "--- structural: SOLEUR_ZOT_DISK self-report (#6244) ---"
 assert "SOLEUR_ZOT_DISK marker line emitted" "grep -qF 'SOLEUR_ZOT_DISK pcent=' '$CI'"
 # Tie each field to the LINE="SOLEUR_ZOT_DISK assignment ITSELF, not anywhere-in-file (Kieran P2:
 # the old anywhere grep false-passes a field named only in a comment). LINE= is one physical line.
+# shellcheck disable=SC2034  # used inside the eval'd `assert` condition strings below (shellcheck can't see it)
 LINE_ASSIGN="$(grep -F 'LINE="SOLEUR_ZOT_DISK' "$CI" | head -1)"
 assert "LINE=\"SOLEUR_ZOT_DISK assignment found" "[ -n \"\$LINE_ASSIGN\" ]"
 for f in pcent= fs_size_gb= block_size_gb= resize_ok= zot_restarts= ping_rc= \
@@ -115,6 +116,7 @@ done
 # rescue it: an expansion error is not a command failure. Since this heartbeat's ABSENCE is
 # itself an alarm, that failure pages "host down" when only the probe broke. This shipped in
 # #6497's first draft and was caught at review — pin it so it cannot come back.
+# shellcheck disable=SC2034  # used inside the eval'd `assert` condition strings below (shellcheck can't see it)
 PROBE_BLOCK="$(awk '/_htp_verify\(\) \{/,/^      fi$/' "$CI")"
 assert "htpasswd probe block found" "[ -n \"\$PROBE_BLOCK\" ]"
 assert "probe never expands a token BARE (set -u would kill the whole heartbeat)" \

--- a/apps/web-platform/infra/registry-boot-guard.test.sh
+++ b/apps/web-platform/infra/registry-boot-guard.test.sh
@@ -3,13 +3,14 @@
 # hardening added in #6240/#6244 (cloud-init-registry.yml).
 #
 # TWO layers:
-#   1. BEHAVIORAL (the load-bearing part): the boot isolation self-check now expects THREE
-#      admitted secrets {ZOT_PULL_TOKEN, ZOT_PUSH_TOKEN, BETTERSTACK_LOGS_TOKEN}. This test
-#      EXTRACTS the admit-regex + the cardinality integer FROM cloud-init-registry.yml (so the
-#      decision logic under test is the SAME bytes the host boots with — no re-derived copy to
-#      drift) and evaluates the guard's exact predicate against synthesized name-sets. The
-#      2-secret set (the OLD cardinality) must now FATAL — that is the RED→GREEN behavioral
-#      change this fix ships. Fixtures are SYNTHESIZED (cq-test-fixtures-synthesized-only).
+#   1. BEHAVIORAL (the load-bearing part): the boot isolation self-check now expects FOUR
+#      admitted secrets {ZOT_PULL_TOKEN, ZOT_PUSH_TOKEN, BETTERSTACK_LOGS_TOKEN, REGISTRY_LUKS_KEY}
+#      (#6895 added the guest-LUKS passphrase to the isolated config). This test EXTRACTS the
+#      admit-regex + the cardinality integer FROM cloud-init-registry.yml (so the decision logic
+#      under test is the SAME bytes the host boots with — no re-derived copy to drift) and
+#      evaluates the guard's exact predicate against synthesized name-sets. The 3-secret set (the
+#      OLD cardinality) must now FATAL — that is the RED→GREEN behavioral change this fix ships.
+#      Fixtures are SYNTHESIZED (cq-test-fixtures-synthesized-only).
 #   2. STRUCTURAL grep assertions: resize2fs fail-loud (no `|| true`), device-wait, e2fsprogs,
 #      .resize-result persistence, the SOLEUR_ZOT_DISK field set, the `doppler run` cron wrap,
 #      and the tightened gc/retention values.
@@ -40,8 +41,9 @@ GUARD_RE="$(grep -F 'n_admitted=' "$CI" | grep -oE "grep -Ec '[^']*'" | sed "s/g
 CARD="$(grep -oE '\[ "\$n_total" -ne [0-9]+ \]' "$CI" | grep -oE '[0-9]+' | head -1)"
 echo "--- extracted: admit-regex='${GUARD_RE}' cardinality='${CARD}' ---"
 assert "admit-regex was extracted" "[[ -n '$GUARD_RE' ]]"
-assert "cardinality extracted and == 3" "[[ '$CARD' == '3' ]]"
+assert "cardinality extracted and == 4" "[[ '$CARD' == '4' ]]"
 assert "admit-regex names BETTERSTACK_LOGS_TOKEN" "grep -q 'BETTERSTACK_LOGS_TOKEN' <<<'$GUARD_RE'"
+assert "admit-regex names REGISTRY_LUKS_KEY (#6895)" "grep -q 'REGISTRY_LUKS_KEY' <<<'$GUARD_RE'"
 
 # guard_decision: replays the file's exact predicate (strip DOPPLER_ builtins, count total +
 # admitted, FATAL unless both == CARD). Prints PASS/FATAL; returns 0 on PASS.
@@ -55,25 +57,27 @@ guard_decision() {
 }
 
 echo "--- behavioral: boot isolation self-check decision ---"
-# The exact isolated 3-secret set → PASS.
-assert "the 3 admitted secrets PASS the guard" \
-  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN)\" == PASS ]]"
-# The OLD 2-secret set is now rejected (the RED→GREEN behavioral change).
-assert "the OLD 2-secret set now FATALs (cardinality raised 2->3)" \
-  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN)\" == FATAL ]]"
-# An over-scoped credential leaks a foreign secret → n_total=4 → FATAL (fail-closed).
-assert "an over-scoped 4th (foreign) secret FATALs" \
-  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN SUPABASE_SERVICE_ROLE_KEY)\" == FATAL ]]"
-# Right count (3) but wrong identity (a non-admitted name) → FATAL (identity, not just cardinality).
-assert "3 names but wrong identity FATALs (identity assert)" \
-  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN FOO_TOKEN)\" == FATAL ]]"
+# The exact isolated 4-secret set → PASS (#6895 added REGISTRY_LUKS_KEY).
+assert "the 4 admitted secrets PASS the guard" \
+  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN REGISTRY_LUKS_KEY)\" == PASS ]]"
+# The OLD 3-secret set is now rejected (the RED→GREEN behavioral change: cardinality raised 3->4).
+assert "the OLD 3-secret set now FATALs (cardinality raised 3->4)" \
+  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN)\" == FATAL ]]"
+# An over-scoped credential leaks a foreign secret → n_total=5 → FATAL (fail-closed).
+assert "an over-scoped 5th (foreign) secret FATALs" \
+  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN REGISTRY_LUKS_KEY SUPABASE_SERVICE_ROLE_KEY)\" == FATAL ]]"
+# Right count (4) but wrong identity (a non-admitted name) → FATAL (identity, not just cardinality).
+assert "4 names but wrong identity FATALs (identity assert)" \
+  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN FOO_TOKEN)\" == FATAL ]]"
 # DOPPLER_* builtins are stripped before counting (so they do not inflate n_total).
 assert "DOPPLER_* builtins are stripped before counting" \
-  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN DOPPLER_PROJECT DOPPLER_CONFIG)\" == PASS ]]"
+  "[[ \"\$(guard_decision ZOT_PULL_TOKEN ZOT_PUSH_TOKEN BETTERSTACK_LOGS_TOKEN REGISTRY_LUKS_KEY DOPPLER_PROJECT DOPPLER_CONFIG)\" == PASS ]]"
 
 echo "--- structural: resize2fs fail-loud (#6240) ---"
-assert "resize2fs is invoked in an if (exit code captured, not swallowed)" \
-  "grep -qE 'if resize2fs \"\\\$DEV\"; then' '$CI'"
+# #6895: resize2fs now targets the LUKS MAPPER (/dev/mapper/registry), not the raw $DEV — a raw
+# resize2fs would hit the LUKS header. The exit code is still captured in an `if` (not swallowed).
+assert "resize2fs is invoked in an if targeting the mapper (exit code captured, not swallowed)" \
+  "grep -qE 'if resize2fs /dev/mapper/registry; then' '$CI'"
 # The silent-swallow was `resize2fs ... || true` on a COMMAND line; the historical comment that
 # documents the old bug legitimately still contains that string, so exclude comment lines first.
 assert "no 'resize2fs ... || true' silent-swallow on any command line" \
@@ -83,8 +87,11 @@ assert "device-wait loop precedes mount (attach race)" \
 assert "e2fsprogs is in packages:" "grep -qE '^[[:space:]]*-[[:space:]]*e2fsprogs' '$CI'"
 assert "e2fsprogs runcmd dpkg re-ensure guard present (packages: stage non-fatal)" \
   "grep -qE 'dpkg -s e2fsprogs' '$CI'"
-assert "ext4-on-raw-device (no-partition) invariant asserted" \
-  "grep -qE 'lsblk -no TYPE .*grep -q .\\^part' '$CI'"
+# #6895: the old ext4-on-raw lsblk `^part` invariant is REPLACED by the D1/Option B blkid TYPE
+# discriminator — the raw device must be "" (fresh, -> luksFormat) or crypto_LUKS (reuse); any
+# other TYPE FATALs (refuse to wipe a plaintext volume the host-replace preserve-path kept).
+assert "raw-device blkid TYPE discriminator present (fresh/crypto_LUKS/else-FATAL)" \
+  "grep -qE 'blkid -o value -s TYPE \"\\\$DEV\"' '$CI' && grep -qE 'crypto_LUKS\\)' '$CI' && grep -qF 'refusing-non-luks-device' '$CI'"
 assert ".resize-result is persisted for the reporter" \
   "grep -qF '/var/lib/zot/.resize-result' '$CI'"
 

--- a/apps/web-platform/infra/registry-luks.test.sh
+++ b/apps/web-platform/infra/registry-luks.test.sh
@@ -43,11 +43,13 @@ fail() { fails=$((fails + 1)); echo "FAIL: $1" >&2; }
 # --- Predicates (each takes a file, echoes "1" if the property holds, else "0") ---
 
 # D1/B blkid TYPE discriminator: reads TYPE off the RAW device, has a crypto_LUKS reuse arm, and
-# an else->FATAL refuse arm (the plaintext-volume footgun). All three must be present.
+# an else->FATAL refuse arm (the plaintext-volume footgun). The refuse arm must not merely PRINT the
+# reason — it must HALT (`exit 1` co-located on the refuse line), else a wrong-TYPE device would log
+# and then fall through to luksOpen/mount. Require reason + `exit 1` on the SAME line.
 p_discriminator() {
   if grep -qE 'blkid -o value -s TYPE "\$DEV"' "$1" \
     && grep -qE 'crypto_LUKS\)' "$1" \
-    && grep -qF 'refusing-non-luks-device' "$1"; then echo 1; else echo 0; fi
+    && grep -qE 'refusing-non-luks-device.*exit 1' "$1"; then echo 1; else echo 0; fi
 }
 
 # Every luksFormat/luksOpen line pipes the key via `--key-file -` (stdin) AND carries NO
@@ -81,9 +83,12 @@ p_fstab_mapper() {
   if grep -Eq "echo '/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2' >> /etc/fstab" "$1"; then echo 1; else echo 0; fi
 }
 
-# Fail-loud on empty key (no unencrypted fallback).
+# Fail-loud on empty key (no unencrypted fallback). Asserting the guard EXISTS is not enough — the
+# `||` branch must actually HALT the mount block (`exit 1`), else an empty key would log and then
+# fall through to luksFormat/mount an unencrypted store. Scope to the mount-block guard by its
+# message ("refusing unencrypted registry mount") so it pins THAT line's exit 1, not any sibling.
 p_fail_loud() {
-  if grep -Eq '\[ -n "\$REGISTRY_LUKS_KEY" \]' "$1"; then echo 1; else echo 0; fi
+  if grep -Eq '\[ -n "\$REGISTRY_LUKS_KEY" \][[:space:]]*\|\|.*refusing unencrypted registry mount.*exit 1' "$1"; then echo 1; else echo 0; fi
 }
 
 # Key sourced from the Doppler-injected env, scoped to the isolated soleur-registry/prd config.
@@ -92,28 +97,42 @@ p_doppler_run() {
 }
 
 # The passphrase is generated (random_password) and pushed to Doppler — NEVER a literal in the .tf.
+# Assert the "no literal passphrase" half the comment claims: the doppler_secret's value is the
+# GENERATED result (random_password.registry_luks.result), not an inline string.
 p_tf_random() {
   if grep -Eq 'resource "random_password" "registry_luks"' "$1" \
-    && grep -Eq 'name[[:space:]]*=[[:space:]]*"REGISTRY_LUKS_KEY"' "$1"; then echo 1; else echo 0; fi
+    && grep -Eq 'name[[:space:]]*=[[:space:]]*"REGISTRY_LUKS_KEY"' "$1" \
+    && grep -Eq 'value[[:space:]]*=[[:space:]]*random_password\.registry_luks\.result' "$1"; then echo 1; else echo 0; fi
 }
 
-# D1/B: the registry volume is a RAW device — NO format="ext4" (guest luksFormats it).
+# D1/B: the registry volume is a RAW device — NO format="ext4" (guest luksFormats it). Scope the
+# negative to the hcloud_volume.registry block so an unrelated ext4 elsewhere in the .tf cannot
+# false-fail it, and so the block-local mutation (inserting format="ext4") genuinely flips it red.
 p_no_format_ext4() {
-  if ! grep -Eq 'format[[:space:]]*=[[:space:]]*"ext4"' "$1"; then echo 1; else echo 0; fi
+  local blk
+  blk="$(awk '/resource "hcloud_volume" "registry" \{/,/^}/' "$1")"
+  if ! grep -Eq 'format[[:space:]]*=[[:space:]]*"ext4"' <<<"$blk"; then echo 1; else echo 0; fi
 }
 
-# The attachment binds the real registry volume (linter attachment_binds_volume).
+# The attachment binds the real registry volume (linter attachment_binds_volume). Anchor at line
+# start so the `registry_volume_id = …` templatefile arg cannot satisfy this as a substring — only
+# the hcloud_volume_attachment's own `volume_id = …` key counts.
 p_attach_binds() {
-  if grep -Eq 'volume_id[[:space:]]*=[[:space:]]*hcloud_volume\.registry\.id' "$1"; then echo 1; else echo 0; fi
+  if grep -Eq '^[[:space:]]*volume_id[[:space:]]*=[[:space:]]*hcloud_volume\.registry\.id' "$1"; then echo 1; else echo 0; fi
 }
 
 # D2 (REQUIRED): boot-time luksOpen oneshot, ordered after network-online and BEFORE docker + cron
-# (the host self-reboots, so the mapper must reopen before the self-heal / zot launch).
+# (the host self-reboots, so the mapper must reopen before the self-heal / zot launch). Scope the
+# unit greps to the registry-luks-open.service write_files block (awk block-extract, mirroring
+# registry-boot-guard.test.sh) so `After=network-online.target` is asserted on THIS unit, not
+# satisfied file-globally by the sibling zot-liveness-heartbeat.service.
 p_d2_bootopen() {
-  if grep -qF 'Reopen the registry LUKS store mapper on boot' "$1" \
-    && grep -qF '/usr/local/bin/registry-luks-open.sh' "$1" \
-    && grep -qE 'After=network-online.target' "$1" \
-    && grep -qF 'Before=docker.service cron.service' "$1"; then echo 1; else echo 0; fi
+  local blk
+  blk="$(awk '/- path: \/etc\/systemd\/system\/registry-luks-open.service/,/owner: root:root/' "$1")"
+  if grep -qF 'Reopen the registry LUKS store mapper on boot' <<<"$blk" \
+    && grep -qF '/usr/local/bin/registry-luks-open.sh' <<<"$blk" \
+    && grep -qE 'After=network-online.target' <<<"$blk" \
+    && grep -qF 'Before=docker.service cron.service' <<<"$blk"; then echo 1; else echo 0; fi
 }
 
 # P1-A: the boot isolation self-check admits REGISTRY_LUKS_KEY AND its cardinality is 4 (was 3).
@@ -137,9 +156,24 @@ p_no_stale_byid_fstab() {
 }
 
 # The resize path targets the MAPPER, never the raw $DEV (a raw resize2fs hits the LUKS header).
+# Anchor on the EXECUTABLE form (`if resize2fs /dev/mapper/registry; then`) — the bare token also
+# appears in a narrative comment ("cryptsetup resize + resize2fs /dev/mapper/registry"), which the
+# old grep false-matched.
 p_resize_mapper() {
-  if grep -Eq 'resize2fs /dev/mapper/registry' "$1" \
+  if grep -Eq 'if resize2fs /dev/mapper/registry; then' "$1" \
     && ! grep -Eq 'resize2fs "\$DEV"' "$1"; then echo 1; else echo 0; fi
+}
+
+# FIX 1 (#6895 P1): the zot launch is GATED on the LUKS mount. The mount block and the zot launch
+# are separate runcmd entries and cloud-init continues past a failed one, so without this gate a
+# failed LUKS mount would still launch zot on an empty root-disk dir (401 → heartbeat green, no
+# alert). Assert the `findmnt … /dev/mapper/registry` gate exists AND precedes the `docker run … zot`
+# (line order), so fail-loud => zot never starts => liveness absence.
+p_zot_mount_gate() {
+  local f="$1" gate_ln run_ln
+  gate_ln="$(grep -nE 'findmnt -no SOURCE /var/lib/zot \| grep -qx /dev/mapper/registry' "$f" | head -1 | cut -d: -f1)"
+  run_ln="$(grep -nE 'docker run -d --name zot' "$f" | head -1 | cut -d: -f1)"
+  if [ -n "$gate_ln" ] && [ -n "$run_ln" ] && [ "$gate_ln" -lt "$run_ln" ]; then echo 1; else echo 0; fi
 }
 
 # --- Assertion + mutation harness ---
@@ -163,6 +197,10 @@ assert_mutation() {
 # A1: blkid TYPE discriminator (fresh/crypto_LUKS/else-FATAL).
 assert_holds    "A1 discriminator" p_discriminator "$CLOUD_INIT"
 assert_mutation "A1 discriminator" p_discriminator "$CLOUD_INIT" 's/crypto_LUKS\)/NOTLUKS)/'
+# A1b: strip the `; exit 1` HALT from the refuse (`*)`) arm — the reason still prints but the arm no
+# longer halts. The tightened predicate (reason + exit 1 co-located) must flip RED.
+assert_mutation "A1b discriminator-refuse-halts" p_discriminator "$CLOUD_INIT" \
+  's/(refusing-non-luks-device.*); exit 1/\1/'
 
 # A2: key via --key-file - stdin, never argv.
 assert_holds    "A2 key-file-stdin" p_keyfile_stdin "$CLOUD_INIT"
@@ -184,6 +222,10 @@ assert_mutation "A5 fstab-mapper" p_fstab_mapper "$CLOUD_INIT" 's#/dev/mapper/re
 # A6: fail-loud on empty key.
 assert_holds    "A6 fail-loud" p_fail_loud "$CLOUD_INIT"
 assert_mutation "A6 fail-loud" p_fail_loud "$CLOUD_INIT" 's/\[ -n "\$REGISTRY_LUKS_KEY" \]/true/g'
+# A6b: flip the mount-block empty-key guard's halt `exit 1` -> `exit 0` — the guard still runs but no
+# longer refuses. The tightened predicate (guard || … exit 1) must flip RED.
+assert_mutation "A6b fail-loud-halts" p_fail_loud "$CLOUD_INIT" \
+  's/(refusing unencrypted registry mount.*)exit 1/\1exit 0/'
 
 # A7: doppler run (scoped soleur-registry/prd) wraps the setup.
 assert_holds    "A7 doppler-run" p_doppler_run "$CLOUD_INIT"
@@ -223,10 +265,16 @@ assert_mutation "A14 no-stale-byid-fstab" p_no_stale_byid_fstab "$CLOUD_INIT" 's
 assert_holds    "A15 resize-mapper" p_resize_mapper "$CLOUD_INIT"
 assert_mutation "A15 resize-mapper" p_resize_mapper "$CLOUD_INIT" 's#resize2fs /dev/mapper/registry#resize2fs "$DEV"#g'
 
+# A16 (FIX 1 / #6895 P1): the zot launch is gated on the LUKS mount (findmnt gate BEFORE docker run).
+assert_holds    "A16 zot-mount-gate" p_zot_mount_gate "$CLOUD_INIT"
+# Mutation: delete the findmnt mount-gate line -> zot would launch on an unmounted (empty) store.
+assert_mutation "A16 zot-mount-gate" p_zot_mount_gate "$CLOUD_INIT" '/findmnt -no SOURCE \/var\/lib\/zot \| grep -qx \/dev\/mapper\/registry/d'
+
 # --- Minimum-cardinality guard (a silent-empty harness must fail loud) ---
+# Floor = 34: 16 assert_holds + 18 assert_mutation (A1 and A6 each carry 2 mutations; A16 added).
 total=$((passes + fails))
-if [ "$total" -lt 30 ]; then
-  echo "FAIL: ran only ${total} assertions (<30) — suite did not execute fully" >&2
+if [ "$total" -lt 34 ]; then
+  echo "FAIL: ran only ${total} assertions (<34) — suite did not execute fully" >&2
   exit 1
 fi
 

--- a/apps/web-platform/infra/registry-luks.test.sh
+++ b/apps/web-platform/infra/registry-luks.test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+#
+# Drift guard for the registry (zot) LUKS-at-rest store volume (#6895 / ADR-096 amendment /
+# ADR-140). Asserts the SECURITY-LOAD-BEARING shape of the guest-side LUKS block in
+# cloud-init-registry.yml + the Terraform apparatus in zot-registry.tf:
+#   * D1/Option B `blkid TYPE` discriminator (fresh -> luksFormat; crypto_LUKS -> reuse; any
+#     OTHER TYPE -> FATAL refuse, never a silent wipe — the ADR-096 preserve-path footgun);
+#   * the LUKS passphrase is delivered via stdin (`--key-file -`) and NEVER appears as a bare
+#     argv token on any luksFormat/luksOpen line (leak via `ps`/argv);
+#   * the mapper /dev/mapper/registry is mounted at /var/lib/zot, with an fstab MAPPER line
+#     (never the stale raw by-id device);
+#   * fail-loud on an empty key — never an unencrypted fallback;
+#   * the key arrives from the Doppler-injected env (scoped soleur-registry/prd), the passphrase
+#     is random_password -> doppler_secret (no literal in .tf), and the volume is a RAW device
+#     (no format="ext4"), its attachment binding the real volume;
+#   * D2 (REQUIRED): an idempotent boot-time luksOpen (registry-luks-open.service) ordered after
+#     network-online and BEFORE docker + the NIC-guard self-heal (the host self-reboots);
+#   * P1-A: the boot isolation self-check admits REGISTRY_LUKS_KEY at cardinality 4;
+#   * P1-B: the Doppler CLI env-file write precedes the LUKS mount block;
+#   * the resize path targets the MAPPER (/dev/mapper/registry), not the raw device.
+#
+# Each assertion is MUTATION-TESTED: the predicate is re-run against a deliberately broken copy
+# and MUST flip to failing (a green test that cannot go red is worthless — the bash-gate-authoring
+# foot-gun). Deliberately-nonzero commands are wrapped in `$(… || true)` so `set -e` never aborts.
+#
+# Run: bash apps/web-platform/infra/registry-luks.test.sh
+# Registered as a step in .github/workflows/infra-validation.yml (infra .test.sh are NOT globbed).
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLOUD_INIT="${DIR}/cloud-init-registry.yml"
+LUKS_TF="${DIR}/zot-registry.tf"
+
+passes=0
+fails=0
+pass() { passes=$((passes + 1)); }
+fail() { fails=$((fails + 1)); echo "FAIL: $1" >&2; }
+
+[ -f "$CLOUD_INIT" ] || { echo "FAIL: cloud-init-registry.yml not found at $CLOUD_INIT" >&2; exit 1; }
+[ -f "$LUKS_TF" ]    || { echo "FAIL: zot-registry.tf not found at $LUKS_TF" >&2; exit 1; }
+
+# --- Predicates (each takes a file, echoes "1" if the property holds, else "0") ---
+
+# D1/B blkid TYPE discriminator: reads TYPE off the RAW device, has a crypto_LUKS reuse arm, and
+# an else->FATAL refuse arm (the plaintext-volume footgun). All three must be present.
+p_discriminator() {
+  if grep -qE 'blkid -o value -s TYPE "\$DEV"' "$1" \
+    && grep -qE 'crypto_LUKS\)' "$1" \
+    && grep -qF 'refusing-non-luks-device' "$1"; then echo 1; else echo 0; fi
+}
+
+# Every luksFormat/luksOpen line pipes the key via `--key-file -` (stdin) AND carries NO
+# $REGISTRY_LUKS_KEY as an argv token (the key must arrive on stdin, not argv).
+p_keyfile_stdin() {
+  local f="$1" luks_args n_lines n_keyfile n_argvkey
+  # Exclude comment lines FIRST (a `# ... cryptsetup luksFormats it ...` narrative line would
+  # otherwise be miscounted as a command line that lacks `--key-file -`).
+  luks_args="$(grep -vE '^[[:space:]]*#' "$f" | grep -E 'cryptsetup[[:space:]]+luks(Format|Open)' | sed -E 's/.*(cryptsetup[[:space:]]+luks)/\1/' || true)"
+  n_lines="$(printf '%s\n' "$luks_args" | grep -c 'cryptsetup' || true)"
+  if [ "$n_lines" -lt 2 ]; then echo 0; return; fi
+  n_keyfile="$(printf '%s\n' "$luks_args" | grep -c -- '--key-file -' || true)"
+  if [ "$n_keyfile" -ne "$n_lines" ]; then echo 0; return; fi
+  n_argvkey="$(printf '%s\n' "$luks_args" | grep -c 'REGISTRY_LUKS_KEY' || true)"
+  if [ "$n_argvkey" -ne 0 ]; then echo 0; return; fi
+  echo 1
+}
+
+# The key IS piped from a printf of $REGISTRY_LUKS_KEY (proves stdin delivery exists).
+p_printf_pipe() {
+  if grep -Eq "printf[[:space:]]+'%s'[[:space:]]+\"\\\$REGISTRY_LUKS_KEY\"[[:space:]]*\|[[:space:]]*cryptsetup" "$1"; then echo 1; else echo 0; fi
+}
+
+# Mapper mounted at the zot store root.
+p_mapper_mount() {
+  if grep -Eq 'mount[[:space:]]+/dev/mapper/registry[[:space:]]+/var/lib/zot' "$1"; then echo 1; else echo 0; fi
+}
+
+# fstab evidence names the MAPPER (this is what the encryption-posture linter resolves).
+p_fstab_mapper() {
+  if grep -Eq "echo '/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2' >> /etc/fstab" "$1"; then echo 1; else echo 0; fi
+}
+
+# Fail-loud on empty key (no unencrypted fallback).
+p_fail_loud() {
+  if grep -Eq '\[ -n "\$REGISTRY_LUKS_KEY" \]' "$1"; then echo 1; else echo 0; fi
+}
+
+# Key sourced from the Doppler-injected env, scoped to the isolated soleur-registry/prd config.
+p_doppler_run() {
+  if grep -Eq 'doppler run --project soleur-registry --config prd -- bash' "$1"; then echo 1; else echo 0; fi
+}
+
+# The passphrase is generated (random_password) and pushed to Doppler — NEVER a literal in the .tf.
+p_tf_random() {
+  if grep -Eq 'resource "random_password" "registry_luks"' "$1" \
+    && grep -Eq 'name[[:space:]]*=[[:space:]]*"REGISTRY_LUKS_KEY"' "$1"; then echo 1; else echo 0; fi
+}
+
+# D1/B: the registry volume is a RAW device — NO format="ext4" (guest luksFormats it).
+p_no_format_ext4() {
+  if ! grep -Eq 'format[[:space:]]*=[[:space:]]*"ext4"' "$1"; then echo 1; else echo 0; fi
+}
+
+# The attachment binds the real registry volume (linter attachment_binds_volume).
+p_attach_binds() {
+  if grep -Eq 'volume_id[[:space:]]*=[[:space:]]*hcloud_volume\.registry\.id' "$1"; then echo 1; else echo 0; fi
+}
+
+# D2 (REQUIRED): boot-time luksOpen oneshot, ordered after network-online and BEFORE docker + cron
+# (the host self-reboots, so the mapper must reopen before the self-heal / zot launch).
+p_d2_bootopen() {
+  if grep -qF 'Reopen the registry LUKS store mapper on boot' "$1" \
+    && grep -qF '/usr/local/bin/registry-luks-open.sh' "$1" \
+    && grep -qE 'After=network-online.target' "$1" \
+    && grep -qF 'Before=docker.service cron.service' "$1"; then echo 1; else echo 0; fi
+}
+
+# P1-A: the boot isolation self-check admits REGISTRY_LUKS_KEY AND its cardinality is 4 (was 3).
+p_isolation_card4() {
+  if grep -qE "grep -Ec '.*REGISTRY_LUKS_KEY.*'" "$1" \
+    && grep -qF '[ "$n_total" -ne 4 ]'  "$1"; then echo 1; else echo 0; fi
+}
+
+# P1-B: the Doppler CLI env-file write precedes the LUKS mount block (else the mount `doppler run`
+# has neither the CLI nor the token).
+p_p1b_order() {
+  local f="$1" env_ln luks_ln
+  env_ln="$(grep -nF '> /etc/default/registry-doppler' "$f" | grep -F 'printf' | head -1 | cut -d: -f1)"
+  luks_ln="$(grep -nE 'cryptsetup[[:space:]]+luksFormat' "$f" | head -1 | cut -d: -f1)"
+  if [ -n "$env_ln" ] && [ -n "$luks_ln" ] && [ "$env_ln" -lt "$luks_ln" ]; then echo 1; else echo 0; fi
+}
+
+# The stale raw by-id fstab line for /var/lib/zot is ABSENT (only the mapper line remains).
+p_no_stale_byid_fstab() {
+  if ! grep -Eq 'scsi-0HC_Volume_[^ ]* /var/lib/zot ext4' "$1"; then echo 1; else echo 0; fi
+}
+
+# The resize path targets the MAPPER, never the raw $DEV (a raw resize2fs hits the LUKS header).
+p_resize_mapper() {
+  if grep -Eq 'resize2fs /dev/mapper/registry' "$1" \
+    && ! grep -Eq 'resize2fs "\$DEV"' "$1"; then echo 1; else echo 0; fi
+}
+
+# --- Assertion + mutation harness ---
+# assert_holds <name> <predicate-fn> <file>            -> predicate MUST be 1
+# assert_mutation <name> <predicate-fn> <file> <sed>   -> after the sed mutation the predicate
+#                                                          MUST flip to 0
+assert_holds() {
+  local name="$1" fn="$2" file="$3" got
+  got="$($fn "$file")"
+  if [ "$got" = "1" ]; then pass; else fail "$name: property does not hold on the real file"; fi
+}
+assert_mutation() {
+  local name="$1" fn="$2" file="$3" sed_expr="$4" tmp got
+  tmp="$(mktemp "${TMPDIR:-/tmp}/regluks-mut.XXXXXX")"
+  sed -E "$sed_expr" "$file" > "$tmp"
+  got="$($fn "$tmp")"
+  if [ "$got" = "0" ]; then pass; else fail "$name: MUTATION did not flip the check to failing (predicate still passed on a broken copy)"; fi
+  rm -f "$tmp"
+}
+
+# A1: blkid TYPE discriminator (fresh/crypto_LUKS/else-FATAL).
+assert_holds    "A1 discriminator" p_discriminator "$CLOUD_INIT"
+assert_mutation "A1 discriminator" p_discriminator "$CLOUD_INIT" 's/crypto_LUKS\)/NOTLUKS)/'
+
+# A2: key via --key-file - stdin, never argv.
+assert_holds    "A2 key-file-stdin" p_keyfile_stdin "$CLOUD_INIT"
+assert_mutation "A2 key-file-stdin" p_keyfile_stdin "$CLOUD_INIT" \
+  's#cryptsetup luksFormat --batch-mode --type luks2 --key-file - "\$DEV"#cryptsetup luksFormat --batch-mode --type luks2 "\$REGISTRY_LUKS_KEY" "\$DEV"#'
+
+# A3: printf-pipe stdin delivery present.
+assert_holds    "A3 printf-pipe" p_printf_pipe "$CLOUD_INIT"
+assert_mutation "A3 printf-pipe" p_printf_pipe "$CLOUD_INIT" "s/printf '%s'/printf 'X%sX'/g"
+
+# A4: mapper mounted at /var/lib/zot.
+assert_holds    "A4 mapper-mount" p_mapper_mount "$CLOUD_INIT"
+assert_mutation "A4 mapper-mount" p_mapper_mount "$CLOUD_INIT" 's#mount /dev/mapper/registry /var/lib/zot#mount /dev/mapper/registry /mnt/wrong#g'
+
+# A5: fstab evidence names the mapper.
+assert_holds    "A5 fstab-mapper" p_fstab_mapper "$CLOUD_INIT"
+assert_mutation "A5 fstab-mapper" p_fstab_mapper "$CLOUD_INIT" 's#/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2#/dev/mapper/WRONG /var/lib/zot ext4 defaults,nofail 0 2#'
+
+# A6: fail-loud on empty key.
+assert_holds    "A6 fail-loud" p_fail_loud "$CLOUD_INIT"
+assert_mutation "A6 fail-loud" p_fail_loud "$CLOUD_INIT" 's/\[ -n "\$REGISTRY_LUKS_KEY" \]/true/g'
+
+# A7: doppler run (scoped soleur-registry/prd) wraps the setup.
+assert_holds    "A7 doppler-run" p_doppler_run "$CLOUD_INIT"
+assert_mutation "A7 doppler-run" p_doppler_run "$CLOUD_INIT" 's/doppler run/doppler_run/g'
+
+# A8: passphrase is random_password -> doppler_secret (no literal in .tf).
+assert_holds    "A8 tf-random-secret" p_tf_random "$LUKS_TF"
+assert_mutation "A8 tf-random-secret" p_tf_random "$LUKS_TF" 's/random_password/static_password/g'
+
+# A9: the registry volume is RAW — no format="ext4" (D1/B).
+assert_holds    "A9 no-format-ext4" p_no_format_ext4 "$LUKS_TF"
+assert_mutation "A9 no-format-ext4" p_no_format_ext4 "$LUKS_TF" 's#resource "hcloud_volume" "registry" \{#resource "hcloud_volume" "registry" {\n  format = "ext4"#'
+
+# A10: the attachment binds the real registry volume.
+assert_holds    "A10 attach-binds" p_attach_binds "$LUKS_TF"
+assert_mutation "A10 attach-binds" p_attach_binds "$LUKS_TF" 's/hcloud_volume\.registry\.id/hcloud_volume.wrong.id/g'
+
+# A11 (D2): boot-time luksOpen ordered before the self-heal + zot launch.
+assert_holds    "A11 d2-bootopen" p_d2_bootopen "$CLOUD_INIT"
+assert_mutation "A11 d2-bootopen" p_d2_bootopen "$CLOUD_INIT" 's/Before=docker.service cron.service/After=docker.service/'
+
+# A12 (P1-A): the isolation self-check admits REGISTRY_LUKS_KEY at cardinality 4.
+assert_holds    "A12 isolation-card4" p_isolation_card4 "$CLOUD_INIT"
+# Mutation (plan-specified): leave the count at 3 => the guard would FATAL a valid 4-secret boot.
+assert_mutation "A12 isolation-card4" p_isolation_card4 "$CLOUD_INIT" 's/-ne 4/-ne 3/g'
+
+# A13 (P1-B): the Doppler env-file write precedes the LUKS mount block.
+assert_holds    "A13 p1b-order" p_p1b_order "$CLOUD_INIT"
+# Mutation: delete the env-file write -> the "precedes" relation can no longer be proven.
+assert_mutation "A13 p1b-order" p_p1b_order "$CLOUD_INIT" '/printf .HOME=.root.*registry-doppler/d'
+
+# A14: the stale raw by-id fstab line for /var/lib/zot is absent.
+assert_holds    "A14 no-stale-byid-fstab" p_no_stale_byid_fstab "$CLOUD_INIT"
+assert_mutation "A14 no-stale-byid-fstab" p_no_stale_byid_fstab "$CLOUD_INIT" 's#/dev/mapper/registry /var/lib/zot ext4#/dev/disk/by-id/scsi-0HC_Volume_x /var/lib/zot ext4#'
+
+# A15: the resize path targets the mapper, not the raw device.
+assert_holds    "A15 resize-mapper" p_resize_mapper "$CLOUD_INIT"
+assert_mutation "A15 resize-mapper" p_resize_mapper "$CLOUD_INIT" 's#resize2fs /dev/mapper/registry#resize2fs "$DEV"#g'
+
+# --- Minimum-cardinality guard (a silent-empty harness must fail loud) ---
+total=$((passes + fails))
+if [ "$total" -lt 30 ]; then
+  echo "FAIL: ran only ${total} assertions (<30) — suite did not execute fully" >&2
+  exit 1
+fi
+
+echo "registry-luks: ${passes} passed, ${fails} failed (${total} assertions)"
+[ "$fails" -eq 0 ]

--- a/apps/web-platform/infra/registry-luks.test.sh
+++ b/apps/web-platform/infra/registry-luks.test.sh
@@ -32,6 +32,13 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLOUD_INIT="${DIR}/cloud-init-registry.yml"
 LUKS_TF="${DIR}/zot-registry.tf"
 
+# Single owning trap for all mutation-test scratch copies (rule c / ADR-129):
+# assert_mutation allocates each per-mutation temp copy under this dir; the trap
+# removes the whole dir on ANY exit, incl. a die between mktemp and the per-call
+# rm -f, so nothing leaks if a predicate or sed aborts mid-run.
+_MUT_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/regluks-mut.XXXXXX")"
+trap 'rm -rf "$_MUT_TMPDIR"' EXIT INT TERM
+
 passes=0
 fails=0
 pass() { passes=$((passes + 1)); }
@@ -187,7 +194,7 @@ assert_holds() {
 }
 assert_mutation() {
   local name="$1" fn="$2" file="$3" sed_expr="$4" tmp got
-  tmp="$(mktemp "${TMPDIR:-/tmp}/regluks-mut.XXXXXX")"
+  tmp="$(mktemp "$_MUT_TMPDIR/mut.XXXXXX")"
   sed -E "$sed_expr" "$file" > "$tmp"
   got="$($fn "$tmp")"
   if [ "$got" = "0" ]; then pass; else fail "$name: MUTATION did not flip the check to failing (predicate still passed on a broken copy)"; fi

--- a/apps/web-platform/infra/zot-registry.tf
+++ b/apps/web-platform/infra/zot-registry.tf
@@ -91,7 +91,8 @@ locals {
   # reuses this SAME source + token (SOLEUR_ZOT_DISK is the discriminating grep marker), so no
   # new source is provisioned. NON-secret host routing (like disk_heartbeat_url) → baked into
   # user_data via templatefile; the token is the only secret and stays in the isolated Doppler
-  # config, so the boot isolation self-check cardinality is 3 (2 ZOT + 1 logs token), NOT 4.
+  # config. (#6895) The boot isolation self-check cardinality is now 4 — 2 ZOT tokens + this logs
+  # token + REGISTRY_LUKS_KEY (the guest-LUKS passphrase) — see the self-check at :741-746.
   # keep in sync with vector.toml [sinks.betterstack].uri (same source 2457081 / eu-fsn-3 endpoint).
   betterstack_logs_ingest_url = "https://s2457081.eu-fsn-3.betterstackdata.com/"
 }
@@ -152,6 +153,22 @@ resource "random_password" "zot_push" {
   special = false
 }
 
+# --- #6895 (ADR-096 amendment / ADR-140) — guest-side LUKS-at-rest passphrase --------
+# The zot storage volume (hcloud_volume.registry) is a RAW block device (no `format`
+# below); cryptsetup luksFormat/luksOpen runs IN THE GUEST at cloud-init
+# (cloud-init-registry.yml), unlocked by THIS passphrase delivered ONLY as the
+# Doppler-injected env REGISTRY_LUKS_KEY — never an argv positional, never baked into
+# user_data. There is NO hcloud `encrypted` volume attribute (ADR-140). Mirrors
+# random_password.git_data_luks (git-data-luks.tf): length 40 alphanumeric (~238 bits),
+# special=false keeps it shell/stdin-safe for the `printf %s | cryptsetup --key-file -`
+# pipe. NO keepers / NO ignore_changes — rotation is operator-explicit via `-replace`
+# (SE1: a rotation is a volume RECUT, not a bare host replace — see the depends_on note
+# and cloud-init-registry.yml's LUKS block).
+resource "random_password" "registry_luks" {
+  length  = 40
+  special = false
+}
+
 # --- Host-scoped boot credential: the ISOLATED `soleur-registry` project ---------------
 # The registry host builds its htpasswd from BOTH tokens at boot, reading them via a
 # read-only service token. TRUE isolation requires a boundary that does NOT share the `prd`
@@ -204,6 +221,21 @@ resource "doppler_secret" "zot_push_token_registry" {
   config     = doppler_environment.registry_prd.slug
   name       = "ZOT_PUSH_TOKEN"
   value      = random_password.zot_push.result
+  visibility = "masked"
+}
+
+# #6895 — the guest-side LUKS passphrase, published to the SAME isolated soleur-registry/prd
+# root config the host already reads at boot (doppler_service_token.registry). Mirrors
+# doppler_secret.git_data_luks_key — no NEW service token is provisioned; the existing scoped
+# read token resolves it alongside the two ZOT tokens + the logs token. This is the FOURTH
+# secret in the isolated config, so the boot isolation self-check cardinality moves 3->4
+# (cloud-init-registry.yml :741-746, P1-A) and REGISTRY_LUKS_KEY is admitted BY NAME. It is a
+# registry-scoped secret, so the #6122 isolation property is preserved (no soleur/prd path).
+resource "doppler_secret" "registry_luks_key" {
+  project    = doppler_project.registry.name
+  config     = doppler_environment.registry_prd.slug
+  name       = "REGISTRY_LUKS_KEY"
+  value      = random_password.registry_luks.result
   visibility = "masked"
 }
 
@@ -389,10 +421,18 @@ resource "hcloud_server" "registry" {
   # GATE the htpasswd bake, so they need the identical treatment — the #6244 fix was made for
   # one secret and never generalized. Without them a fresh stand-up (or this host's own
   # replace) may boot before the secret writes land and bake an htpasswd from a stale read.
+  # #6895: REGISTRY_LUKS_KEY is read at boot through the SAME scoped Doppler CLI path and GATES
+  # the guest luksFormat/luksOpen of the store volume — the identical boot-ordering hazard the
+  # three secrets above already guard. Without this edge a fresh stand-up (or this host's own
+  # replace) may boot before the secret write lands and FATAL on an empty key (fail-loud). Do NOT
+  # add random_password.registry_luks to lifecycle.replace_triggered_by above: rotating the
+  # passphrase and merely replacing the HOST would luksOpen the OLD-key volume with the NEW key
+  # and FATAL — a rotation is a volume RECUT (SE1), not a bare host replace.
   depends_on = [
     doppler_secret.registry_betterstack_logs_token,
     doppler_secret.zot_pull_token_registry,
     doppler_secret.zot_push_token_registry,
+    doppler_secret.registry_luks_key,
   ]
 
   labels = {
@@ -408,7 +448,15 @@ resource "hcloud_volume" "registry" {
   name     = "soleur-registry-store"
   size     = var.registry_volume_size
   location = var.registry_location # MUST match hcloud_server.registry (#6122: nbg1)
-  format   = "ext4"
+  # SHARP EDGE (#6895 / D1 Option B): NO `format` — this is a RAW block device. Guest-side
+  # cryptsetup luksFormats it luks2 at cloud-init and mkfs.ext4's the real FS INSIDE the
+  # /dev/mapper/registry mapper (cloud-init-registry.yml). There is no hcloud `encrypted`
+  # attribute (ADR-140); at-rest encryption is guest-side only. A raw device lets the guest's
+  # `blkid TYPE` discriminator distinguish fresh ("") -> luksFormat, crypto_LUKS -> reuse, and
+  # any OTHER TYPE (e.g. a populated plaintext ext4 the registry-host-replace preserve-path
+  # kept) -> FATAL refuse instead of a silent wipe. This DEPARTS from git_data_luks (which keeps
+  # format=ext4 + an isLuks guard, Option A) precisely because the registry has a volume-preserving
+  # host-replace dispatch git-data lacks (ADR-096 footgun).
 
   labels = {
     app = "soleur-web-platform"

--- a/apps/web-platform/infra/zot-registry.tf
+++ b/apps/web-platform/infra/zot-registry.tf
@@ -92,7 +92,8 @@ locals {
   # new source is provisioned. NON-secret host routing (like disk_heartbeat_url) → baked into
   # user_data via templatefile; the token is the only secret and stays in the isolated Doppler
   # config. (#6895) The boot isolation self-check cardinality is now 4 — 2 ZOT tokens + this logs
-  # token + REGISTRY_LUKS_KEY (the guest-LUKS passphrase) — see the self-check at :741-746.
+  # token + REGISTRY_LUKS_KEY (the guest-LUKS passphrase) — see the boot isolation self-check
+  # (`n_admitted=…REGISTRY_LUKS_KEY…`, cardinality 4) in cloud-init-registry.yml.
   # keep in sync with vector.toml [sinks.betterstack].uri (same source 2457081 / eu-fsn-3 endpoint).
   betterstack_logs_ingest_url = "https://s2457081.eu-fsn-3.betterstackdata.com/"
 }
@@ -228,8 +229,9 @@ resource "doppler_secret" "zot_push_token_registry" {
 # root config the host already reads at boot (doppler_service_token.registry). Mirrors
 # doppler_secret.git_data_luks_key — no NEW service token is provisioned; the existing scoped
 # read token resolves it alongside the two ZOT tokens + the logs token. This is the FOURTH
-# secret in the isolated config, so the boot isolation self-check cardinality moves 3->4
-# (cloud-init-registry.yml :741-746, P1-A) and REGISTRY_LUKS_KEY is admitted BY NAME. It is a
+# secret in the isolated config, so the boot isolation self-check cardinality moves 3->4 (the
+# `n_admitted=…REGISTRY_LUKS_KEY…`, cardinality 4 self-check in cloud-init-registry.yml, P1-A) and
+# REGISTRY_LUKS_KEY is admitted BY NAME. It is a
 # registry-scoped secret, so the #6122 isolation property is preserved (no soleur/prd path).
 resource "doppler_secret" "registry_luks_key" {
   project    = doppler_project.registry.name

--- a/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md
@@ -475,6 +475,49 @@ email-acceptable surface.
 The restart-loop alarm is fully automated post-merge: `apply-sentry-infra.yml` auto-applies the new
 `sentry_cron_monitor` on merge, and the workflow schedule fires the first run — no operator step.
 
+### Guest-side LUKS at-rest for the store volume (amendment 2026-07-24, #6895)
+
+`hcloud_volume.registry` was a **plaintext ext4** block volume (ADR-140 recorded it as a
+`plaintext-exception` row in the encryption-posture ledger). It now carries **guest-side LUKS**,
+mirroring the `git_data_luks` apparatus (there is no hcloud `encrypted` volume attribute — ADR-140):
+the volume is a **raw** device (no `format`), cryptsetup luksFormats/luksOpens it in the guest at
+cloud-init (`cloud-init-registry.yml`) unlocked by `REGISTRY_LUKS_KEY`, a `random_password` published
+to the isolated `soleur-registry/prd` Doppler config and read at boot via the existing scoped service
+token (no new token). The store mounts from `/dev/mapper/registry` at `/var/lib/zot`; a boot-time
+oneshot (`registry-luks-open.service`) reopens the mapper after a reboot (the host self-`reboot`s via
+the private-NIC guard). The ledger row flips `plaintext-exception → luks`. This is **defense-in-depth
+on a disposable mirror** — the store holds only OCI blobs + cosign signatures (our own images),
+re-fills from GHCR, and carries no user/repo data.
+
+<!-- lint-infra-ignore start -->
+<!-- Deferred-orchestrator prose: this describes a SANCTIONED, gated operator recut that runs OUTSIDE
+     any per-PR apply (an OPERATOR_APPLIED_EXCLUSION `-replace` / the deferred guarded dispatch #6929),
+     not a human-run step prescribed inside a runbook this PR executes. Grandfathered per the lint's
+     own escape hatch; the recommended fully-automated vehicle is the guarded dispatch (#6929). -->
+
+**Recut vehicle (the operator step, OUTSIDE the landing PR).** Encrypting the *live* volume is a
+destroy+recreate: a scoped **`terraform apply -replace` of the volume + its attachment + the host,
+all three together** (a fresh raw volume ⇒ cloud-init luksFormats it ⇒ zot re-fills from GHCR). The
+recommended vehicle is a guarded, typed-confirm `registry-luks-recut` `workflow_dispatch` mirroring
+`workspaces-luks-recut`/`registry-region-migrate`; that guarded dispatch is **deferred to a follow-up**
+(#6929; the landing PR is cloud-init + Terraform + ledger only) — until it ships, the sanctioned
+`OPERATOR_APPLIED_EXCLUSION` `-replace` path is the vehicle, with all three resources targeted together.
+
+**FOOTGUN — do NOT use `registry-host-replace` for the recut.** That existing dispatch **preserves**
+the volume, so it boots cloud-init against the still-**plaintext** ext4 volume, which hits the D1/B
+`blkid TYPE` discriminator's **else → FATAL refuse** arm (a plaintext volume must be recut, never
+silently wiped) and **darks the registry**. Forgetting the `-replace` on the volume has the same
+effect. The refuse is the *safe* failure (it never mounts plaintext / never certifies a false-green
+posture), but it takes zot down — the only correct first apply is the three-way recut on a fresh volume.
+
+**Escrow deliberately omitted.** Unlike `workspaces_luks` (#6649 R2 LUKS-header escrow), there is **no**
+header escrow and **no** dedicated at-rest monitor here: passphrase loss ⇒ recreate + re-fill from
+GHCR, so escrow buys nothing for a disposable, born-fresh store (matches `git_data_luks`). Rotation is
+therefore a volume **recut**, not a bare host replace (`random_password.registry_luks` is deliberately
+absent from the host's `replace_triggered_by`, or cloud-init would luksOpen the old-key volume with the
+new key and FATAL).
+<!-- lint-infra-ignore end -->
+
 ## Alternatives Considered
 
 The 7 registry-choice options are tabled above. The **apply-path** alternatives (per-PR `-target`

--- a/knowledge-base/project/learnings/2026-07-24-guest-luks-store-must-gate-consumer-on-mount-and-guard-suite-must-pin-fail-loud-semantics.md
+++ b/knowledge-base/project/learnings/2026-07-24-guest-luks-store-must-gate-consumer-on-mount-and-guard-suite-must-pin-fail-loud-semantics.md
@@ -1,0 +1,50 @@
+# Learning: guest-side volume encryption must gate the consuming service on the actual mount, and its guard suite must pin fail-loud SEMANTICS not token presence
+
+**Date:** 2026-07-24
+**Feature:** #6895 — guest-side LUKS for `hcloud_volume.registry` (the zot OCI-registry store) + encryption-posture ledger flip
+**PR:** #6926
+
+## Problem
+
+Adding guest-side LUKS to the registry volume (mirroring `git_data_luks`) shipped past the implementation phase green — mutation-tested guard 30/30, `lint-encryption-posture.py --repo-sweep` PASS, terraform fmt clean — yet a 5-agent review found a **production P1** and three **vacuous test guards** that all read green.
+
+### The production P1 (converged by observability + architecture reviewers)
+
+The LUKS mount block and the zot-launch block are **separate cloud-init `runcmd` entries**. cloud-init logs a failed entry and **continues to the next one** (no `set -e` across entries). So on *any* LUKS-mount failure arm — empty key, the wrong-TYPE FATAL-refuse arm (the ADR-096 `registry-host-replace` footgun), or a closed mapper after reboot — `/var/lib/zot` was left as the empty root-disk dir created by `mkdir -p`, and the zot-launch block ran `docker run … -v /var/lib/zot:/var/lib/zot …` **without checking the mount**. zot then served an empty store answering `/v2/` with 401 → the liveness feeder (treats `200|401` as alive) and the disk heartbeat both stayed **GREEN**. The plan's entire safety story ("fail-loud ⇒ zot never starts ⇒ Better Stack liveness-absence alert") was **false against the code**: zero telemetry was indistinguishable from healthy. The lean template's precedent (`cloud-init-git-data.yml`) gates its service on the mount; the registry silently dropped that invariant.
+
+### The three vacuous guards (test-design reviewer, confirmed on sandbox copies)
+
+The new `registry-luks.test.sh` mutation battery was internally sound (every one of its 15 mutations flipped its own predicate) but pinned the wrong thing on the three highest-value security semantics:
+
+- **A1** asserted the `blkid TYPE` else→refuse arm's *reason string* but not that it `exit 1`s. Stripping `; exit 1` from the `*)` arm left the suite 30/30 green while the refuse-and-halt guarantee was gone (fall-through to `luksFormat`/`mount` on a plaintext device).
+- **A6** asserted the empty-key guard's `[ -n … ]` *presence*, not that its `||` branch halts. Flipping `exit 1`→`exit 0` stayed green (fall-through to `luksFormat` with an empty passphrase).
+- **A11**'s `grep 'After=network-online.target'` was **file-global**, satisfied by a sibling `zot-liveness-heartbeat.service` unit; deleting the ordering from `registry-luks-open.service` stayed green.
+
+## Solution
+
+All findings were pr-introduced and small → fixed inline (`eb020ac92`), zero scope-out:
+
+- **Gate the consumer on the mount.** Before `docker run … zot`: `findmnt -no SOURCE /var/lib/zot | grep -qx /dev/mapper/registry || { echo "[zot] FATAL … refusing to serve an empty/unencrypted store" >&2; exit 1; }`. This makes the plan's fail-loud invariant *true*: a failed mount now stops zot, the heartbeat genuinely goes absent, and every named `alert_route` fires. Restores git-data parity.
+- **Pin the guards on exit-code semantics.** A1 now requires `exit 1` co-located with the refuse reason (+ a mutation that strips it → RED); A6 requires the guard's `||` branch to carry `exit 1` (+ a flip mutation → RED); A11 awk-extracts the `registry-luks-open.service` unit block and scopes the ordering greps to it. Added A16 asserting the new mount-gate. Floor 30→34.
+- **Boot-open hardening (F2):** added the provision block's 30×2s device-wait to `registry-luks-open.sh`, and had the NIC-guard self-heal invoke it (not just `mount -a`, which can only remount an *already-open* mapper) so a closed mapper self-heals within the 5-min cron instead of waiting for a reboot.
+- Content-anchor citations (not line numbers) in `zot-registry.tf`; `>&2` on the FATAL echo; SC2034 suppressions.
+
+## Key Insight
+
+Two generalizable rules, both **recurrences** of documented review classes (see `plugins/soleur/skills/review/SKILL.md` "Defect Classes"):
+
+1. **A new persistent store's at-rest encryption is only as safe as the gate on the CONSUMER of that store.** Encrypting the volume is necessary but not sufficient: if the consuming service can start on the *unmounted* path (an empty dir, a fallback), a failed encryption boot degrades **silently behind whatever liveness signal the service already has** — worse than a loud failure, because it reads as healthy. When the volume mount and the service launch are separate steps in a continue-on-error runner (cloud-init `runcmd`, a compose file, a systemd target without `RequiresMountsFor`), the service MUST re-assert the mount (`findmnt … == the mapper`) and fail loud before serving. Check the LEAN precedent you're mirroring for exactly this gate — dropping it is easy and invisible.
+
+2. **A mutation-tested guard suite must anchor each assertion on the fail-loud SEMANTICS (the `exit 1`, the halt), not on token PRESENCE.** A guard that greps for the reason string / the `[ -n … ]` test / a file-global unit directive passes identically whether the code halts or falls through — the exact regression it exists to catch survives it. The author's own green mutation battery is a floor, not proof: it only covers the mutations the author imagined. Litmus per assertion: *name a mutation that satisfies the grep while violating the property* — if you can, the guard is vacuous. Scope every unit/block grep to the specific block (awk-extract), never file-global.
+
+## Session Errors
+
+1. **Consumer not gated on the mount (production P1).** Recovery: `findmnt` mount-gate before `docker run zot`. Prevention: when mirroring a lean guest-LUKS template for a service-backed store, confirm the consumer re-asserts the mount and fails loud — the precedent's service-bootstrap gate is the thing most easily dropped. (Recurrence of the review catalogue's "new store encryption posture" + "self-healing guard must fail-safe on its own instrument" families.)
+2. **Guard suite pinned presence not exit-code (A1/A6/A11 vacuous).** Recovery: re-anchor on `exit 1` + block-scope + add flip mutations. Prevention: `mutation battery only covers what you mutate` — for every guard whose correctness is a *direction/halt*, require a mutation that removes the halt and confirm RED. (Recurrence of the documented mutation-vacuity class.)
+3. **Stale `:741-746` citations after a ~100-line insertion.** Recovery: repoint to content anchor. Prevention: `cq-cite-content-anchor-not-line-number` — never a bare line range into a churning file.
+4. **F2 boot-open silent-success + impotent self-heal; missing `>&2`.** One-off hardening; fixed inline.
+5. **shellcheck SC2034 unused vars.** One-off; suppressed with justification.
+
+## Tags
+category: infrastructure
+module: encryption-posture / cloud-init / zot-registry

--- a/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
+++ b/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
@@ -15,6 +15,38 @@ milestone: "Phase 4: Validate + Scale"
 
 > Spec lacks a `lane:` (no `spec.md` for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
 
+## Enhancement Summary
+
+**Deepened on:** 2026-07-24. **Agents:** architecture-strategist, code-simplicity-reviewer,
+mechanical verify-the-negative pass. **10/10 load-bearing claims verified against real code**
+(git-data `format=ext4` vs workspaces raw; linter chain resolvable via `zot-registry.tf` co-location;
+existing `doppler_service_token.registry` reads `soleur-registry/prd`; drift detector plan-only;
+`workspaces_luks` is the sole `live_verification: available` row).
+
+### Key improvements folded in from review
+1. **P1-A (P0-at-recut) — boot isolation self-check.** `cloud-init-registry.yml:741-746` FATALs
+   unless the boot token resolves **exactly 3** secrets; `REGISTRY_LUKS_KEY` makes 4 → zot never
+   launches. Added an explicit `3→4` widen step + AC + mutation test.
+2. **P1-B (P0-at-recut) — cloud-init ordering.** The registry installs Doppler + writes the token
+   env-file *after* the mount block; a `doppler run` LUKS block would have neither. Added a required
+   reorder step.
+3. **D2 promoted RECOMMENDED→REQUIRED.** Resolved a reviewer split: the host self-`reboot`s via the
+   NIC guard (`:610`), so a boot-time luksOpen is load-bearing (without it, LUKS ships a known
+   dark-after-reboot regression). Simplicity's "defer D2" premise was falsified by code.
+4. **Stale by-id fstab line must be deleted** (else reboot double-mount / raw-mount vs `crypto_LUKS`).
+5. **D1 rationale re-framed** — from "data loss" to "don't silently touch a volume the
+   `registry-host-replace` preserve-path deliberately keeps"; Option A noted as a leaner valid choice.
+6. **D4 — recommend the guarded `registry-luks-recut` dispatch** + flag the "wrong-dispatch
+   (`registry-host-replace`) = FATAL" footgun (PR body + ADR-096); floor = tracking issue.
+7. **ADR-096 amendment now REQUIRED** (captures the recut vehicle + footgun the ledger row can't).
+8. Added `## Downtime & Cutover` (zero-downtime-first evaluation), exclusion-parity-test +
+   drift-dedup verifications.
+
+### Open decision for plan-review/CTO
+Whether the guarded `registry-luks-recut` dispatch lands **in this PR** (unfired, code-only) or an
+immediate follow-up — the task scopes the PR to "cloud-init + terraform + ledger", but the footgun
+argues for including it. Floor holds either way (tracking issue + PR-body hazard flag).
+
 ## Overview
 
 `hcloud_volume.registry` (`apps/web-platform/infra/zot-registry.tf:407`, `format = "ext4"`) is
@@ -114,41 +146,66 @@ per preflight Check 6. No CPO sign-off required at `none`.)
   disposable mirror, but silent.
 - **Option B (workspaces parity — RECOMMENDED):** remove `format` (raw volume) and use the `blkid
   -o value -s TYPE` discriminator: `""` → `luksFormat`; `crypto_LUKS` → `luksOpen` (no-op format);
-  **any other TYPE (e.g. `ext4`) → FATAL, refuse to touch.** Fail-loud instead of silent-wipe if
-  the apparatus is ever pointed at the old populated plaintext volume (e.g. an accidental
-  `registry-host-replace`, which *preserves* the volume, run before the recut). ADR-140-aligned
-  (the plaintext/LUKS sibling-namespace hazard is the exact false-green this whole feature exists
-  to prevent). Cost: a ForceNew diff on the volume — but drift is plan-only and the resource is
-  operator-excluded, so **no live mutation on merge**; the gated recut provides a fresh raw volume
-  regardless. **Recommend Option B.** (Note: the host `user_data` change already forces a
-  host-replace diff regardless of D1, so D1 does not change the "drift until the operator applies"
-  reality — only the safety guard.)
+  **any other TYPE (e.g. `ext4`) → FATAL, refuse to touch.** **Rationale (re-framed per
+  architecture review — the "data loss" framing overstated it):** both options are
+  *security-equivalent* (neither ever mounts plaintext, so neither can produce a false-green). The
+  real, registry-specific distinguisher is that — unlike git-data — the registry has a
+  `registry-host-replace` dispatch (`zot-registry.tf:23-29`) that `-replace`s the host while
+  **PRESERVING the (plaintext) volume**. Option B means an accidental `registry-host-replace` run
+  before the recut **fails loud and refuses** rather than silently `luksFormat`-wiping a volume the
+  preserve-path was explicitly designed to keep — the operator stays in control of the
+  plaintext→luks transition. Cost is tiny (a few lines + one FATAL arm + one test). Cost of the
+  ForceNew diff: none live — drift is plan-only and the resource is operator-excluded, so **no live
+  mutation on merge**; the gated recut provides a fresh raw volume regardless. **Recommend Option B**
+  — but **Option A (`format=ext4`+`isLuks`) is a leaner, also-valid choice** (on a disposable mirror
+  a silent wipe self-heals to an *encrypted* volume, the desired end state); the resize + raw-device
+  rework in Phase 2 is required under BOTH options, so A saves less than it first appears. (Note: the
+  host `user_data` change already forces a host-replace diff regardless of D1, so D1 does not change
+  the "drift until applied" reality — only the safety guard.)
 
-### D2 — Reboot survivability (RECOMMENDED: add a boot-time idempotent luksOpen)
-Unlike git-data (never rebooted, only replaced), the registry host has an **existing reboot
-self-heal** (`cloud-init-registry.yml:484-506`) that runs `mount -a` + `docker restart zot`.
-With LUKS, fstab points at `/dev/mapper/registry`, which is **closed after a reboot** (no
-`/etc/crypttab`, matching git-data) — so `mount -a` fails and zot stays dark until re-provision.
-**Recommend** a lean idempotent boot-time luksOpen (a `bootcmd`/systemd-oneshot ordered before the
-self-heal / zot start) that reads `REGISTRY_LUKS_KEY` via the existing scoped
-`doppler_service_token.registry` and opens the mapper — so a routine reboot remounts cleanly. This
-is the one place the registry apparatus should exceed bare git-data parity, because the registry
-host's self-heal assumes the mount returns. If judged out-of-scope, defer with a tracking issue
-(re-eval: "does a registry-host reboot recur outside a full re-provision?").
+### D2 — Reboot survivability (REQUIRED — a boot-time idempotent luksOpen)
+**Elevated from "recommended, defer-able" to REQUIRED by architecture review, on decisive code
+evidence.** `runcmd` is per-instance and does NOT re-run on reboot (`cloud-init-registry.yml:486-488`),
+so after a reboot the mapper stays **closed**; fstab points at `/dev/mapper/registry`; the reboot
+self-heal's `mount -a` (`:496`) fails; zot binds an empty dir and 404s. **Critically, this host
+reboots ITSELF:** the private-NIC guard calls `reboot` as a convergence primitive
+(`cloud-init-registry.yml:610`). So the re-eval question ("does a registry reboot recur outside a
+full re-provision?") has a definite answer — **yes, by design** — which means shipping LUKS without
+D2 ships a *known* dark-after-reboot regression triggered by normal NIC convergence, not a rare
+event. **A reviewer disagreement is resolved here:** the simplicity reviewer recommended deferring
+D2 on the premise that reboot recurrence was unproven; the architecture reviewer falsified that
+premise with `:610`. D2 stays in scope.
+
+**Implementation:** a lean idempotent boot-time luksOpen — a `bootcmd`/systemd-oneshot ordered
+**after** `network-online` (Doppler egress) and before the self-heal / zot start — that reads
+`REGISTRY_LUKS_KEY` via the existing scoped `doppler_service_token.registry` (from the persisted
+`/etc/default/registry-doppler`, which survives reboot on the root disk) and luksOpens the mapper if
+closed. **Reject `/etc/crypttab`-with-keyfile** (it would write the passphrase in cleartext on the
+host disk, defeating the "key lives only in Doppler" custody property).
 
 ### D3 — No escrow, no separate at-rest monitor (RECOMMENDED, matches git-data)
 git-data has neither; the registry is disposable, so neither is warranted. Confirmed.
 
-### D4 — Recut vehicle for the operator step (OUTSIDE this PR)
-The sanctioned operator apply is a scoped `terraform apply -replace` of the volume + attachment +
-host (fresh raw volume ⇒ cloud-init luksFormats it ⇒ zot re-fills from GHCR). Two vehicles exist
-or could: (i) the operator's untargeted full apply / a local `-replace` (already the sanctioned
-`OPERATOR_APPLIED_EXCLUSION` path per `zot-registry.tf:15`); (ii) a lean, destroy-guarded,
-typed-confirm `registry-luks-recut` `workflow_dispatch` target mirroring the existing
-`registry-region-migrate` / `workspaces-luks-recut` guards. **This PR does NOT add or fire (ii)** —
-it is documented as the recommended operator vehicle and deferred to the gated step (file a
-follow-up if a dispatch target is wanted). Keeps the PR to "cloud-init + terraform + ledger" per
-the task scope.
+### D4 — Recut vehicle for the operator step (OUTSIDE this PR) — RECOMMEND the guarded dispatch
+The re-encryption apply is a scoped `terraform apply -replace` of the volume + attachment + host
+(fresh raw volume ⇒ cloud-init luksFormats it ⇒ zot re-fills from GHCR). **Architecture review adds
+a load-bearing footgun the plan must not leave to the operator:** the operator must **NOT** use the
+existing `registry-host-replace` dispatch — it *preserves* the volume, so with Option B it boots the
+still-plaintext ext4 volume straight into the FATAL refuse arm (registry darks). The *only* correct
+apply `-replace`s volume + attachment + host **together**; forgetting the volume darks the registry.
+That is exactly the kind of manual, error-prone step Soleur's non-technical-operator principle
+(`feedback_never_defer_operator_actions`) says to encode, not defer.
+- **(ii) RECOMMENDED:** a lean, destroy-guarded, typed-confirm `registry-luks-recut`
+  `workflow_dispatch` target mirroring the existing `registry-region-migrate` / `workspaces-luks-recut`
+  guards, which `-replace`s the three resources atomically. Adding the job is code-only (unfired → no
+  live mutation); firing it is the gated step OUTSIDE this PR. **Scope call for plan-review/CTO:**
+  include the guarded dispatch in THIS PR (it removes the footgun and is unfired) vs. an immediate
+  follow-up PR. **Floor (required regardless):** file the D4(ii) tracking issue with re-eval criteria
+  + milestone, and flag the **"wrong-dispatch (`registry-host-replace`) = FATAL"** hazard prominently
+  in the PR body **and** the ADR-096 amendment. Do NOT leave the operator a bare `-replace` recipe as
+  the only path.
+- **(i) fallback:** the sanctioned `OPERATOR_APPLIED_EXCLUSION` `-replace` path (`zot-registry.tf:15`)
+  remains valid, but only with all three resources targeted together (the footgun above).
 
 ## Implementation Phases
 
@@ -187,11 +244,20 @@ attachment from its secret pair). Add:
    which satisfies `attachment_binds_volume`).
 
 ### Phase 2 — Guest cryptsetup in `cloud-init-registry.yml`
+> **P1-B (ordering — load-bearing, from architecture review):** the registry cloud-init currently
+> installs the Doppler CLI (`~695-702`) and writes the token env-file `/etc/default/registry-doppler`
+> (`~710-711`) **AFTER** the mount block (`656-687`). git-data does the reverse (Doppler at `~126-140`,
+> BEFORE its LUKS block `~151-171`). A `doppler run` LUKS block dropped in at `~657` would have
+> **neither the CLI nor the token yet** and fail on first boot. **Fix:** move the Doppler CLI install
+> + env-file write ahead of the LUKS mount block (or relocate the LUKS block to after `:711`). This
+> reorder is a REQUIRED part of Phase 2, not optional.
+
 1. `packages:` — add `cryptsetup` (keep `e2fsprogs`).
-2. Pass `REGISTRY_LUKS_KEY` to the guest via the EXISTING scoped Doppler path (the host already
-   writes a 0600 root env file with `doppler_service_token.registry.key` and runs `doppler run` at
-   boot). Read the key with `doppler run --project soleur-registry --config prd -- ...` (or
-   `doppler secrets get REGISTRY_LUKS_KEY --plain`), never argv, never baked into `user_data`.
+2. **Reorder (P1-B):** ensure the Doppler CLI install + `/etc/default/registry-doppler` write precede
+   the LUKS mount block. Then pass `REGISTRY_LUKS_KEY` to the guest via that EXISTING scoped Doppler
+   path (0600 root env file with `doppler_service_token.registry.key` + `doppler run` at boot). Read
+   the key with `doppler run --project soleur-registry --config prd -- ...` (or `doppler secrets get
+   REGISTRY_LUKS_KEY --plain`), never argv, never baked into `user_data`.
 3. Replace the plaintext mount runcmd (`656-687`) with the git-data-shaped block, keyed off
    `DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}`:
    - Fail-loud: `[ -n "$REGISTRY_LUKS_KEY" ] || { echo "FATAL ... refusing unencrypted mount"; exit 1; }`
@@ -202,16 +268,30 @@ attachment from its secret pair). Add:
    - `blkid /dev/mapper/registry >/dev/null 2>&1 || mkfs.ext4 -q /dev/mapper/registry`
    - `mountpoint -q /var/lib/zot || mount /dev/mapper/registry /var/lib/zot`
    - fstab: `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` (append-if-absent; no crypttab).
+   - **DELETE the stale by-id fstab line (`:687`)** `/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}
+     /var/lib/zot ext4 ...` when adding the mapper line. Leaving it causes a reboot double-mount of
+     `/var/lib/zot` and a raw-ext4 mount attempt against a now-`crypto_LUKS` device (fails). Hard
+     requirement (architecture review; adjacent to SE5).
    - **resize path (`642-682`):** `resize2fs` must target `/dev/mapper/registry` (and `cryptsetup
      resize registry` first if the underlying volume grew) — NOT the raw `$DEV`. Update the
      `.resize-result` record accordingly.
    - **raw-device invariant (`664`, `lsblk TYPE ... part`)**: rework — the LUKS device presents
      `crypto_LUKS`, the mapper presents `ext4`; the no-partition assert moves to `$DEV` being
      `crypto_LUKS` (or empty pre-format), not `ext4`-on-raw.
-4. **D2 boot-time luksOpen:** add an idempotent boot step (bootcmd/oneshot) ordered before the
-   self-heal (`484-506`) that reads `REGISTRY_LUKS_KEY` (scoped doppler) and luksOpens the mapper if
+4. **D2 boot-time luksOpen (REQUIRED):** add an idempotent boot step (bootcmd/oneshot) ordered
+   **after** `network-online` and **before** the self-heal (`484-506`) that reads `REGISTRY_LUKS_KEY`
+   (scoped doppler, from persisted `/etc/default/registry-doppler`) and luksOpens the mapper if
    closed, so `mount -a`/`docker restart zot` on reboot remounts `/dev/mapper/registry`. Keep the
-   self-heal's `mountpoint -q /var/lib/zot` short-circuit.
+   self-heal's `mountpoint -q /var/lib/zot` short-circuit. Load-bearing because the NIC guard
+   self-`reboot`s the host (`cloud-init-registry.yml:610`) — see D2.
+5. **P1-A — widen the boot isolation self-check (REQUIRED, from architecture review).** The fail-closed
+   isolation self-check at `cloud-init-registry.yml:741-746` asserts the boot token resolves **exactly
+   three** secrets (`^(ZOT_(PULL|PUSH)_TOKEN|BETTERSTACK_LOGS_TOKEN)$`, `n_total -ne 3` → FATAL). Adding
+   `REGISTRY_LUKS_KEY` to `soleur-registry/prd` makes it **4** → the guard FATALs and **zot never
+   launches** on the recut boot. Edit: bump `-ne 3` → `-ne 4`, extend the admitted-names regex to
+   include `REGISTRY_LUKS_KEY`, and fix the "THREE admitted" / "a 2-secret config now FATALs" comments
+   at `:730,:740`. This is the enforcement mechanism, not the #6122 isolation property (which is
+   preserved — `REGISTRY_LUKS_KEY` is a registry-scoped secret). Mutation-tested in Phase 3.
 
 ### Phase 3 — Mutation-tested guard suite `registry-luks.test.sh`
 Mirror `git-data-luks.test.sh` (each assertion paired with a mutation that must flip it to RED;
@@ -225,7 +305,11 @@ Assertions:
 - doppler read (scoped `soleur-registry`/`prd`) wraps the setup.
 - TF: `resource "random_password" "registry_luks"` + `name = "REGISTRY_LUKS_KEY"` present;
   `hcloud_volume.registry` has **no** `format = "ext4"` (D1/B); attachment binds `hcloud_volume.registry.id`.
-- (if D2) boot-time luksOpen present & ordered before the self-heal.
+- **D2 (unconditional):** boot-time luksOpen present & ordered before the reboot self-heal.
+- **P1-A:** the isolation self-check admits `REGISTRY_LUKS_KEY` and the cardinality is `4` (mutation:
+  delete `REGISTRY_LUKS_KEY` from the admitted set, or leave the count at `3`, ⇒ RED).
+- **P1-B:** the Doppler CLI install + `/etc/default/registry-doppler` write precede the LUKS mount block.
+- the stale by-id fstab line for `/var/lib/zot` is **absent** (only `/dev/mapper/registry` remains).
 - resize path targets `/dev/mapper/registry`, not the raw `$DEV`.
 
 ### Phase 4 — Ledger flip (`scripts/encryption-posture-ledger.json`, the `hcloud_volume.registry` row)
@@ -253,6 +337,14 @@ Verify `python3 scripts/lint-encryption-posture.py --repo-sweep` resolves the ch
   `cloud-init-ghcr-seed-login.test.sh` (grep them for hard-coded `mount $DEV /var/lib/zot` / raw-device
   assumptions that the LUKS change breaks; update in-scope if the change falsifies them).
 - `git grep -n 'format *= *"ext4"' apps/web-platform/infra/zot-registry.tf` → **no hit** (D1/B).
+- **Exclusion parity test (architecture Q5):** `zot-registry.tf:16` references an
+  `OPERATOR_APPLIED_EXCLUSION` parity test. Determine whether it *enumerates* expected-excluded
+  resources; if so, register the two NEW resources (`random_password.registry_luks`,
+  `doppler_secret.registry_luks_key`) so the parity guard does not FAIL CI. Grep
+  `apps/web-platform/infra/*parity*.test.sh` + the workflow `-target=` allow-list.
+- **Drift-issue dedup:** confirm `scheduled-terraform-drift.yml` dedups (refreshes one advisory issue)
+  rather than filing a fresh issue every 12h for the perpetual pending-replace (workspaces_luks
+  additive-resource precedent suggests it tolerates this — confirm).
 
 ## Acceptance Criteria
 
@@ -261,8 +353,11 @@ Verify `python3 scripts/lint-encryption-posture.py --repo-sweep` resolves the ch
 - [ ] `zot-registry.tf` declares `random_password.registry_luks` (length 40, special=false) and `doppler_secret.registry_luks_key` (`project = "soleur-registry"`, `name = "REGISTRY_LUKS_KEY"`), co-located with `hcloud_volume_attachment.registry`.
 - [ ] `hcloud_server.registry.depends_on` includes `doppler_secret.registry_luks_key`; `registry_luks` is **absent** from `lifecycle.replace_triggered_by`.
 - [ ] `cloud-init-registry.yml` `packages:` includes `cryptsetup`; the mount runcmd does `cryptsetup luksFormat --type luks2 --key-file -` + `luksOpen --key-file - "$DEV" registry` + `mount /dev/mapper/registry /var/lib/zot`; the key is piped from `printf '%s' "$REGISTRY_LUKS_KEY"` (stdin) and never appears as a bare argv token; fail-loud empty-key guard present; else-TYPE→FATAL refuse arm present.
-- [ ] fstab line `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` present; resize path targets `/dev/mapper/registry`.
-- [ ] (D2, if adopted) an idempotent boot-time luksOpen is ordered before the reboot self-heal.
+- [ ] fstab line `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` present; the **stale by-id fstab line** for `/var/lib/zot` is **removed** (P1); resize path targets `/dev/mapper/registry`.
+- [ ] **(D2, REQUIRED)** an idempotent boot-time luksOpen is ordered after `network-online` and before the reboot self-heal (host self-`reboot`s via NIC guard `cloud-init-registry.yml:610`).
+- [ ] **(P1-A)** the boot isolation self-check (`cloud-init-registry.yml:741-746`) admits `REGISTRY_LUKS_KEY` and its cardinality is `4` (was `3`); the "THREE admitted" comments are updated. Mutation: count left at `3` ⇒ RED.
+- [ ] **(P1-B)** the Doppler CLI install + `/etc/default/registry-doppler` write precede the LUKS mount block in `cloud-init-registry.yml`.
+- [ ] **(architecture Q5)** the `OPERATOR_APPLIED_EXCLUSION` parity test (if resource-enumerated) registers `random_password.registry_luks` + `doppler_secret.registry_luks_key`; the parity/exclusion suites are green.
 - [ ] `registry-luks.test.sh` passes, meets its mutation-cardinality floor, and every assertion has a paired mutation proven to flip it RED.
 - [ ] Ledger row `hcloud_volume.registry`: `at_rest.mechanism == "luks"`, **no `exception` key**, `device_binding.mapper == "registry"`, `does_not_defend` non-empty (≥8 chars), `live_verification` matches `^(available|unavailable:.+)$`.
 - [ ] `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (device-binding chain resolves to real code; positive-work floor + `live_coverage_floor: 1` still satisfied).
@@ -271,7 +366,8 @@ Verify `python3 scripts/lint-encryption-posture.py --repo-sweep` resolves the ch
 - [ ] PR body uses `Closes #6895` (title uses no `#`); references #6893/#6588 as `Ref` only.
 
 ### Post-merge (operator, OUTSIDE this PR — the gated re-encryption)
-- [ ] `Automation: sanctioned OPERATOR_APPLIED_EXCLUSION apply path` (per `zot-registry.tf:15` CTO ruling). The operator runs a scoped `terraform apply -replace='hcloud_volume.registry' -replace='hcloud_volume_attachment.registry' -replace='hcloud_server.registry'` (fresh raw volume ⇒ cloud-init luksFormats ⇒ zot re-fills from GHCR), OR a `registry-luks-recut` dispatch if D4(ii) is later added. Not `Closes`-linked (the fix runs post-merge). Blast radius near-zero (disposable mirror; brief cold-pull gap while it re-fills).
+- [ ] `Automation: sanctioned OPERATOR_APPLIED_EXCLUSION apply path` (per `zot-registry.tf:15` CTO ruling). The gated apply is a scoped `terraform apply -replace='hcloud_volume.registry' -replace='hcloud_volume_attachment.registry' -replace='hcloud_server.registry'` (fresh raw volume ⇒ cloud-init luksFormats ⇒ zot re-fills from GHCR) — **all three `-replace` together** — preferably via the recommended guarded `registry-luks-recut` dispatch (D4(ii)). Not `Closes`-linked. Blast radius near-zero (disposable mirror; brief cold-pull gap).
+- [ ] **FOOTGUN (must be in PR body + ADR-096 amendment):** do **NOT** use the existing `registry-host-replace` dispatch for the recut — it *preserves* the plaintext volume, so with D1/B it boots into the FATAL refuse arm and darks the registry. Forgetting the `-replace` on the volume has the same effect.
 - [ ] After the recut: zot liveness + disk heartbeats green; `web-zot-consumer-probe` green; the volume's device is `/dev/mapper/registry` (LUKS-backed).
 
 ## Infrastructure (IaC)
@@ -363,10 +459,15 @@ volume; the **ledger row flip IS the recorded decision**. No new cross-cutting i
 or trust boundary is introduced.
 
 ### ADR
-- **No new ADR.** Recommend a lean **amendment to ADR-096** (the zot-registry ADR) recording: the
-  registry store volume flips plaintext->guest-side-LUKS; the recut (D4) is the sanctioned
-  re-encryption vehicle; escrow is intentionally omitted (disposable). deepen-plan/CTO to confirm
-  whether the amendment is warranted or the ledger row + this plan suffice.
+- **No new ADR; a lean ADR-096 amendment is REQUIRED (not optional).** Deepen-plan resolved a
+  reviewer split here: the simplicity reviewer wanted to drop the amendment to a pointer (the ledger
+  row is the record); the architecture reviewer showed the ledger row alone does **not** capture two
+  operator-facing facts that need a decision record per `wg-architecture-decision-is-a-plan-deliverable` —
+  (a) the D4 recut vehicle (`registry-luks-recut` / three-`-replace` apply), and (b) the
+  **"wrong-dispatch (`registry-host-replace`) = FATAL" footgun** (D4). The architecture position wins:
+  land a lean amendment to ADR-096 recording the plaintext→guest-LUKS flip, the recut vehicle, the
+  footgun, and the deliberate escrow omission (disposable). Keep it short; do NOT gate PR-ready on
+  prose length, but the amendment itself is in-scope for this PR.
 
 ### C4 views
 - **Reviewer MUST read all three model files** (`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`)
@@ -385,6 +486,39 @@ The ledger row's `mechanism: luks` describes the **target** state; it becomes *l
 operator recut. Because Layer A resolves the row against the **apparatus code** (not live state),
 the row PASSES the sweep the moment the apparatus lands — no `status: adopting` sequencing gap for
 the ledger. Live truth is Layer B's job (deferred, ADR-141).
+
+## Downtime & Cutover
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+
+**Offline-inducing operation:** the gated re-encryption (D4, OUTSIDE this PR) is a
+`terraform apply -replace` of `hcloud_volume.registry` + `hcloud_volume_attachment.registry` +
+`hcloud_server.registry` — a destroy+recreate of the sole registry host and its store volume.
+Surface affected: the private-net zot pull endpoint (`10.0.1.30:5000`) that web hosts + CI pull our
+two platform images from. **This PR itself induces zero downtime** (code-only; the registry
+resources are `OPERATOR_APPLIED_EXCLUSION`, never applied on merge; drift is plan-only).
+
+**Zero-downtime evaluation (default-to-zero-downtime):**
+- A **blue-green** cutover (provision a fresh registry host+LUKS volume alongside, drain, cut the
+  private-net endpoint over, retire the old) is *possible* but **not warranted** here: the store is
+  a **disposable GHCR mirror** — a fresh volume is born empty and re-fills from GHCR on demand, so
+  there is no data to migrate and no rollback backstop to preserve (unlike the workspaces/git-data
+  sole-copy cutovers). The engineering cost of a blue-green registry (a second host, endpoint
+  failover, a second placement-group slot) exceeds the benefit for a mirror whose consumers already
+  tolerate a cold-pull miss.
+- **Chosen path (accepted bounded downtime):** a maintenance-window `-replace`. Residual downtime =
+  the cold-pull gap between the old host's destroy and the new host's zot coming up + first re-fill
+  from GHCR. Justification: near-zero blast radius (disposable mirror; web hosts fall back to
+  re-pulling from GHCR/upstream during the gap — the exact re-fill semantics the existing
+  `registry-region-migrate` dispatch already relies on), single-operator maintenance window, and no
+  user-data path. Per-stage verification: the D1/B fail-loud boot guard + zot liveness heartbeat
+  (green ⇒ mount + re-fill succeeded); rollback = the mirror is recreatable from GHCR at any time.
+- **Operator sign-off:** the recut is an explicit gated dispatch/`-replace` (D4) run in a
+  maintenance window — not an unattended apply.
+
+This is consistent with #5887's zero-downtime-first discipline: the zero-downtime path was
+*evaluated and consciously declined* for a disposable store where it buys nothing, not skipped by
+default.
 
 ## Encryption Posture
 
@@ -422,9 +556,9 @@ explicit decisions above and routed to the plan-review CTO lens + deepen-plan pr
 
 ## Files to Edit
 - `apps/web-platform/infra/zot-registry.tf` — add `random_password.registry_luks` + `doppler_secret.registry_luks_key`; remove `format` from `hcloud_volume.registry`; extend `hcloud_server.registry.depends_on`.
-- `apps/web-platform/infra/cloud-init-registry.yml` — add `cryptsetup` package; replace plaintext mount with LUKS format/open/mount; fix resize + raw-device invariant; add D2 boot-open.
+- `apps/web-platform/infra/cloud-init-registry.yml` — add `cryptsetup` package; **reorder Doppler CLI install + env-file write ahead of the mount block (P1-B)**; replace plaintext mount with LUKS format/open/mount; **delete the stale by-id fstab line (P1)**; fix resize + raw-device invariant; **widen the isolation self-check `:741-746` cardinality 3→4 + admit `REGISTRY_LUKS_KEY` (P1-A)**; add the required D2 boot-open.
 - `scripts/encryption-posture-ledger.json` — flip the `hcloud_volume.registry` row to `mechanism: luks` (remove exception; retarget mapper; update evidence/verification fields).
-- (possibly) `knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md` — lean amendment (D-decision; confirm at deepen-plan).
+- `knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md` — **required** lean amendment (plaintext→guest-LUKS flip, D4 recut vehicle, `registry-host-replace`=FATAL footgun, escrow omission).
 - (possibly, if any existing registry test hard-codes the plaintext mount) `apps/web-platform/infra/registry-boot-guard.test.sh` / `registry-insecure-config.test.sh` / `zot-liveness-heartbeat.test.sh` — update in-scope only if the LUKS change falsifies an existing assertion (verify via grep in Phase 5).
 
 ## Files to Create

--- a/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
+++ b/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
@@ -421,6 +421,12 @@ No new vendor, no free-tier gate (Hetzner volumes + Doppler secrets are already 
 liveness_signal:
   what: zot answers on its private IP (existing SOLEUR liveness heartbeat) — gated on a successful
         LUKS mount of /var/lib/zot; a failed luksOpen/mount => zot never starts => heartbeat stops.
+        ENFORCED by the zot-launch mount-gate (`findmnt -no SOURCE /var/lib/zot | grep -qx
+        /dev/mapper/registry || exit 1`, immediately before `docker run … zot`): the mount and the
+        launch are separate runcmd entries and cloud-init continues past a failed one, so without
+        this gate a failed LUKS mount would still launch zot on an empty root-disk dir answering 401
+        (heartbeat green, no alert). The gate makes "fail-loud => zot never starts => liveness
+        absence" TRUE rather than aspirational.
   cadence: existing zot-liveness-heartbeat cron cadence (betteruptime_heartbeat.registry_prd)
   alert_target: Better Stack absence alert (betteruptime_heartbeat.registry_prd)
   configured_in: apps/web-platform/infra/zot-registry.tf (betteruptime_heartbeat.registry_prd) + cloud-init-registry.yml
@@ -448,7 +454,10 @@ discoverability_test:
 **Blind-surface note (Phase 2.9.2):** the cloud-init cryptsetup block is a blind execution surface.
 Its in-surface probe is the **fail-loud boot guard** (a FATAL that discriminates empty-key vs
 wrong-TYPE-device vs closed-mapper in one stderr marker) surfaced off-box via the liveness-absence
-heartbeat — no SSH needed. Layer B live-reconcile (ADR-141, deferred) is the eventual per-volume
+heartbeat — no SSH needed. The liveness-absence route is only load-bearing because the **zot-launch
+mount-gate** (`findmnt … /dev/mapper/registry` before `docker run … zot`) refuses to start zot on
+an unmounted store: without it a failed mount would launch an empty-store zot that answers 401 and
+keeps the heartbeat green, so the gate is what turns any LUKS failure into an observable absence. Layer B live-reconcile (ADR-141, deferred) is the eventual per-volume
 posture probe (`live_verification` stays `unavailable:...#6895` until then).
 
 ## Architecture Decision (ADR/C4)

--- a/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
+++ b/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
@@ -1,0 +1,475 @@
+---
+title: "feat(#6895): guest-side LUKS apparatus for hcloud_volume.registry + ledger flip"
+date: 2026-07-24
+issue: 6895
+parent_gate: 6893
+related_issues: [6588, 6893, 6896, 6897, 6901]
+related_adrs: [ADR-140, ADR-141, ADR-119, ADR-096]
+brand_survival_threshold: none
+lane: cross-domain
+type: feat
+milestone: "Phase 4: Validate + Scale"
+---
+
+# feat(#6895): guest-side LUKS at-rest for the registry (zot) volume + posture-ledger flip
+
+> Spec lacks a `lane:` (no `spec.md` for this branch) — defaulted to `cross-domain` (TR2 fail-closed).
+
+## Overview
+
+`hcloud_volume.registry` (`apps/web-platform/infra/zot-registry.tf:407`, `format = "ext4"`) is
+the **plaintext** block volume for the self-hosted zot OCI registry (the GHCR mirror at
+`/var/lib/zot`). It holds OCI blobs + cosign `.sig` referrers for our two private platform
+images. It is **disposable** — a seized/snapshot disk exposes only container-image bytes whose
+integrity comes from cosign digest-pinning, and the store re-fills from GHCR on any recreate.
+Per ADR-140 it is currently recorded as a `plaintext-exception` row in the encryption-posture
+ledger (`scripts/encryption-posture-ledger.json`, expires `2026-10-22`, tracking #6895).
+
+This feature builds the **guest-side LUKS apparatus** for that volume — mirroring the existing
+`git_data_luks` apparatus (the correct template; see §Template choice) — and flips the ledger
+row from `mechanism: plaintext-exception` → `mechanism: luks`.
+
+**Deliverable = a reviewed, mergeable PR containing ONLY:** the LUKS apparatus (Terraform in
+`zot-registry.tf`, guest cryptsetup in `cloud-init-registry.yml`, a mutation-tested guard suite)
+plus the one-row ledger flip. **No `terraform apply` runs in this PR.** The destroy+recreate that
+actually re-encrypts the live registry volume is a **separate, deliberately gated operator step
+OUTSIDE this PR** (see §Infrastructure → Apply path). **Zero live-infra mutation on merge** — the
+registry resources are `OPERATOR_APPLIED_EXCLUSION` (never in the per-PR `-target=` list;
+`zot-registry.tf:15`), and the 12h drift detector is **plan-only** (`terraform plan
+-detailed-exitcode`, files an issue, never applies — `scheduled-terraform-drift.yml:100`).
+
+**Parent gate #6893 and P1 #6588 STAY OPEN** — this PR touches neither.
+
+### Template choice — git_data_luks, not workspaces_luks
+
+The repo has two guest-side LUKS templates. `workspaces_luks` is heavy (10 TF resources across 2
+files, a 176 KB freeze/rsync/dead-man/canary cutover, R2 header escrow, a reviewer-gated GitHub
+environment, ~9 test files) — all of it exists to migrate **sole-copy, populated, live user data
+in place** irreversibly (ADR-119). `git_data_luks` is lean (5 TF resources, boot-time
+`cryptsetup` in cloud-init, one mutation-tested guard file, **no escrow, no reviewer gate, no
+freeze machinery**) because its volume is **born fresh**. The registry volume is disposable and
+born-fresh (re-fills from GHCR) — exactly the `git_data` situation. **Mirror `git-data-luks.tf` +
+the `cloud-init-git-data.yml` LUKS block + `git-data-luks.test.sh`. Do NOT port header escrow,
+the reviewer environment, the CI boot-token channel, the cutover/freeze/dead-man machinery, or the
+emit/harness leaf helpers.** The registry apparatus is even leaner than git-data on the secret
+channel: the isolated `soleur-registry` Doppler project + read-only `doppler_service_token.registry`
+already exist and already reach the host at boot — so **no new Doppler service token is needed.**
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Claim (issue #6895 / task) | Reality (verified against `origin` worktree) | Plan response |
+|---|---|---|
+| terraform at `zot-registry.tf:407` | Confirmed: `hcloud_volume.registry`, `format = "ext4"`, `size = var.registry_volume_size`, `location = var.registry_location` | Edit in place |
+| "disposable GHCR mirror; integrity via cosign digest-pinning" | Confirmed: `rootDirectory` `/var/lib/zot`; re-fills from GHCR; a `registry-region-migrate` dispatch already recreates the store and re-fills | Drives `threshold: none` + lean git-data template |
+| "mirror the EXISTING workspaces_luks and git_data_luks apparatus" | Both exist. git_data_luks is the lean/correct fit; workspaces_luks is the heavy sole-copy-data fit | Mirror **git_data_luks** |
+| ledger row exists as plaintext-exception | Confirmed: `scripts/encryption-posture-ledger.json:130-152`, `mapper: "registry-plain"`, `expires_on 2026-10-22`, `tracking #6895` | Flip to `luks` in the same PR (linter requires apparatus + row atomic) |
+| ledger `kind` "flips" plaintext→guest-luks | **Correction:** `kind` is already `guest-luks-volume` (permanent for the class). What flips is `at_rest.mechanism` `plaintext-exception`→`luks` **and** removal of the `exception` block **and** `mapper` `registry-plain`→`registry` | Edit those fields only |
+| "destroy+recreate ... SEPARATE gated operator step" | Registry resources are `OPERATOR_APPLIED_EXCLUSION`; sanctioned operator apply is an untargeted/`-replace` apply, not per-PR | Operator step documented OUTSIDE this PR; PR is code-only |
+| Layer A linter is a required check | **Correction:** currently **advisory/non-blocking** (absent from `required-checks.txt`; soaking, tracked #6901) — but the edit must still make `python3 scripts/lint-encryption-posture.py --repo-sweep` PASS | AC gates on a green sweep |
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** nothing at merge (code-only, zero apply). If the
+apparatus itself is wrong, the **operator's** later gated recut boots a registry host that either
+(a) fails loud and zot never starts → Better-Stack liveness-absence alert (the safe failure), or
+(b) — the failure this plan guards against — silently mounts plaintext, certifying a false-green
+posture row. No end-user data is on this volume.
+
+**If this leaks, the user's data is exposed via:** it is **not** — the registry volume holds only
+OCI image blobs + cosign signatures (our own platform images), never user/personal/repo data. A
+seized disk exposes container bytes whose integrity is cosign-pinned; at-rest LUKS here is
+defense-in-depth on a disposable mirror, not a user-data control.
+
+**Brand-survival threshold:** none.
+`threshold: none, reason: the registry volume holds only OCI image blobs + cosign signatures (a disposable GHCR mirror that re-fills from GHCR) — no user, personal, or repository data is ever written to it; at-rest encryption is defense-in-depth, not a user-data confidentiality control.`
+(Required scope-out bullet because the diff touches sensitive paths — `.tf` + `cloud-init*.yml` —
+per preflight Check 6. No CPO sign-off required at `none`.)
+
+## Goals
+
+1. Add the guest-side LUKS apparatus for `hcloud_volume.registry`, mirroring `git_data_luks`,
+   so a freshly-provisioned registry volume boots LUKS-encrypted at `/var/lib/zot`.
+2. Flip the ledger row `hcloud_volume.registry` to `mechanism: luks` (remove exception; retarget
+   `mapper`), and make `scripts/lint-encryption-posture.py --repo-sweep` resolve the device-binding
+   chain to real code and PASS.
+3. Ship a mutation-tested guard suite (`registry-luks.test.sh`) mirroring `git-data-luks.test.sh`.
+4. Preserve **zero live-infra mutation on merge** and keep #6893 / #6588 open.
+
+## Non-Goals / Out of Scope (deferred — file tracking issues)
+
+- **Running the destroy+recreate re-encryption apply.** Gated operator step, OUTSIDE this PR.
+- **R2 LUKS-header escrow** (workspaces `#6649` pattern). Not needed for a disposable volume —
+  passphrase loss ⇒ recreate + re-fill from GHCR. Do NOT port `workspaces-luks-header.tf`.
+- **A dedicated daily at-rest monitor unit** (`luks-monitor.*` is workspaces-only). Registry
+  at-rest liveness rides the existing zot liveness/disk heartbeats + the fail-loud boot guard;
+  Layer B live-reconcile (ADR-141, deferred) is the eventual live check. If a decision (D2/D3
+  below) is deferred, file a tracking issue with re-evaluation criteria + the Phase-4 milestone.
+
+## Key Design Decisions (surface to CTO / plan-review / deepen-plan)
+
+### D1 — Raw volume + refuse-on-populated discriminator (RECOMMENDED) vs `format=ext4` + `isLuks`
+- **Option A (git-data parity):** keep `format = "ext4"`, guard with `if ! cryptsetup isLuks`.
+  Simplest, precedented. **Hazard:** on a *populated plaintext* device `isLuks` is false ⇒
+  `luksFormat` wipes it (ADR-119 fact 2, the headline data-loss mechanism). Acceptable for a
+  disposable mirror, but silent.
+- **Option B (workspaces parity — RECOMMENDED):** remove `format` (raw volume) and use the `blkid
+  -o value -s TYPE` discriminator: `""` → `luksFormat`; `crypto_LUKS` → `luksOpen` (no-op format);
+  **any other TYPE (e.g. `ext4`) → FATAL, refuse to touch.** Fail-loud instead of silent-wipe if
+  the apparatus is ever pointed at the old populated plaintext volume (e.g. an accidental
+  `registry-host-replace`, which *preserves* the volume, run before the recut). ADR-140-aligned
+  (the plaintext/LUKS sibling-namespace hazard is the exact false-green this whole feature exists
+  to prevent). Cost: a ForceNew diff on the volume — but drift is plan-only and the resource is
+  operator-excluded, so **no live mutation on merge**; the gated recut provides a fresh raw volume
+  regardless. **Recommend Option B.** (Note: the host `user_data` change already forces a
+  host-replace diff regardless of D1, so D1 does not change the "drift until the operator applies"
+  reality — only the safety guard.)
+
+### D2 — Reboot survivability (RECOMMENDED: add a boot-time idempotent luksOpen)
+Unlike git-data (never rebooted, only replaced), the registry host has an **existing reboot
+self-heal** (`cloud-init-registry.yml:484-506`) that runs `mount -a` + `docker restart zot`.
+With LUKS, fstab points at `/dev/mapper/registry`, which is **closed after a reboot** (no
+`/etc/crypttab`, matching git-data) — so `mount -a` fails and zot stays dark until re-provision.
+**Recommend** a lean idempotent boot-time luksOpen (a `bootcmd`/systemd-oneshot ordered before the
+self-heal / zot start) that reads `REGISTRY_LUKS_KEY` via the existing scoped
+`doppler_service_token.registry` and opens the mapper — so a routine reboot remounts cleanly. This
+is the one place the registry apparatus should exceed bare git-data parity, because the registry
+host's self-heal assumes the mount returns. If judged out-of-scope, defer with a tracking issue
+(re-eval: "does a registry-host reboot recur outside a full re-provision?").
+
+### D3 — No escrow, no separate at-rest monitor (RECOMMENDED, matches git-data)
+git-data has neither; the registry is disposable, so neither is warranted. Confirmed.
+
+### D4 — Recut vehicle for the operator step (OUTSIDE this PR)
+The sanctioned operator apply is a scoped `terraform apply -replace` of the volume + attachment +
+host (fresh raw volume ⇒ cloud-init luksFormats it ⇒ zot re-fills from GHCR). Two vehicles exist
+or could: (i) the operator's untargeted full apply / a local `-replace` (already the sanctioned
+`OPERATOR_APPLIED_EXCLUSION` path per `zot-registry.tf:15`); (ii) a lean, destroy-guarded,
+typed-confirm `registry-luks-recut` `workflow_dispatch` target mirroring the existing
+`registry-region-migrate` / `workspaces-luks-recut` guards. **This PR does NOT add or fire (ii)** —
+it is documented as the recommended operator vehicle and deferred to the gated step (file a
+follow-up if a dispatch target is wanted). Keeps the PR to "cloud-init + terraform + ledger" per
+the task scope.
+
+## Implementation Phases
+
+### Phase 0 — Preconditions (verify, no writes)
+- `git branch --show-current` = `feat-one-shot-6895-registry-volume-luks`; #6895 / #6893 / #6588 all OPEN.
+- Re-read the four load-bearing sources against HEAD before editing: `zot-registry.tf` (volume
+  407, attachment 418, host 290-401, `random_password`/`doppler_secret` blocks 145-287),
+  `cloud-init-registry.yml` (packages ~21, mount runcmd 656-687, self-heal 484-506, resize
+  642-682), `git-data-luks.tf` + `cloud-init-git-data.yml` LUKS block (the template),
+  `scripts/lint-encryption-posture.py` `check_luks_row()` + `git-data-luks.test.sh`.
+- Confirm mapper-name choice `registry` is unused elsewhere (`grep -rn 'mapper/registry\|"registry-plain"' apps/web-platform/infra/`).
+
+### Phase 1 — Terraform LUKS resources (in `zot-registry.tf`, co-located with the attachment)
+The linter's `file_has_secret_pair` requires the `random_password` + `doppler_secret` pair to live
+in the **same file as the attachment** (`hcloud_volume_attachment.registry`, `zot-registry.tf`).
+Keep them in `zot-registry.tf` (do NOT split into a new `registry-luks.tf`, which would orphan the
+attachment from its secret pair). Add:
+1. `resource "random_password" "registry_luks"` — `length = 40`, `special = false` (stdin/htpasswd-safe,
+   ~238 bits). No `keepers`, no `ignore_changes` — rotation is operator-explicit `-replace` (see SE).
+   Comment cross-refs `random_password.git_data_luks`.
+2. `resource "doppler_secret" "registry_luks_key"` — `project = "soleur-registry"`,
+   `config = "prd"` (the ISOLATED project's root, via `doppler_environment.registry_prd`),
+   `name = "REGISTRY_LUKS_KEY"`, `value = random_password.registry_luks.result`, `visibility = "masked"`.
+   (Reuses the isolated project; the existing `doppler_service_token.registry` already reads it —
+   **no new service token**.)
+3. `hcloud_volume.registry` (`:407`) — **remove `format = "ext4"`** (Option B / D1). Leave name,
+   size, location, labels unchanged. Add a SHARP-EDGE comment: raw device + guest luksFormat; there
+   is no hcloud `encrypted` attribute (ADR-140).
+4. `hcloud_server.registry` — extend `depends_on` with `doppler_secret.registry_luks_key` (mirrors
+   the existing `zot_pull_token_registry`/`zot_push_token_registry` boot-ordering guard); add the
+   `registry_luks_key`/`REGISTRY_LUKS_KEY` to the boot secret set the host's fail-loud guard expects.
+   **Do NOT add `registry_luks` to `lifecycle.replace_triggered_by`** — a passphrase rotation must
+   NOT merely replace the host (cloud-init would luksOpen the OLD-key volume with the NEW key and
+   fail); rotation is a recut (SE below).
+5. `hcloud_volume_attachment.registry` (`:418`) — unchanged (already `volume_id = hcloud_volume.registry.id`,
+   which satisfies `attachment_binds_volume`).
+
+### Phase 2 — Guest cryptsetup in `cloud-init-registry.yml`
+1. `packages:` — add `cryptsetup` (keep `e2fsprogs`).
+2. Pass `REGISTRY_LUKS_KEY` to the guest via the EXISTING scoped Doppler path (the host already
+   writes a 0600 root env file with `doppler_service_token.registry.key` and runs `doppler run` at
+   boot). Read the key with `doppler run --project soleur-registry --config prd -- ...` (or
+   `doppler secrets get REGISTRY_LUKS_KEY --plain`), never argv, never baked into `user_data`.
+3. Replace the plaintext mount runcmd (`656-687`) with the git-data-shaped block, keyed off
+   `DEV=/dev/disk/by-id/scsi-0HC_Volume_${registry_volume_id}`:
+   - Fail-loud: `[ -n "$REGISTRY_LUKS_KEY" ] || { echo "FATAL ... refusing unencrypted mount"; exit 1; }`
+   - **D1/Option B discriminator:** `TYPE=$(blkid -o value -s TYPE "$DEV" ...)`; `""` →
+     `printf '%s' "$REGISTRY_LUKS_KEY" | cryptsetup luksFormat --batch-mode --type luks2 --key-file - "$DEV"`;
+     `crypto_LUKS` → skip format; else → `FATAL` refuse.
+   - `[ -e /dev/mapper/registry ] || printf '%s' "$REGISTRY_LUKS_KEY" | cryptsetup luksOpen --key-file - "$DEV" registry`
+   - `blkid /dev/mapper/registry >/dev/null 2>&1 || mkfs.ext4 -q /dev/mapper/registry`
+   - `mountpoint -q /var/lib/zot || mount /dev/mapper/registry /var/lib/zot`
+   - fstab: `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` (append-if-absent; no crypttab).
+   - **resize path (`642-682`):** `resize2fs` must target `/dev/mapper/registry` (and `cryptsetup
+     resize registry` first if the underlying volume grew) — NOT the raw `$DEV`. Update the
+     `.resize-result` record accordingly.
+   - **raw-device invariant (`664`, `lsblk TYPE ... part`)**: rework — the LUKS device presents
+     `crypto_LUKS`, the mapper presents `ext4`; the no-partition assert moves to `$DEV` being
+     `crypto_LUKS` (or empty pre-format), not `ext4`-on-raw.
+4. **D2 boot-time luksOpen:** add an idempotent boot step (bootcmd/oneshot) ordered before the
+   self-heal (`484-506`) that reads `REGISTRY_LUKS_KEY` (scoped doppler) and luksOpens the mapper if
+   closed, so `mount -a`/`docker restart zot` on reboot remounts `/dev/mapper/registry`. Keep the
+   self-heal's `mountpoint -q /var/lib/zot` short-circuit.
+
+### Phase 3 — Mutation-tested guard suite `registry-luks.test.sh`
+Mirror `git-data-luks.test.sh` (each assertion paired with a mutation that must flip it to RED;
+enforce a minimum-cardinality floor). Files under test: `cloud-init-registry.yml`, `zot-registry.tf`.
+Assertions:
+- isLuks/blkid discriminator present (incl. the `crypto_LUKS`→no-op and else→FATAL arms).
+- every `luksFormat`/`luksOpen` carries `--key-file -`; `REGISTRY_LUKS_KEY` never a bare argv token.
+- key delivered via `printf '%s' "$REGISTRY_LUKS_KEY" | cryptsetup` (stdin).
+- `mount /dev/mapper/registry /var/lib/zot` present; fstab evidence `/dev/mapper/registry` present.
+- fail-loud empty-key guard present.
+- doppler read (scoped `soleur-registry`/`prd`) wraps the setup.
+- TF: `resource "random_password" "registry_luks"` + `name = "REGISTRY_LUKS_KEY"` present;
+  `hcloud_volume.registry` has **no** `format = "ext4"` (D1/B); attachment binds `hcloud_volume.registry.id`.
+- (if D2) boot-time luksOpen present & ordered before the self-heal.
+- resize path targets `/dev/mapper/registry`, not the raw `$DEV`.
+
+### Phase 4 — Ledger flip (`scripts/encryption-posture-ledger.json`, the `hcloud_volume.registry` row)
+Edit only the registry row (lines 130-152). Set `at_rest.mechanism: "luks"`; **delete the entire
+`exception` block**; set `device_binding.mapper: "registry"` (was `registry-plain`). Rewrite:
+- `evidence`: `apps/web-platform/infra/cloud-init-registry.yml:<luksFormat-line>,<luksOpen-line> (cryptsetup luksFormat/luksOpen registry); key: random_password.registry_luks + doppler_secret.registry_luks_key (zot-registry.tf); fstab: cloud-init-registry.yml:<fstab-line>` (fill real line numbers post-edit).
+- `defends_against`: "a seized/RMA'd or snapshot-imaged Hetzner block volume: OCI blobs + cosign signatures are unreadable without the Doppler-held LUKS passphrase".
+- `does_not_defend`: "a leaked credential, an app-layer read on the unlocked live registry host, or exfiltration via a compromised zot process" (must be ≥8 chars, non-empty, not "none/n/a").
+- `disclosed_as`: `not-publicly-claimed` (registry LUKS is not a public legal claim).
+- `live_verification`: `unavailable:no zot-host at-rest posture probe yet; tracked #6895` (a `luks`
+  row does NOT need a live probe; keep `hcloud_volume.workspaces_luks` as the ≥1 `available` row so
+  `live_coverage_floor: 1` still holds — do not touch that row).
+Verify `python3 scripts/lint-encryption-posture.py --repo-sweep` resolves the chain and PASSES
+(device_binding volume+attachment real, attachment binds volume, secret pair co-located in
+`zot-registry.tf`, mapper `registry` resolves through the cryptsetup site + fstab evidence).
+
+### Phase 5 — Full verification (no apply)
+- `registry-luks.test.sh` green (+ mutation floor met).
+- `python3 scripts/lint-encryption-posture.py --repo-sweep` green.
+- `cd apps/web-platform && terraform -chdir=infra fmt -check` (or the repo's `terraform validate`
+  path) — **plan/validate only, NEVER apply**. If `terraform validate` needs providers, use the
+  existing infra test/validation harness; do NOT authenticate to Hetzner/Doppler.
+- Existing registry test suites still green: `registry-boot-guard.test.sh`,
+  `registry-insecure-config.test.sh`, `zot-liveness-heartbeat.test.sh`, `web-zot-consumer-probe.test.sh`,
+  `cloud-init-ghcr-seed-login.test.sh` (grep them for hard-coded `mount $DEV /var/lib/zot` / raw-device
+  assumptions that the LUKS change breaks; update in-scope if the change falsifies them).
+- `git grep -n 'format *= *"ext4"' apps/web-platform/infra/zot-registry.tf` → **no hit** (D1/B).
+
+## Acceptance Criteria
+
+### Pre-merge (this PR)
+- [ ] `hcloud_volume.registry` in `zot-registry.tf` has **no** `format` attribute (D1/B); `grep -c 'format' <the-registry-volume-block>` = 0.
+- [ ] `zot-registry.tf` declares `random_password.registry_luks` (length 40, special=false) and `doppler_secret.registry_luks_key` (`project = "soleur-registry"`, `name = "REGISTRY_LUKS_KEY"`), co-located with `hcloud_volume_attachment.registry`.
+- [ ] `hcloud_server.registry.depends_on` includes `doppler_secret.registry_luks_key`; `registry_luks` is **absent** from `lifecycle.replace_triggered_by`.
+- [ ] `cloud-init-registry.yml` `packages:` includes `cryptsetup`; the mount runcmd does `cryptsetup luksFormat --type luks2 --key-file -` + `luksOpen --key-file - "$DEV" registry` + `mount /dev/mapper/registry /var/lib/zot`; the key is piped from `printf '%s' "$REGISTRY_LUKS_KEY"` (stdin) and never appears as a bare argv token; fail-loud empty-key guard present; else-TYPE→FATAL refuse arm present.
+- [ ] fstab line `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` present; resize path targets `/dev/mapper/registry`.
+- [ ] (D2, if adopted) an idempotent boot-time luksOpen is ordered before the reboot self-heal.
+- [ ] `registry-luks.test.sh` passes, meets its mutation-cardinality floor, and every assertion has a paired mutation proven to flip it RED.
+- [ ] Ledger row `hcloud_volume.registry`: `at_rest.mechanism == "luks"`, **no `exception` key**, `device_binding.mapper == "registry"`, `does_not_defend` non-empty (≥8 chars), `live_verification` matches `^(available|unavailable:.+)$`.
+- [ ] `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (device-binding chain resolves to real code; positive-work floor + `live_coverage_floor: 1` still satisfied).
+- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` is unaffected (no TS touched) — sanity only; the TS gate is not the target here.
+- [ ] No `terraform apply` was run; `git status` shows only the intended files changed; #6893 and #6588 remain OPEN (do not reference them with `Closes`).
+- [ ] PR body uses `Closes #6895` (title uses no `#`); references #6893/#6588 as `Ref` only.
+
+### Post-merge (operator, OUTSIDE this PR — the gated re-encryption)
+- [ ] `Automation: sanctioned OPERATOR_APPLIED_EXCLUSION apply path` (per `zot-registry.tf:15` CTO ruling). The operator runs a scoped `terraform apply -replace='hcloud_volume.registry' -replace='hcloud_volume_attachment.registry' -replace='hcloud_server.registry'` (fresh raw volume ⇒ cloud-init luksFormats ⇒ zot re-fills from GHCR), OR a `registry-luks-recut` dispatch if D4(ii) is later added. Not `Closes`-linked (the fix runs post-merge). Blast radius near-zero (disposable mirror; brief cold-pull gap while it re-fills).
+- [ ] After the recut: zot liveness + disk heartbeats green; `web-zot-consumer-probe` green; the volume's device is `/dev/mapper/registry` (LUKS-backed).
+
+## Infrastructure (IaC)
+
+<!-- iac-routing-ack: plan-phase-2-8-reviewed -->
+Phase 2.8 reviewed: ALL infrastructure lives in Terraform (`zot-registry.tf`) + cloud-init
+(`cloud-init-registry.yml`) — no SSH, no dashboard clicks, no manual host config. The only
+non-in-PR action is the **sanctioned `OPERATOR_APPLIED_EXCLUSION` `terraform apply`** (CTO ruling,
+`zot-registry.tf:15`), an established Terraform apply path for the registry resources — not a
+manual provisioning step. It is deliberately outside this PR per the task's gating requirement.
+
+### Terraform changes
+- Files: `apps/web-platform/infra/zot-registry.tf` (add `random_password.registry_luks` +
+  `doppler_secret.registry_luks_key`; remove `format` from `hcloud_volume.registry`; extend host
+  `depends_on`), `apps/web-platform/infra/cloud-init-registry.yml` (guest cryptsetup + resize +
+  D2 boot open). No new `.tf` file, no new Terraform root (extends the existing
+  `apps/web-platform/infra/` root; R2 backend already configured).
+- Providers: `hashicorp/random`, `DopplerHQ/doppler`, `hetznercloud/hcloud` — all already required
+  in `main.tf`; no new provider, no version-pin change.
+- Sensitive vars: **none new required** — the passphrase is `random_password` (Soleur-minted, in
+  tfstate, R2-encrypted backend), published to `soleur-registry/prd` as `REGISTRY_LUKS_KEY`. **No
+  operator-minted `TF_VAR_*`** (`hr-tf-variable-no-operator-mint-default`); `registry_volume_size`
+  already has a default. The isolated `soleur-registry`/`prd` Doppler config already exists.
+
+### Apply path
+- **On merge: NONE.** Registry resources are `OPERATOR_APPLIED_EXCLUSION` (never in the per-PR
+  `-target=` set); the 12h drift detector is plan-only. Merging is byte-safe.
+- **Gated operator re-encryption (OUTSIDE this PR):** scoped `terraform apply -replace` of volume +
+  attachment + host (D4). Destroy+recreate of a disposable, born-fresh raw volume ⇒ guest luksFormat
+  ⇒ re-fill from GHCR. Expected downtime: a brief cold-pull gap (web hosts re-fill on demand);
+  blast radius near-zero.
+- **Transient drift note:** between merge and the operator recut, `terraform plan` shows the
+  volume + host as pending replace. This is the accepted `OPERATOR_APPLIED_EXCLUSION` state (same as
+  the workspaces_luks additive resources before their cutover) — the drift detector files/refreshes
+  one advisory issue; it never applies.
+
+### Distinctness / drift safeguards
+- `dev != prd`: the registry is prd-only (a single `soleur-registry` host); no dev registry host.
+- `lifecycle`: `random_password.registry_luks` has no `keepers` (stable across routine applies);
+  the host's `replace_triggered_by` deliberately excludes it (passphrase rotation = recut, not a
+  bare host replace).
+- State: the passphrase lands in `terraform.tfstate` (R2-encrypted backend) and Doppler
+  `soleur-registry/prd` — the same two-plane exposure as `git_data_luks`/`workspaces_luks`.
+
+### Vendor-tier reality check
+No new vendor, no free-tier gate (Hetzner volumes + Doppler secrets are already in use). N/A.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: zot answers on its private IP (existing SOLEUR liveness heartbeat) — gated on a successful
+        LUKS mount of /var/lib/zot; a failed luksOpen/mount => zot never starts => heartbeat stops.
+  cadence: existing zot-liveness-heartbeat cron cadence (betteruptime_heartbeat.registry_prd)
+  alert_target: Better Stack absence alert (betteruptime_heartbeat.registry_prd)
+  configured_in: apps/web-platform/infra/zot-registry.tf (betteruptime_heartbeat.registry_prd) + cloud-init-registry.yml
+error_reporting:
+  destination: cloud-init fail-loud FATAL (stderr -> journald) + Better Stack liveness-absence; the
+               boot guard EXITS non-zero on empty key or an ext4/other-TYPE device (never mounts plaintext)
+  fail_loud: true  # refuses to bring zot up rather than serving from an unencrypted/wrong device
+failure_modes:
+  - mode: empty/unreadable REGISTRY_LUKS_KEY at boot
+    detection: cloud-init FATAL exit; zot never starts; liveness heartbeat absence
+    alert_route: Better Stack (registry_prd heartbeat)
+  - mode: device is populated plaintext ext4 (accidental host-replace before recut)
+    detection: blkid TYPE=ext4 -> FATAL refuse (D1/B); in-surface stderr marker "refusing non-LUKS registry device"
+    alert_route: Better Stack liveness absence (zot does not start)
+  - mode: mapper closed after reboot (no crypttab)
+    detection: D2 boot-open reopens it; if absent, mount -a fails -> liveness absence
+    alert_route: Better Stack (registry_prd heartbeat)
+logs:
+  where: journald on the registry host (cloud-init + zot); disk self-report -> Better Stack Logs (SOLEUR_ZOT_DISK)
+  retention: existing registry-host journald + Better Stack Logs retention (unchanged)
+discoverability_test:
+  command: python3 scripts/lint-encryption-posture.py --repo-sweep
+  expected_output: exit 0 — hcloud_volume.registry row resolves as mechanism=luks via the real cryptsetup+fstab chain
+```
+**Blind-surface note (Phase 2.9.2):** the cloud-init cryptsetup block is a blind execution surface.
+Its in-surface probe is the **fail-loud boot guard** (a FATAL that discriminates empty-key vs
+wrong-TYPE-device vs closed-mapper in one stderr marker) surfaced off-box via the liveness-absence
+heartbeat — no SSH needed. Layer B live-reconcile (ADR-141, deferred) is the eventual per-volume
+posture probe (`live_verification` stays `unavailable:...#6895` until then).
+
+## Architecture Decision (ADR/C4)
+
+This applies the **already-accepted** design-time default (ADR-140: encryption posture is a
+resolvable-evidence ledger; ADR-119: guest-side LUKS is the Hetzner-volume mechanism) to one more
+volume; the **ledger row flip IS the recorded decision**. No new cross-cutting invariant, substrate,
+or trust boundary is introduced.
+
+### ADR
+- **No new ADR.** Recommend a lean **amendment to ADR-096** (the zot-registry ADR) recording: the
+  registry store volume flips plaintext->guest-side-LUKS; the recut (D4) is the sanctioned
+  re-encryption vehicle; escrow is intentionally omitted (disposable). deepen-plan/CTO to confirm
+  whether the amendment is warranted or the ledger row + this plan suffice.
+
+### C4 views
+- **Reviewer MUST read all three model files** (`knowledge-base/engineering/architecture/diagrams/{model.c4,views.c4,spec.c4}`)
+  before concluding — a keyword grep is not sufficient (per the C4-completeness mandate).
+- **Enumeration checked:** external human actors — none new (no user interacts with the registry
+  volume). External systems — GHCR (already modeled as the upstream mirror source; unchanged);
+  Doppler/Hetzner (already modeled). Container/data store — `hcloud_volume.registry` / the zot
+  store (already modeled as the registry host's storage; encryption is an at-rest *property*, not a
+  C4 element). Access relationship — unchanged (web hosts + CI pull over the private net; the
+  passphrase is a boot-time host-scoped read, no new edge). **Expected conclusion: no C4 impact**
+  (at-rest LUKS is a mechanism the C4 model does not render) — but the reviewer records this only
+  after reading the three files and citing this enumeration; an unsupported "None" is a reject.
+
+### Sequencing
+The ledger row's `mechanism: luks` describes the **target** state; it becomes *live* only after the
+operator recut. Because Layer A resolves the row against the **apparatus code** (not live state),
+the row PASSES the sweep the moment the apparatus lands — no `status: adopting` sequencing gap for
+the ledger. Live truth is Layer B's job (deferred, ADR-141).
+
+## Encryption Posture
+
+```yaml
+at_rest:
+  store: hcloud_volume.registry
+  mechanism: luks   # was plaintext-exception
+  evidence: apps/web-platform/infra/cloud-init-registry.yml (cryptsetup luksFormat/luksOpen registry) + zot-registry.tf (random_password.registry_luks + doppler_secret.registry_luks_key) + fstab /dev/mapper/registry
+  defends_against: a seized/RMA'd/snapshot-imaged Hetzner block volume — OCI blobs + cosign signatures unreadable without the Doppler-held LUKS passphrase
+  does_not_defend: a leaked credential, an app-layer read on the unlocked live host, or exfiltration via a compromised zot process
+  disclosed_as: not-publicly-claimed
+  live_verification: unavailable:no zot-host at-rest posture probe yet; tracked #6895
+in_transit:
+  # unchanged by this PR — registry pull transport is private-net only (deny-all public firewall);
+  # docker->zot is TLS on the private net (proxy-tls.tf / registry endpoint). Not re-declared here.
+exception: none   # removed — mechanism is now luks, not plaintext-exception
+```
+
+## Domain Review
+
+**Domains relevant:** engineering (infrastructure/security).
+
+### Engineering / Infra (CTO)
+**Status:** deferred to plan-review/deepen-plan (headless one-shot). **Assessment:** the load-bearing
+CTO calls are D1 (raw+refuse vs ext4+isLuks — the ADR-119-fact-2 safety choice), D2 (reboot
+survivability), and D4 (recut vehicle / whether to add a gated dispatch). These are surfaced as
+explicit decisions above and routed to the plan-review CTO lens + deepen-plan precedent-diff
+(§4.4). No live-infra mutation, no new vendor, no user-data surface.
+
+### Product/UX Gate
+**Tier:** none. No `## Files to Create`/`Files to Edit` path matches a UI surface (all changes are
+`.tf` / `cloud-init*.yml` / `.json` ledger / `.test.sh`). Skipped.
+
+**Skipped specialists:** none. **Pencil available:** N/A (no UI surface).
+
+## Files to Edit
+- `apps/web-platform/infra/zot-registry.tf` — add `random_password.registry_luks` + `doppler_secret.registry_luks_key`; remove `format` from `hcloud_volume.registry`; extend `hcloud_server.registry.depends_on`.
+- `apps/web-platform/infra/cloud-init-registry.yml` — add `cryptsetup` package; replace plaintext mount with LUKS format/open/mount; fix resize + raw-device invariant; add D2 boot-open.
+- `scripts/encryption-posture-ledger.json` — flip the `hcloud_volume.registry` row to `mechanism: luks` (remove exception; retarget mapper; update evidence/verification fields).
+- (possibly) `knowledge-base/engineering/architecture/decisions/ADR-096-migrate-container-registry-ghcr-to-self-hosted-zot.md` — lean amendment (D-decision; confirm at deepen-plan).
+- (possibly, if any existing registry test hard-codes the plaintext mount) `apps/web-platform/infra/registry-boot-guard.test.sh` / `registry-insecure-config.test.sh` / `zot-liveness-heartbeat.test.sh` — update in-scope only if the LUKS change falsifies an existing assertion (verify via grep in Phase 5).
+
+## Files to Create
+- `apps/web-platform/infra/registry-luks.test.sh` — mutation-tested guard suite (mirrors `git-data-luks.test.sh`).
+
+## Open Code-Review Overlap
+None. (`gh issue list --label code-review --state open` bodies grepped for `zot-registry.tf`,
+`cloud-init-registry.yml`, `registry-luks`, `encryption-posture-ledger`, `hcloud_volume.registry`
+— zero matches.)
+
+## Test Scenarios
+- **T1** fresh raw volume → cloud-init `luksFormat`+`luksOpen registry`+`mkfs.ext4 mapper`+`mount /var/lib/zot`; asserted by `registry-luks.test.sh` (mutation-tested).
+- **T2** populated plaintext ext4 device → `blkid TYPE=ext4` → FATAL refuse (never wipes); mutation flips the else-arm.
+- **T3** already-LUKS device → `crypto_LUKS` → skip format, luksOpen no-op, mount; idempotent.
+- **T4** empty `REGISTRY_LUKS_KEY` → fail-loud FATAL, non-zero exit, no mount.
+- **T5** `lint-encryption-posture.py --repo-sweep` resolves the device-binding chain (volume+attachment real, secret pair co-located, mapper `registry` → cryptsetup + fstab) → PASS.
+- **T6** (D2) reboot with closed mapper → boot-open reopens → `mount -a`/self-heal remounts.
+- **T7** ledger: no `exception` key on the registry row; `live_coverage_floor: 1` still satisfied by `hcloud_volume.workspaces_luks`.
+
+## Risks & Sharp Edges
+- **A plan whose `## User-Brand Impact` section is empty or placeholder fails `deepen-plan` Phase 4.6.** Filled above (threshold: none + reason).
+- **SE1 — passphrase rotation is a recut, not a host replace.** `registry_luks` is deliberately
+  absent from `replace_triggered_by`; rotating `random_password.registry_luks` then only replacing
+  the host would luksOpen the OLD-key volume with the NEW key and FATAL. Rotation ⇒ `-replace` the
+  passphrase + the volume (fresh) + host. Mirror the git-data rotation note.
+- **SE2 — the linter requires the `random_password`+`doppler_secret` pair in the attachment's file.**
+  Keep them in `zot-registry.tf`; a `registry-luks.tf` split would orphan the attachment and FAIL
+  `file_has_secret_pair` — unless the attachment moves too (more churn; not recommended).
+- **SE3 — do NOT let the ledger flip land without the apparatus.** Layer A resolves the mapper
+  through the real cryptsetup site + fstab; flipping the row before the cloud-init/tf edits ⇒ sweep
+  FAILs on the unresolved mapper. Land both in one commit.
+- **SE4 — after this merges, an accidental `registry-host-replace` (which PRESERVES the volume) runs
+  cloud-init against the still-plaintext ext4 volume.** With D1/B it fails loud (refuse) — safe but
+  darks the registry. The ONLY sanctioned first apply is the recut (fresh volume). Document in the
+  PR body + the ADR-096 amendment.
+- **SE5 — resize + raw-device invariant.** The existing `resize2fs $DEV` and `lsblk TYPE ... part`
+  logic assumes ext4-on-raw; both must move to the mapper (`cryptsetup resize` + `resize2fs
+  /dev/mapper/registry`), or the disk-full resize apparatus (#6240/#6247) silently no-ops on LUKS.
+- **SE6 — verify real line numbers in the ledger `evidence` string post-edit** (cryptsetup +
+  fstab lines shift as cloud-init changes); a stale `file:line` still resolves via device_binding
+  but the human-facing evidence should be accurate.
+- **SE7 — do not reference #6893/#6588 with `Closes`.** They stay open; use `Ref`.
+
+## Rollout
+Code-only PR → review → merge (zero apply). The gated operator recut (D4) is a separate,
+maintenance-window step outside this PR. If D2/D4/the ADR-096 amendment are descoped, file
+tracking issues with re-evaluation criteria + the Phase-4 milestone before marking ready
+(`wg-when-deferring-a-capability-create-a`).

--- a/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
+++ b/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
@@ -349,21 +349,21 @@ Verify `python3 scripts/lint-encryption-posture.py --repo-sweep` resolves the ch
 ## Acceptance Criteria
 
 ### Pre-merge (this PR)
-- [ ] `hcloud_volume.registry` in `zot-registry.tf` has **no** `format` attribute (D1/B); `grep -c 'format' <the-registry-volume-block>` = 0.
-- [ ] `zot-registry.tf` declares `random_password.registry_luks` (length 40, special=false) and `doppler_secret.registry_luks_key` (`project = "soleur-registry"`, `name = "REGISTRY_LUKS_KEY"`), co-located with `hcloud_volume_attachment.registry`.
-- [ ] `hcloud_server.registry.depends_on` includes `doppler_secret.registry_luks_key`; `registry_luks` is **absent** from `lifecycle.replace_triggered_by`.
-- [ ] `cloud-init-registry.yml` `packages:` includes `cryptsetup`; the mount runcmd does `cryptsetup luksFormat --type luks2 --key-file -` + `luksOpen --key-file - "$DEV" registry` + `mount /dev/mapper/registry /var/lib/zot`; the key is piped from `printf '%s' "$REGISTRY_LUKS_KEY"` (stdin) and never appears as a bare argv token; fail-loud empty-key guard present; else-TYPE→FATAL refuse arm present.
-- [ ] fstab line `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` present; the **stale by-id fstab line** for `/var/lib/zot` is **removed** (P1); resize path targets `/dev/mapper/registry`.
-- [ ] **(D2, REQUIRED)** an idempotent boot-time luksOpen is ordered after `network-online` and before the reboot self-heal (host self-`reboot`s via NIC guard `cloud-init-registry.yml:610`).
-- [ ] **(P1-A)** the boot isolation self-check (`cloud-init-registry.yml:741-746`) admits `REGISTRY_LUKS_KEY` and its cardinality is `4` (was `3`); the "THREE admitted" comments are updated. Mutation: count left at `3` ⇒ RED.
-- [ ] **(P1-B)** the Doppler CLI install + `/etc/default/registry-doppler` write precede the LUKS mount block in `cloud-init-registry.yml`.
-- [ ] **(architecture Q5)** the `OPERATOR_APPLIED_EXCLUSION` parity test (if resource-enumerated) registers `random_password.registry_luks` + `doppler_secret.registry_luks_key`; the parity/exclusion suites are green.
-- [ ] `registry-luks.test.sh` passes, meets its mutation-cardinality floor, and every assertion has a paired mutation proven to flip it RED.
-- [ ] Ledger row `hcloud_volume.registry`: `at_rest.mechanism == "luks"`, **no `exception` key**, `device_binding.mapper == "registry"`, `does_not_defend` non-empty (≥8 chars), `live_verification` matches `^(available|unavailable:.+)$`.
-- [ ] `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (device-binding chain resolves to real code; positive-work floor + `live_coverage_floor: 1` still satisfied).
-- [ ] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` is unaffected (no TS touched) — sanity only; the TS gate is not the target here.
-- [ ] No `terraform apply` was run; `git status` shows only the intended files changed; #6893 and #6588 remain OPEN (do not reference them with `Closes`).
-- [ ] PR body uses `Closes #6895` (title uses no `#`); references #6893/#6588 as `Ref` only.
+- [x] `hcloud_volume.registry` in `zot-registry.tf` has **no** `format` attribute (D1/B); `grep -c 'format' <the-registry-volume-block>` = 0.
+- [x] `zot-registry.tf` declares `random_password.registry_luks` (length 40, special=false) and `doppler_secret.registry_luks_key` (`project = "soleur-registry"`, `name = "REGISTRY_LUKS_KEY"`), co-located with `hcloud_volume_attachment.registry`.
+- [x] `hcloud_server.registry.depends_on` includes `doppler_secret.registry_luks_key`; `registry_luks` is **absent** from `lifecycle.replace_triggered_by`.
+- [x] `cloud-init-registry.yml` `packages:` includes `cryptsetup`; the mount runcmd does `cryptsetup luksFormat --type luks2 --key-file -` + `luksOpen --key-file - "$DEV" registry` + `mount /dev/mapper/registry /var/lib/zot`; the key is piped from `printf '%s' "$REGISTRY_LUKS_KEY"` (stdin) and never appears as a bare argv token; fail-loud empty-key guard present; else-TYPE→FATAL refuse arm present.
+- [x] fstab line `/dev/mapper/registry /var/lib/zot ext4 defaults,nofail 0 2` present; the **stale by-id fstab line** for `/var/lib/zot` is **removed** (P1); resize path targets `/dev/mapper/registry`.
+- [x] **(D2, REQUIRED)** an idempotent boot-time luksOpen is ordered after `network-online` and before the reboot self-heal (host self-`reboot`s via NIC guard `cloud-init-registry.yml:610`).
+- [x] **(P1-A)** the boot isolation self-check (`cloud-init-registry.yml:741-746`) admits `REGISTRY_LUKS_KEY` and its cardinality is `4` (was `3`); the "THREE admitted" comments are updated. Mutation: count left at `3` ⇒ RED.
+- [x] **(P1-B)** the Doppler CLI install + `/etc/default/registry-doppler` write precede the LUKS mount block in `cloud-init-registry.yml`.
+- [x] **(architecture Q5)** the `OPERATOR_APPLIED_EXCLUSION` parity test (if resource-enumerated) registers `random_password.registry_luks` + `doppler_secret.registry_luks_key`; the parity/exclusion suites are green.
+- [x] `registry-luks.test.sh` passes, meets its mutation-cardinality floor, and every assertion has a paired mutation proven to flip it RED.
+- [x] Ledger row `hcloud_volume.registry`: `at_rest.mechanism == "luks"`, **no `exception` key**, `device_binding.mapper == "registry"`, `does_not_defend` non-empty (≥8 chars), `live_verification` matches `^(available|unavailable:.+)$`.
+- [x] `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (device-binding chain resolves to real code; positive-work floor + `live_coverage_floor: 1` still satisfied).
+- [x] `cd apps/web-platform && ./node_modules/.bin/tsc --noEmit` is unaffected (no TS touched) — sanity only; the TS gate is not the target here.
+- [x] No `terraform apply` was run; `git status` shows only the intended files changed; #6893 and #6588 remain OPEN (do not reference them with `Closes`).
+- [x] PR body uses `Closes #6895` (title uses no `#`); references #6893/#6588 as `Ref` only.
 
 ### Post-merge (operator, OUTSIDE this PR — the gated re-encryption)
 - [ ] `Automation: sanctioned OPERATOR_APPLIED_EXCLUSION apply path` (per `zot-registry.tf:15` CTO ruling). The gated apply is a scoped `terraform apply -replace='hcloud_volume.registry' -replace='hcloud_volume_attachment.registry' -replace='hcloud_server.registry'` (fresh raw volume ⇒ cloud-init luksFormats ⇒ zot re-fills from GHCR) — **all three `-replace` together** — preferably via the recommended guarded `registry-luks-recut` dispatch (D4(ii)). Not `Closes`-linked. Blast radius near-zero (disposable mirror; brief cold-pull gap).

--- a/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
+++ b/knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
@@ -63,9 +63,13 @@ row from `mechanism: plaintext-exception` → `mechanism: luks`.
 
 **Deliverable = a reviewed, mergeable PR containing ONLY:** the LUKS apparatus (Terraform in
 `zot-registry.tf`, guest cryptsetup in `cloud-init-registry.yml`, a mutation-tested guard suite)
-plus the one-row ledger flip. **No `terraform apply` runs in this PR.** The destroy+recreate that
+plus the one-row ledger flip. **No `terraform apply` runs in this PR.**
+<!-- lint-infra-ignore start -->
+The destroy+recreate that
 actually re-encrypts the live registry volume is a **separate, deliberately gated operator step
-OUTSIDE this PR** (see §Infrastructure → Apply path). **Zero live-infra mutation on merge** — the
+OUTSIDE this PR** (see §Infrastructure → Apply path).
+<!-- lint-infra-ignore end -->
+**Zero live-infra mutation on merge** — the
 registry resources are `OPERATOR_APPLIED_EXCLUSION` (never in the per-PR `-target=` list;
 `zot-registry.tf:15`), and the 12h drift detector is **plan-only** (`terraform plan
 -detailed-exitcode`, files an issue, never applies — `scheduled-terraform-drift.yml:100`).
@@ -395,10 +399,12 @@ manual provisioning step. It is deliberately outside this PR per the task's gati
 ### Apply path
 - **On merge: NONE.** Registry resources are `OPERATOR_APPLIED_EXCLUSION` (never in the per-PR
   `-target=` set); the 12h drift detector is plan-only. Merging is byte-safe.
+<!-- lint-infra-ignore start -->
 - **Gated operator re-encryption (OUTSIDE this PR):** scoped `terraform apply -replace` of volume +
   attachment + host (D4). Destroy+recreate of a disposable, born-fresh raw volume ⇒ guest luksFormat
   ⇒ re-fill from GHCR. Expected downtime: a brief cold-pull gap (web hosts re-fill on demand);
   blast radius near-zero.
+<!-- lint-infra-ignore end -->
 - **Transient drift note:** between merge and the operator recut, `terraform plan` shows the
   volume + host as pending replace. This is the accepted `OPERATOR_APPLIED_EXCLUSION` state (same as
   the workspaces_luks additive resources before their cutover) — the drift detector files/refreshes
@@ -522,8 +528,10 @@ resources are `OPERATOR_APPLIED_EXCLUSION`, never applied on merge; drift is pla
   `registry-region-migrate` dispatch already relies on), single-operator maintenance window, and no
   user-data path. Per-stage verification: the D1/B fail-loud boot guard + zot liveness heartbeat
   (green ⇒ mount + re-fill succeeded); rollback = the mirror is recreatable from GHCR at any time.
+<!-- lint-infra-ignore start -->
 - **Operator sign-off:** the recut is an explicit gated dispatch/`-replace` (D4) run in a
   maintenance window — not an unattended apply.
+<!-- lint-infra-ignore end -->
 
 This is consistent with #5887's zero-downtime-first discipline: the zero-downtime path was
 *evaluated and consciously declined* for a disposable store where it buys nothing, not skipped by

--- a/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/decision-challenges.md
+++ b/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/decision-challenges.md
@@ -1,0 +1,36 @@
+---
+title: "Decision challenges — feat(#6895) registry volume guest-side LUKS"
+issue: 6895
+---
+
+# Decision challenges — feat(#6895)
+
+## D4 guarded `registry-luks-recut` dispatch deferred to follow-up
+
+**Operator's stated direction.** Scope this PR to **cloud-init + Terraform + ledger flip only**
+(the guest-side LUKS apparatus for `hcloud_volume.registry` + the ledger row flip
+`plaintext-exception → luks`). The guarded `registry-luks-recut` `workflow_dispatch` (plan D4(ii))
+is explicitly OUT of scope for this PR.
+
+<!-- lint-infra-ignore start -->
+<!-- Deferred-orchestrator prose: the paragraphs below describe the SANCTIONED gated operator recut
+     (an OPERATOR_APPLIED_EXCLUSION `-replace` / the deferred guarded dispatch #6929) that runs
+     OUTSIDE any per-PR apply — not a human-run step this PR executes. -->
+**Architecture reviewer's counter-argument.** The guarded three-`-replace` dispatch removes a
+load-bearing operator **footgun**: without it, the only recut path is a bare, error-prone
+`terraform apply -replace` of volume + attachment + host *together*, and the operator can easily
+reach instead for the existing `registry-host-replace` dispatch — which **preserves** the plaintext
+volume and boots it straight into the D1/B `blkid TYPE` else→FATAL refuse arm, darking the registry.
+Adding the guarded dispatch is code-only (unfired ⇒ zero live mutation), so the footgun-removal
+argues for including it in this PR.
+
+**Resolution — DEFERRED.** The dispatch is deferred to a follow-up tracking issue (the operator
+scoped this PR to cloud-init + Terraform + ledger). The floor holds regardless:
+- The **D4(ii) tracking issue** is filed with re-evaluation criteria + the "Phase 4: Validate + Scale"
+  milestone (`Tracks #6929`).
+- The **"wrong-dispatch (`registry-host-replace`) = FATAL" footgun** is flagged prominently in **both**
+  the PR body **and** the ADR-096 amendment (this PR), so the hazard is recorded even though the
+  guarded vehicle that would eliminate it lands later.
+- The sanctioned `OPERATOR_APPLIED_EXCLUSION` three-`-replace` apply remains the interim recut vehicle
+  until the guarded dispatch ships.
+<!-- lint-infra-ignore end -->

--- a/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/tasks.md
@@ -1,0 +1,53 @@
+---
+title: "Tasks — feat(#6895): registry volume guest-side LUKS + ledger flip"
+plan: knowledge-base/project/plans/2026-07-24-feat-6895-registry-volume-luks-plan.md
+issue: 6895
+lane: cross-domain
+---
+
+# Tasks — feat(#6895) registry LUKS at-rest
+
+Derived from the plan. Template = `git_data_luks`. Deliverable = code-only PR (Terraform +
+cloud-init + ledger flip + guard suite); **no `terraform apply`**; #6893 / #6588 stay OPEN.
+
+## Phase 0 — Preconditions (no writes)
+- [ ] 0.1 Confirm branch `feat-one-shot-6895-registry-volume-luks`; #6895/#6893/#6588 all OPEN (`gh issue view`).
+- [ ] 0.2 Re-read against HEAD: `zot-registry.tf` (vol 407 / attach 418 / host 290-401 / secret blocks), `cloud-init-registry.yml` (packages ~21 / mount 656-687 / self-heal 484-506 / resize 642-682), `git-data-luks.tf` + `cloud-init-git-data.yml` LUKS block, `lint-encryption-posture.py::check_luks_row`, `git-data-luks.test.sh`.
+- [ ] 0.3 `grep -rn 'mapper/registry\|"registry-plain"' apps/web-platform/infra/` — confirm mapper name `registry` is free.
+- [ ] 0.4 Resolve D1 (recommend raw+refuse), D2 (recommend boot-open), D4 (operator recut vehicle) — carry plan-review/deepen-plan/CTO ruling.
+
+## Phase 1 — Terraform (in `zot-registry.tf`)
+- [ ] 1.1 Add `resource "random_password" "registry_luks"` (length 40, special=false, no keepers/ignore_changes; comment cross-refs `git_data_luks`).
+- [ ] 1.2 Add `resource "doppler_secret" "registry_luks_key"` (`project="soleur-registry"`, `config="prd"`, `name="REGISTRY_LUKS_KEY"`, `value=random_password.registry_luks.result`, `visibility="masked"`). Reuse existing `doppler_service_token.registry` — no new token.
+- [ ] 1.3 Remove `format = "ext4"` from `hcloud_volume.registry` (D1/B); add SHARP-EDGE comment (raw device + guest luksFormat; no hcloud `encrypted` attr, ADR-140).
+- [ ] 1.4 Extend `hcloud_server.registry.depends_on` with `doppler_secret.registry_luks_key`; add `REGISTRY_LUKS_KEY` to the boot secret set. Do **NOT** add `registry_luks` to `lifecycle.replace_triggered_by`.
+- [ ] 1.5 Leave `hcloud_volume_attachment.registry` unchanged (already binds `hcloud_volume.registry.id`).
+
+## Phase 2 — Guest cryptsetup (`cloud-init-registry.yml`)
+- [ ] 2.1 `packages:` add `cryptsetup`.
+- [ ] 2.2 Read `REGISTRY_LUKS_KEY` via the existing scoped doppler path (`--project soleur-registry --config prd`); never argv, never baked into user_data.
+- [ ] 2.3 Replace plaintext mount (656-687): fail-loud empty-key guard → `blkid` TYPE discriminator (`""`→luksFormat luks2 `--key-file -`; `crypto_LUKS`→skip; else→FATAL refuse) → `luksOpen --key-file - "$DEV" registry` → `mkfs.ext4` mapper if unformatted → `mount /dev/mapper/registry /var/lib/zot` → fstab `/dev/mapper/registry ... nofail`.
+- [ ] 2.4 Rework resize (642-682) to `cryptsetup resize registry` + `resize2fs /dev/mapper/registry`; update `.resize-result`.
+- [ ] 2.5 Rework the raw-device invariant (664) for `crypto_LUKS`/mapper (not ext4-on-raw).
+- [ ] 2.6 (D2) Add idempotent boot-time luksOpen ordered before the self-heal (484-506) so `mount -a` remounts on reboot.
+
+## Phase 3 — Guard suite (`registry-luks.test.sh`, mirrors `git-data-luks.test.sh`)
+- [ ] 3.1 Author mutation-tested assertions: discriminator (incl. crypto_LUKS/else-FATAL arms), `--key-file -` + no key in argv, printf-stdin delivery, `mount /dev/mapper/registry /var/lib/zot`, fstab evidence, fail-loud guard, scoped doppler read, TF (`random_password.registry_luks` + `REGISTRY_LUKS_KEY` present; no `format="ext4"`; attachment binds volume), resize-targets-mapper, (D2) boot-open present.
+- [ ] 3.2 Enforce a minimum-assertion floor; each assertion paired with a mutation proven to flip RED.
+
+## Phase 4 — Ledger flip (`scripts/encryption-posture-ledger.json`, `hcloud_volume.registry` row only)
+- [ ] 4.1 `at_rest.mechanism` → `"luks"`; **delete the `exception` block**; `device_binding.mapper` → `"registry"`.
+- [ ] 4.2 Rewrite `evidence` (real cloud-init luksFormat/luksOpen + fstab line numbers + tf secret pair), `defends_against`, `does_not_defend` (≥8 chars, non-empty), `disclosed_as: not-publicly-claimed`, `live_verification: "unavailable:no zot-host at-rest posture probe yet; tracked #6895"`.
+- [ ] 4.3 Do NOT touch `hcloud_volume.workspaces_luks` (keep the ≥1 `available` row for `live_coverage_floor: 1`).
+
+## Phase 5 — Verify (no apply)
+- [ ] 5.1 `registry-luks.test.sh` green (+ mutation floor).
+- [ ] 5.2 `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (chain resolves).
+- [ ] 5.3 `terraform -chdir=apps/web-platform/infra validate`/`fmt -check` (validate/plan only, NEVER apply).
+- [ ] 5.4 Re-run existing registry suites (`registry-boot-guard`, `registry-insecure-config`, `zot-liveness-heartbeat`, `web-zot-consumer-probe`, `cloud-init-ghcr-seed-login`); grep for hard-coded plaintext-mount assumptions; fix in-scope only if falsified.
+- [ ] 5.5 `git grep -n 'format *= *"ext4"' apps/web-platform/infra/zot-registry.tf` → no hit.
+- [ ] 5.6 `git status` shows only intended files; no apply ran; #6893/#6588 still OPEN.
+
+## Phase 6 — Deferrals / follow-ups (if any decision descoped)
+- [ ] 6.1 If D2 (boot-open), D4(ii) (`registry-luks-recut` dispatch), or the ADR-096 amendment are descoped, file tracking issues (re-eval criteria + Phase-4 milestone) — `wg-when-deferring-a-capability-create-a`.
+- [ ] 6.2 PR body: `Closes #6895`; `Ref #6893`, `Ref #6588` (never `Closes` on those).

--- a/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/tasks.md
@@ -11,46 +11,46 @@ Derived from the plan. Template = `git_data_luks`. Deliverable = code-only PR (T
 cloud-init + ledger flip + guard suite); **no `terraform apply`**; #6893 / #6588 stay OPEN.
 
 ## Phase 0 — Preconditions (no writes)
-- [ ] 0.1 Confirm branch `feat-one-shot-6895-registry-volume-luks`; #6895/#6893/#6588 all OPEN (`gh issue view`).
-- [ ] 0.2 Re-read against HEAD: `zot-registry.tf` (vol 407 / attach 418 / host 290-401 / secret blocks), `cloud-init-registry.yml` (packages ~21 / mount 656-687 / self-heal 484-506 / resize 642-682), `git-data-luks.tf` + `cloud-init-git-data.yml` LUKS block, `lint-encryption-posture.py::check_luks_row`, `git-data-luks.test.sh`.
-- [ ] 0.3 `grep -rn 'mapper/registry\|"registry-plain"' apps/web-platform/infra/` — confirm mapper name `registry` is free.
-- [ ] 0.4 Carry decisions: D1 = raw+refuse (Option B, recommended; A is valid); D2 = boot-open **REQUIRED** (host self-reboots :610); D4 = guarded `registry-luks-recut` dispatch recommended (in-PR vs follow-up = plan-review/CTO). P1-A/P1-B are required correctness fixes.
+- [x] 0.1 Confirm branch `feat-one-shot-6895-registry-volume-luks`; #6895/#6893/#6588 all OPEN (`gh issue view`).
+- [x] 0.2 Re-read against HEAD: `zot-registry.tf` (vol 407 / attach 418 / host 290-401 / secret blocks), `cloud-init-registry.yml` (packages ~21 / mount 656-687 / self-heal 484-506 / resize 642-682), `git-data-luks.tf` + `cloud-init-git-data.yml` LUKS block, `lint-encryption-posture.py::check_luks_row`, `git-data-luks.test.sh`.
+- [x] 0.3 `grep -rn 'mapper/registry\|"registry-plain"' apps/web-platform/infra/` — confirm mapper name `registry` is free.
+- [x] 0.4 Carry decisions: D1 = raw+refuse (Option B, recommended; A is valid); D2 = boot-open **REQUIRED** (host self-reboots :610); D4 = guarded `registry-luks-recut` dispatch recommended (in-PR vs follow-up = plan-review/CTO). P1-A/P1-B are required correctness fixes.
 
 ## Phase 1 — Terraform (in `zot-registry.tf`)
-- [ ] 1.1 Add `resource "random_password" "registry_luks"` (length 40, special=false, no keepers/ignore_changes; comment cross-refs `git_data_luks`).
-- [ ] 1.2 Add `resource "doppler_secret" "registry_luks_key"` (`project="soleur-registry"`, `config="prd"`, `name="REGISTRY_LUKS_KEY"`, `value=random_password.registry_luks.result`, `visibility="masked"`). Reuse existing `doppler_service_token.registry` — no new token.
-- [ ] 1.3 Remove `format = "ext4"` from `hcloud_volume.registry` (D1/B); add SHARP-EDGE comment (raw device + guest luksFormat; no hcloud `encrypted` attr, ADR-140).
-- [ ] 1.4 Extend `hcloud_server.registry.depends_on` with `doppler_secret.registry_luks_key`; add `REGISTRY_LUKS_KEY` to the boot secret set. Do **NOT** add `registry_luks` to `lifecycle.replace_triggered_by`.
-- [ ] 1.5 Leave `hcloud_volume_attachment.registry` unchanged (already binds `hcloud_volume.registry.id`).
+- [x] 1.1 Add `resource "random_password" "registry_luks"` (length 40, special=false, no keepers/ignore_changes; comment cross-refs `git_data_luks`).
+- [x] 1.2 Add `resource "doppler_secret" "registry_luks_key"` (`project="soleur-registry"`, `config="prd"`, `name="REGISTRY_LUKS_KEY"`, `value=random_password.registry_luks.result`, `visibility="masked"`). Reuse existing `doppler_service_token.registry` — no new token.
+- [x] 1.3 Remove `format = "ext4"` from `hcloud_volume.registry` (D1/B); add SHARP-EDGE comment (raw device + guest luksFormat; no hcloud `encrypted` attr, ADR-140).
+- [x] 1.4 Extend `hcloud_server.registry.depends_on` with `doppler_secret.registry_luks_key`; add `REGISTRY_LUKS_KEY` to the boot secret set. Do **NOT** add `registry_luks` to `lifecycle.replace_triggered_by`.
+- [x] 1.5 Leave `hcloud_volume_attachment.registry` unchanged (already binds `hcloud_volume.registry.id`).
 
 ## Phase 2 — Guest cryptsetup (`cloud-init-registry.yml`)
-- [ ] 2.1 `packages:` add `cryptsetup`.
-- [ ] 2.2 **P1-B (REQUIRED reorder):** move the Doppler CLI install + `/etc/default/registry-doppler` write AHEAD of the mount block (currently at ~695-711, after the mount block). Then read `REGISTRY_LUKS_KEY` via the existing scoped doppler path (`--project soleur-registry --config prd`); never argv, never baked into user_data.
-- [ ] 2.3 Replace plaintext mount (656-687): fail-loud empty-key guard → `blkid` TYPE discriminator (`""`→luksFormat luks2 `--key-file -`; `crypto_LUKS`→skip; else→FATAL refuse) → `luksOpen --key-file - "$DEV" registry` → `mkfs.ext4` mapper if unformatted → `mount /dev/mapper/registry /var/lib/zot` → fstab `/dev/mapper/registry ... nofail`. **DELETE the stale by-id fstab line (:687).**
-- [ ] 2.4 Rework resize (642-682) to `cryptsetup resize registry` + `resize2fs /dev/mapper/registry`; update `.resize-result`.
-- [ ] 2.5 Rework the raw-device invariant (664) for `crypto_LUKS`/mapper (not ext4-on-raw).
-- [ ] 2.6 **D2 (REQUIRED):** add idempotent boot-time luksOpen ordered after `network-online` and before the self-heal (484-506) so `mount -a` remounts on reboot (host self-`reboot`s via NIC guard :610). No crypttab-keyfile.
-- [ ] 2.7 **P1-A (REQUIRED):** widen the isolation self-check (:741-746) cardinality `3→4`, admit `REGISTRY_LUKS_KEY` in the names regex, update the "THREE admitted" comments (:730,:740).
+- [x] 2.1 `packages:` add `cryptsetup`.
+- [x] 2.2 **P1-B (REQUIRED reorder):** move the Doppler CLI install + `/etc/default/registry-doppler` write AHEAD of the mount block (currently at ~695-711, after the mount block). Then read `REGISTRY_LUKS_KEY` via the existing scoped doppler path (`--project soleur-registry --config prd`); never argv, never baked into user_data.
+- [x] 2.3 Replace plaintext mount (656-687): fail-loud empty-key guard → `blkid` TYPE discriminator (`""`→luksFormat luks2 `--key-file -`; `crypto_LUKS`→skip; else→FATAL refuse) → `luksOpen --key-file - "$DEV" registry` → `mkfs.ext4` mapper if unformatted → `mount /dev/mapper/registry /var/lib/zot` → fstab `/dev/mapper/registry ... nofail`. **DELETE the stale by-id fstab line (:687).**
+- [x] 2.4 Rework resize (642-682) to `cryptsetup resize registry` + `resize2fs /dev/mapper/registry`; update `.resize-result`.
+- [x] 2.5 Rework the raw-device invariant (664) for `crypto_LUKS`/mapper (not ext4-on-raw).
+- [x] 2.6 **D2 (REQUIRED):** add idempotent boot-time luksOpen ordered after `network-online` and before the self-heal (484-506) so `mount -a` remounts on reboot (host self-`reboot`s via NIC guard :610). No crypttab-keyfile.
+- [x] 2.7 **P1-A (REQUIRED):** widen the isolation self-check (:741-746) cardinality `3→4`, admit `REGISTRY_LUKS_KEY` in the names regex, update the "THREE admitted" comments (:730,:740).
 
 ## Phase 3 — Guard suite (`registry-luks.test.sh`, mirrors `git-data-luks.test.sh`)
-- [ ] 3.1 Author mutation-tested assertions: discriminator (incl. crypto_LUKS/else-FATAL arms), `--key-file -` + no key in argv, printf-stdin delivery, `mount /dev/mapper/registry /var/lib/zot`, fstab evidence, fail-loud guard, scoped doppler read, TF (`random_password.registry_luks` + `REGISTRY_LUKS_KEY` present; no `format="ext4"`; attachment binds volume), resize-targets-mapper, **D2 boot-open present (unconditional)**, **P1-A isolation self-check admits REGISTRY_LUKS_KEY + cardinality 4**, **P1-B Doppler-before-LUKS ordering**, **stale by-id fstab line absent**.
-- [ ] 3.2 Enforce a minimum-assertion floor; each assertion paired with a mutation proven to flip RED (P1-A mutation: leave count at 3 ⇒ RED).
+- [x] 3.1 Author mutation-tested assertions: discriminator (incl. crypto_LUKS/else-FATAL arms), `--key-file -` + no key in argv, printf-stdin delivery, `mount /dev/mapper/registry /var/lib/zot`, fstab evidence, fail-loud guard, scoped doppler read, TF (`random_password.registry_luks` + `REGISTRY_LUKS_KEY` present; no `format="ext4"`; attachment binds volume), resize-targets-mapper, **D2 boot-open present (unconditional)**, **P1-A isolation self-check admits REGISTRY_LUKS_KEY + cardinality 4**, **P1-B Doppler-before-LUKS ordering**, **stale by-id fstab line absent**.
+- [x] 3.2 Enforce a minimum-assertion floor; each assertion paired with a mutation proven to flip RED (P1-A mutation: leave count at 3 ⇒ RED).
 
 ## Phase 4 — Ledger flip (`scripts/encryption-posture-ledger.json`, `hcloud_volume.registry` row only)
-- [ ] 4.1 `at_rest.mechanism` → `"luks"`; **delete the `exception` block**; `device_binding.mapper` → `"registry"`.
-- [ ] 4.2 Rewrite `evidence` (real cloud-init luksFormat/luksOpen + fstab line numbers + tf secret pair), `defends_against`, `does_not_defend` (≥8 chars, non-empty), `disclosed_as: not-publicly-claimed`, `live_verification: "unavailable:no zot-host at-rest posture probe yet; tracked #6895"`.
-- [ ] 4.3 Do NOT touch `hcloud_volume.workspaces_luks` (keep the ≥1 `available` row for `live_coverage_floor: 1`).
+- [x] 4.1 `at_rest.mechanism` → `"luks"`; **delete the `exception` block**; `device_binding.mapper` → `"registry"`.
+- [x] 4.2 Rewrite `evidence` (real cloud-init luksFormat/luksOpen + fstab line numbers + tf secret pair), `defends_against`, `does_not_defend` (≥8 chars, non-empty), `disclosed_as: not-publicly-claimed`, `live_verification: "unavailable:no zot-host at-rest posture probe yet; tracked #6895"`.
+- [x] 4.3 Do NOT touch `hcloud_volume.workspaces_luks` (keep the ≥1 `available` row for `live_coverage_floor: 1`).
 
 ## Phase 5 — Verify (no apply)
-- [ ] 5.1 `registry-luks.test.sh` green (+ mutation floor).
-- [ ] 5.2 `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (chain resolves).
-- [ ] 5.3 `terraform -chdir=apps/web-platform/infra validate`/`fmt -check` (validate/plan only, NEVER apply).
-- [ ] 5.4 Re-run existing registry suites (`registry-boot-guard`, `registry-insecure-config`, `zot-liveness-heartbeat`, `web-zot-consumer-probe`, `cloud-init-ghcr-seed-login`); grep for hard-coded plaintext-mount assumptions; fix in-scope only if falsified.
-- [ ] 5.5 `git grep -n 'format *= *"ext4"' apps/web-platform/infra/zot-registry.tf` → no hit.
-- [ ] 5.6 **Exclusion parity test:** if resource-enumerated, register `random_password.registry_luks` + `doppler_secret.registry_luks_key`; parity/exclusion suites green. Confirm drift-issue dedup.
-- [ ] 5.7 `git status` shows only intended files; no apply ran; #6893/#6588 still OPEN.
+- [x] 5.1 `registry-luks.test.sh` green (+ mutation floor).
+- [x] 5.2 `python3 scripts/lint-encryption-posture.py --repo-sweep` exits 0 (chain resolves).
+- [x] 5.3 `terraform -chdir=apps/web-platform/infra validate`/`fmt -check` (validate/plan only, NEVER apply).
+- [x] 5.4 Re-run existing registry suites (`registry-boot-guard`, `registry-insecure-config`, `zot-liveness-heartbeat`, `web-zot-consumer-probe`, `cloud-init-ghcr-seed-login`); grep for hard-coded plaintext-mount assumptions; fix in-scope only if falsified.
+- [x] 5.5 `git grep -n 'format *= *"ext4"' apps/web-platform/infra/zot-registry.tf` → no hit.
+- [x] 5.6 **Exclusion parity test:** if resource-enumerated, register `random_password.registry_luks` + `doppler_secret.registry_luks_key`; parity/exclusion suites green. Confirm drift-issue dedup.
+- [x] 5.7 `git status` shows only intended files; no apply ran; #6893/#6588 still OPEN.
 
 ## Phase 6 — ADR + deferrals / follow-ups
-- [ ] 6.1 Land the **required** lean ADR-096 amendment (plaintext→guest-LUKS flip, D4 recut vehicle, `registry-host-replace`=FATAL footgun, escrow omission).
-- [ ] 6.2 D4(ii): decide (plan-review/CTO) whether the guarded `registry-luks-recut` dispatch lands in this PR (unfired) or a follow-up. **Floor regardless:** file the D4(ii) tracking issue (re-eval criteria + Phase-4 milestone) + flag the wrong-dispatch=FATAL footgun in the PR body — `wg-when-deferring-a-capability-create-a`.
-- [ ] 6.3 PR body: `Closes #6895`; `Ref #6893`, `Ref #6588` (never `Closes` on those).
+- [x] 6.1 Land the **required** lean ADR-096 amendment (plaintext→guest-LUKS flip, D4 recut vehicle, `registry-host-replace`=FATAL footgun, escrow omission).
+- [x] 6.2 D4(ii): decide (plan-review/CTO) whether the guarded `registry-luks-recut` dispatch lands in this PR (unfired) or a follow-up. **Floor regardless:** file the D4(ii) tracking issue (re-eval criteria + Phase-4 milestone) + flag the wrong-dispatch=FATAL footgun in the PR body — `wg-when-deferring-a-capability-create-a`.
+- [x] 6.3 PR body: `Closes #6895`; `Ref #6893`, `Ref #6588` (never `Closes` on those).

--- a/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6895-registry-volume-luks/tasks.md
@@ -14,7 +14,7 @@ cloud-init + ledger flip + guard suite); **no `terraform apply`**; #6893 / #6588
 - [ ] 0.1 Confirm branch `feat-one-shot-6895-registry-volume-luks`; #6895/#6893/#6588 all OPEN (`gh issue view`).
 - [ ] 0.2 Re-read against HEAD: `zot-registry.tf` (vol 407 / attach 418 / host 290-401 / secret blocks), `cloud-init-registry.yml` (packages ~21 / mount 656-687 / self-heal 484-506 / resize 642-682), `git-data-luks.tf` + `cloud-init-git-data.yml` LUKS block, `lint-encryption-posture.py::check_luks_row`, `git-data-luks.test.sh`.
 - [ ] 0.3 `grep -rn 'mapper/registry\|"registry-plain"' apps/web-platform/infra/` — confirm mapper name `registry` is free.
-- [ ] 0.4 Resolve D1 (recommend raw+refuse), D2 (recommend boot-open), D4 (operator recut vehicle) — carry plan-review/deepen-plan/CTO ruling.
+- [ ] 0.4 Carry decisions: D1 = raw+refuse (Option B, recommended; A is valid); D2 = boot-open **REQUIRED** (host self-reboots :610); D4 = guarded `registry-luks-recut` dispatch recommended (in-PR vs follow-up = plan-review/CTO). P1-A/P1-B are required correctness fixes.
 
 ## Phase 1 — Terraform (in `zot-registry.tf`)
 - [ ] 1.1 Add `resource "random_password" "registry_luks"` (length 40, special=false, no keepers/ignore_changes; comment cross-refs `git_data_luks`).
@@ -25,15 +25,16 @@ cloud-init + ledger flip + guard suite); **no `terraform apply`**; #6893 / #6588
 
 ## Phase 2 — Guest cryptsetup (`cloud-init-registry.yml`)
 - [ ] 2.1 `packages:` add `cryptsetup`.
-- [ ] 2.2 Read `REGISTRY_LUKS_KEY` via the existing scoped doppler path (`--project soleur-registry --config prd`); never argv, never baked into user_data.
-- [ ] 2.3 Replace plaintext mount (656-687): fail-loud empty-key guard → `blkid` TYPE discriminator (`""`→luksFormat luks2 `--key-file -`; `crypto_LUKS`→skip; else→FATAL refuse) → `luksOpen --key-file - "$DEV" registry` → `mkfs.ext4` mapper if unformatted → `mount /dev/mapper/registry /var/lib/zot` → fstab `/dev/mapper/registry ... nofail`.
+- [ ] 2.2 **P1-B (REQUIRED reorder):** move the Doppler CLI install + `/etc/default/registry-doppler` write AHEAD of the mount block (currently at ~695-711, after the mount block). Then read `REGISTRY_LUKS_KEY` via the existing scoped doppler path (`--project soleur-registry --config prd`); never argv, never baked into user_data.
+- [ ] 2.3 Replace plaintext mount (656-687): fail-loud empty-key guard → `blkid` TYPE discriminator (`""`→luksFormat luks2 `--key-file -`; `crypto_LUKS`→skip; else→FATAL refuse) → `luksOpen --key-file - "$DEV" registry` → `mkfs.ext4` mapper if unformatted → `mount /dev/mapper/registry /var/lib/zot` → fstab `/dev/mapper/registry ... nofail`. **DELETE the stale by-id fstab line (:687).**
 - [ ] 2.4 Rework resize (642-682) to `cryptsetup resize registry` + `resize2fs /dev/mapper/registry`; update `.resize-result`.
 - [ ] 2.5 Rework the raw-device invariant (664) for `crypto_LUKS`/mapper (not ext4-on-raw).
-- [ ] 2.6 (D2) Add idempotent boot-time luksOpen ordered before the self-heal (484-506) so `mount -a` remounts on reboot.
+- [ ] 2.6 **D2 (REQUIRED):** add idempotent boot-time luksOpen ordered after `network-online` and before the self-heal (484-506) so `mount -a` remounts on reboot (host self-`reboot`s via NIC guard :610). No crypttab-keyfile.
+- [ ] 2.7 **P1-A (REQUIRED):** widen the isolation self-check (:741-746) cardinality `3→4`, admit `REGISTRY_LUKS_KEY` in the names regex, update the "THREE admitted" comments (:730,:740).
 
 ## Phase 3 — Guard suite (`registry-luks.test.sh`, mirrors `git-data-luks.test.sh`)
-- [ ] 3.1 Author mutation-tested assertions: discriminator (incl. crypto_LUKS/else-FATAL arms), `--key-file -` + no key in argv, printf-stdin delivery, `mount /dev/mapper/registry /var/lib/zot`, fstab evidence, fail-loud guard, scoped doppler read, TF (`random_password.registry_luks` + `REGISTRY_LUKS_KEY` present; no `format="ext4"`; attachment binds volume), resize-targets-mapper, (D2) boot-open present.
-- [ ] 3.2 Enforce a minimum-assertion floor; each assertion paired with a mutation proven to flip RED.
+- [ ] 3.1 Author mutation-tested assertions: discriminator (incl. crypto_LUKS/else-FATAL arms), `--key-file -` + no key in argv, printf-stdin delivery, `mount /dev/mapper/registry /var/lib/zot`, fstab evidence, fail-loud guard, scoped doppler read, TF (`random_password.registry_luks` + `REGISTRY_LUKS_KEY` present; no `format="ext4"`; attachment binds volume), resize-targets-mapper, **D2 boot-open present (unconditional)**, **P1-A isolation self-check admits REGISTRY_LUKS_KEY + cardinality 4**, **P1-B Doppler-before-LUKS ordering**, **stale by-id fstab line absent**.
+- [ ] 3.2 Enforce a minimum-assertion floor; each assertion paired with a mutation proven to flip RED (P1-A mutation: leave count at 3 ⇒ RED).
 
 ## Phase 4 — Ledger flip (`scripts/encryption-posture-ledger.json`, `hcloud_volume.registry` row only)
 - [ ] 4.1 `at_rest.mechanism` → `"luks"`; **delete the `exception` block**; `device_binding.mapper` → `"registry"`.
@@ -46,8 +47,10 @@ cloud-init + ledger flip + guard suite); **no `terraform apply`**; #6893 / #6588
 - [ ] 5.3 `terraform -chdir=apps/web-platform/infra validate`/`fmt -check` (validate/plan only, NEVER apply).
 - [ ] 5.4 Re-run existing registry suites (`registry-boot-guard`, `registry-insecure-config`, `zot-liveness-heartbeat`, `web-zot-consumer-probe`, `cloud-init-ghcr-seed-login`); grep for hard-coded plaintext-mount assumptions; fix in-scope only if falsified.
 - [ ] 5.5 `git grep -n 'format *= *"ext4"' apps/web-platform/infra/zot-registry.tf` → no hit.
-- [ ] 5.6 `git status` shows only intended files; no apply ran; #6893/#6588 still OPEN.
+- [ ] 5.6 **Exclusion parity test:** if resource-enumerated, register `random_password.registry_luks` + `doppler_secret.registry_luks_key`; parity/exclusion suites green. Confirm drift-issue dedup.
+- [ ] 5.7 `git status` shows only intended files; no apply ran; #6893/#6588 still OPEN.
 
-## Phase 6 — Deferrals / follow-ups (if any decision descoped)
-- [ ] 6.1 If D2 (boot-open), D4(ii) (`registry-luks-recut` dispatch), or the ADR-096 amendment are descoped, file tracking issues (re-eval criteria + Phase-4 milestone) — `wg-when-deferring-a-capability-create-a`.
-- [ ] 6.2 PR body: `Closes #6895`; `Ref #6893`, `Ref #6588` (never `Closes` on those).
+## Phase 6 — ADR + deferrals / follow-ups
+- [ ] 6.1 Land the **required** lean ADR-096 amendment (plaintext→guest-LUKS flip, D4 recut vehicle, `registry-host-replace`=FATAL footgun, escrow omission).
+- [ ] 6.2 D4(ii): decide (plan-review/CTO) whether the guarded `registry-luks-recut` dispatch lands in this PR (unfired) or a follow-up. **Floor regardless:** file the D4(ii) tracking issue (re-eval criteria + Phase-4 milestone) + flag the wrong-dispatch=FATAL footgun in the PR body — `wg-when-deferring-a-capability-create-a`.
+- [ ] 6.3 PR body: `Closes #6895`; `Ref #6893`, `Ref #6588` (never `Closes` on those).

--- a/plugins/soleur/test/terraform-target-parity.test.ts
+++ b/plugins/soleur/test/terraform-target-parity.test.ts
@@ -666,6 +666,15 @@ const OPERATOR_APPLIED_EXCLUSIONS = new Set<string>([
   "doppler_secret.zot_pull_token",
   "doppler_secret.zot_push_user",
   "doppler_secret.zot_push_token",
+  // #6895 (ADR-096 amendment / ADR-119 / ADR-140) — the guest-side LUKS-at-rest apparatus for the
+  // registry (zot) store volume: the at-rest passphrase (random_password) + its masked secret in the
+  // ISOLATED soleur-registry/prd project. Same class as random_password.git_data_luks +
+  // doppler_secret.git_data_luks_key above: they ride the operator's gated registry recut apply (a
+  // scoped -replace of the volume+attachment+host together), NOT the #5566 per-PR-CI class. The
+  // isolated project's existing doppler_service_token.registry (above) already reads the key at boot;
+  // no new CI-published token type this test forces.
+  "random_password.registry_luks",
+  "doppler_secret.registry_luks_key",
   "betteruptime_heartbeat.registry_prd",
   "betteruptime_heartbeat.registry_disk_prd",
   // doppler_secret.zot_heartbeat_url_prd removed (#6438 B3): it was a reserved-but-inert secret for

--- a/scripts/encryption-posture-ledger.json
+++ b/scripts/encryption-posture-ledger.json
@@ -133,21 +133,15 @@
       "device_binding": {
         "volume": "hcloud_volume.registry",
         "attachment": "hcloud_volume_attachment.registry",
-        "mapper": "registry-plain"
+        "mapper": "registry"
       },
       "at_rest": {
-        "mechanism": "plaintext-exception",
-        "evidence": "apps/web-platform/infra/zot-registry.tf:407 (format = \"ext4\", no LUKS apparatus)",
-        "defends_against": "nothing at the volume layer; integrity of the mirror comes from cosign digest-pinning, not at-rest encryption",
-        "does_not_defend": "a seized/snapshot disk exposes OCI blobs + cosign signatures (a disposable GHCR mirror; low sensitivity)",
+        "mechanism": "luks",
+        "evidence": "apps/web-platform/infra/cloud-init-registry.yml:773,778 (cryptsetup luksFormat/luksOpen registry); key: random_password.registry_luks + doppler_secret.registry_luks_key (zot-registry.tf); fstab: cloud-init-registry.yml:804",
+        "defends_against": "a seized/RMA'd or snapshot-imaged Hetzner block volume: OCI blobs + cosign signatures are unreadable without the Doppler-held LUKS passphrase",
+        "does_not_defend": "a leaked credential, an app-layer read on the unlocked live registry host, or exfiltration via a compromised zot process",
         "disclosed_as": "not-publicly-claimed",
-        "live_verification": "unavailable:no zot-host posture probe; tracked #6895",
-        "exception": {
-          "justification": "disposable GHCR mirror; low sensitivity; destroy+recreate as a LUKS volume is cheap but not urgent",
-          "tracking_issue": "#6895",
-          "reevaluate_when": "the registry volume is recreated with guest-side LUKS",
-          "expires_on": "2026-10-22"
-        }
+        "live_verification": "unavailable:no zot-host at-rest posture probe yet; tracked #6895"
       }
     },
     {


### PR DESCRIPTION
## Summary

Builds the **guest-side LUKS apparatus** for `hcloud_volume.registry` (the self-hosted zot OCI-registry store, `/var/lib/zot`) mirroring the lean `git_data_luks` template, and flips its encryption-posture ledger row `plaintext-exception → luks`. The registry volume is a disposable GHCR mirror (integrity is cosign digest-pinning; it re-fills from GHCR), so at-rest LUKS here is defense-in-depth — no user/personal/repo data is on it.

**This PR is code-only. Zero live-infra mutation on merge:** the registry resources are `OPERATOR_APPLIED_EXCLUSION` (never in the per-PR `-target=` set) and the 12h drift detector is plan-only. No `terraform apply` runs.

Closes #6895

Ref #6893 (parent claim-unlock gate — stays open)
Ref #6588 (P1 at-rest over-claim class — stays open)
Tracks #6929 (deferred: guarded `registry-luks-recut` dispatch)

## Changelog

### Web Platform (infra)
- **Terraform (`zot-registry.tf`):** add `random_password.registry_luks` (40 chars) + `doppler_secret.registry_luks_key` (`REGISTRY_LUKS_KEY` in the isolated `soleur-registry/prd` — no new service token); remove `format = "ext4"` from `hcloud_volume.registry` (raw device + guest luksFormat, Option B); extend `hcloud_server.registry.depends_on`. `registry_luks` deliberately excluded from `replace_triggered_by` (rotation is a recut, not a bare host replace).
- **cloud-init (`cloud-init-registry.yml`):** `cryptsetup` package; a fail-closed guest LUKS block (empty-key guard; `blkid TYPE` discriminator — fresh→`luksFormat luks2`, `crypto_LUKS`→reuse, **any other TYPE→FATAL refuse**, never mounts plaintext); reorder so Doppler CLI + token env-file precede the LUKS block; delete the stale by-id fstab line; resize path targets `/dev/mapper/registry`; a reboot-survivable boot-time `luksOpen` oneshot; widen the boot isolation self-check cardinality 3→4 to admit `REGISTRY_LUKS_KEY`.
- **Review hardening:** gate the zot launch on the actual mount (`findmnt … == /dev/mapper/registry` → fail loud) so a failed encryption boot genuinely stops zot and fires the liveness-absence alert (was: served an empty store behind a green heartbeat); boot-open device-wait + self-heal re-open of a closed mapper.
- **Guard suite (`registry-luks.test.sh`, new):** 34 assertions, mutation-tested (each guard proven RED under its mutation), registered in `infra-validation.yml`.
- **Ledger (`encryption-posture-ledger.json`):** registry row `mechanism: luks`, exception block removed, `mapper: registry`; `--repo-sweep` resolves the device-binding chain to real apparatus.
- **ADR-096 amendment:** records the plaintext→guest-LUKS flip, the recut vehicle, the FATAL footgun, and the deliberate escrow omission.

## ⚠️ Post-merge recut (gated, OUTSIDE this PR — Tracks #6929)

The destroy+recreate `terraform apply` that actually re-encrypts the live registry volume is a **separate, deliberately gated operator step** (near-zero blast radius: disposable mirror, brief cold-pull gap, re-fills from GHCR).

**FOOTGUN — do NOT use the existing `registry-host-replace` dispatch for the recut:** it *preserves* the still-plaintext volume, so cloud-init boots it into the Option-B `blkid TYPE` else→FATAL refuse arm and darks the registry (forgetting the `-replace` on the volume has the same effect). The only correct first apply is a scoped `terraform apply -replace` of `hcloud_volume.registry` + `hcloud_volume_attachment.registry` + `hcloud_server.registry` **together**, on a fresh raw volume. #6929 tracks encoding this as a guarded dispatch so the footgun cannot be hit.

## Test plan

- [x] `registry-luks.test.sh` — 34/34, mutation floor met (each guard's mutation proven RED)
- [x] `registry-boot-guard.test.sh` — 79/79 (updated in-scope for the LUKS change)
- [x] `python3 scripts/lint-encryption-posture.py --repo-sweep` — PASS (14 stores, 0 failing checks; `live_coverage_floor:1` held by untouched `workspaces_luks`)
- [x] `terraform -chdir=apps/web-platform/infra fmt -check` — clean; cloud-init render-validate — ok
- [x] `shellcheck` — clean (SC2016 single-quote infos are intentional literal-`$VAR` greps)
- [x] 5-agent review (security-sentinel / test-design / architecture / observability / code-quality) — all findings fixed inline, zero scope-out

The gated post-merge recut is tracked by #6929 (see the Post-merge section above); it has no user-visible effect until the operator runs it and is not a merge precondition.

Generated with [Claude Code](https://claude.com/claude-code)
