### PR TITLE
fix(inngest): channel-key parity HARD GATE in op=arm + ADR-100 §4 correction (#6178 durability)

### DIFF
--- a/.github/workflows/cutover-inngest.yml
+++ b/.github/workflows/cutover-inngest.yml
@@ -936,6 +936,41 @@ jobs:
               fi
               echo "::notice::op=arm: G3 positive prod-URI assertion passed (prod != dark, :5432 session pooler, prod project-ref present — all value-silent)"
 
+              # G3.5 — CHANNEL-KEY PARITY HARD GATE (#6178 durability). INNGEST_EVENT_KEY +
+              # INNGEST_SIGNING_KEY are a SHARED app<->host CHANNEL auth token, NOT an
+              # isolation-sensitive per-host secret (ADR-100 §4 Amendment). The app (soleur/prd)
+              # and the dedicated host (soleur-inngest/prd) MUST hold BYTE-IDENTICAL values or
+              # every app-originated inngest.send() to 10.0.1.40:8288 is rejected. The #6178
+              # cutover 502 was exactly this: the host-repoint minted FRESH host keys (Decision 4)
+              # but NEVER reconciled them into soleur/prd, so post-2.4 the app kept sending the
+              # STALE event key -> op=rearm returned HTTP 502. This gate makes the divergence a
+              # HARD PRE-FLIP failure instead of a silent post-cutover 502. The app value is read
+              # read-through from prd_terraform via the read-only DOPPLER_TOKEN (exactly as G2
+              # reads INNGEST_POSTGRES_URI); the host value via the arm token on soleur-inngest/prd.
+              # AC-NOBODY: every value is ::add-mask::'d and compared by sha256 ONLY — never echoed;
+              # only MATCH/MISMATCH per key reaches the log.
+              PARITY_FAIL=0
+              for CK in INNGEST_EVENT_KEY INNGEST_SIGNING_KEY; do
+                APP_CK=$(doppler secrets get "$CK" --plain 2>/dev/null || true)
+                printf '::add-mask::%s\n' "$APP_CK"
+                HOST_CK=$(DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get "$CK" -p soleur-inngest -c prd --plain 2>/dev/null || true)
+                printf '::add-mask::%s\n' "$HOST_CK"
+                if [[ -z "$APP_CK" || -z "$HOST_CK" ]]; then
+                  echo "::error::op=arm: G3.5 channel-key parity FAIL-CLOSED — $CK unreadable (app$([[ -n "$APP_CK" ]] && echo =set || echo =empty) host$([[ -n "$HOST_CK" ]] && echo =set || echo =empty)). Cannot prove app<->host channel parity; refusing to arm (no value echoed)."; PARITY_FAIL=1; continue
+                fi
+                APP_CK_H=$(printf '%s' "$APP_CK" | sha256sum | cut -d' ' -f1)
+                HOST_CK_H=$(printf '%s' "$HOST_CK" | sha256sum | cut -d' ' -f1)
+                if [[ "$APP_CK_H" == "$HOST_CK_H" ]]; then
+                  echo "::notice::op=arm: G3.5 channel-key parity — $CK MATCH (soleur/prd == soleur-inngest/prd, sha256-verified, value-silent)"
+                else
+                  echo "::error::op=arm: G3.5 channel-key parity — $CK MISMATCH: the app (soleur/prd) key differs from the dedicated host (soleur-inngest/prd) key. This is the #6178 cutover-502 condition — post-repoint every app inngest.send() to 10.0.1.40:8288 is rejected (op=rearm 502). RECONCILE the app to the host's SHARED channel key, then redeploy: the host key is TF-owned in soleur-inngest/prd (fresh, no ignore_changes); the app key in soleur/prd carries lifecycle ignore_changes=[value] (inngest.tf), so a naive 'terraform apply' does NOT propagate it. Copy the host value INTO soleur/prd out-of-band (supported by ignore_changes): read it (DOPPLER_TOKEN=\$DOPPLER_TOKEN_INNGEST_ARM doppler secrets get $CK -p soleur-inngest -c prd --plain) and pipe it on STDIN into 'doppler secrets set $CK -p soleur -c prd' (never argv/log), THEN REDEPLOY web-platform (ci-deploy regenerates env each deploy) so the app bakes the shared key. Re-run op=arm. See runbook §2.4 + ADR-100 §4 Amendment. Do NOT SSH the host."; PARITY_FAIL=1
+                fi
+              done
+              if [[ "$PARITY_FAIL" -ne 0 ]]; then
+                echo "::error::op=arm: G3.5 CHANNEL-KEY PARITY GATE FAILED — refusing to arm the flip while the app<->host channel keys diverge (the #6178 durability gate). Reconcile + redeploy per the per-key remediation above, then re-run op=arm. Do NOT SSH the host."; exit 1
+              fi
+              echo "::notice::op=arm: G3.5 channel-key parity gate PASSED — app (soleur/prd) and host (soleur-inngest/prd) share both channel keys (sha256-verified). The post-2.4 app->host channel will authenticate."
+
               # G4 — write the two DATA secrets FIRST, each via stdin (never argv), each exit-gated
               # before the next. Order is a correctness invariant: the URIs must land before `armed`.
               printf '%s' "$PG" | DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets set INNGEST_POSTGRES_URI -p soleur-inngest -c prd --no-interactive >/dev/null || { echo "::error::op=arm: G4 — writing INNGEST_POSTGRES_URI to soleur-inngest/prd FAILED. armed NOT written. Job aborts (no value echoed)."; exit 1; }

--- a/apps/web-platform/infra/cutover-inngest-workflow.test.sh
+++ b/apps/web-platform/infra/cutover-inngest-workflow.test.sh
@@ -418,6 +418,32 @@ assert "arm) adds NO deploy-status poll (Better Stack read only — QMAX/RMAX un
 # AC13 no ssh in the arm block.
 assert "arm) contains no ssh (AC-NOSSH/AC13)" "! grep -qE '(^|[^[:alnum:]])ssh[[:space:]]' '$ARM_FILE'"
 
+# ============================================================================
+# #6178 durability — G3.5 CHANNEL-KEY PARITY HARD GATE. INNGEST_EVENT_KEY +
+# INNGEST_SIGNING_KEY are a SHARED app<->host channel token (ADR-100 §4 Amendment),
+# NOT isolation-sensitive; op=arm must REFUSE the flip if the app (soleur/prd) and
+# host (soleur-inngest/prd) copies diverge — the exact #6178 cutover-502. AC-NOBODY:
+# the gate compares via sha256 and NEVER echoes a key value. Asserted against the
+# extracted arm) case body (ARM_FILE) so the gate can only pass by living in op=arm.
+# ============================================================================
+assert "arm) has a G3.5 channel-key parity gate (#6178 durability)" "grep -qF 'G3.5 channel-key parity' '$ARM_FILE'"
+assert "arm) G3.5 checks BOTH channel keys (event + signing)" "grep -qE 'for CK in INNGEST_EVENT_KEY INNGEST_SIGNING_KEY' '$ARM_FILE'"
+assert "arm) G3.5 compares by sha256 (never by echoing the value — AC-NOBODY)" "grep -qF 'sha256sum' '$ARM_FILE'"
+assert "arm) G3.5 reads the HOST key from soleur-inngest/prd via the arm token" "grep -qE 'DOPPLER_TOKEN=\"\\\$DOPPLER_TOKEN_INNGEST_ARM\" doppler secrets get \"\\\$CK\" -p soleur-inngest -c prd --plain' '$ARM_FILE'"
+assert "arm) G3.5 reads the APP key read-through from prd_terraform (no -p/-c on the app get)" "grep -qE 'APP_CK=\\\$\(doppler secrets get \"\\\$CK\" --plain' '$ARM_FILE'"
+# Value-silent: both copies masked; NEITHER raw value is ever echoed.
+ARM_CK_MASK_N=$(grep -cE '::add-mask::.*(APP_CK|HOST_CK)' "$ARM_FILE" || true)
+assert "arm) G3.5 masks BOTH the app + host key values (>=2 ::add-mask::)" "[[ '$ARM_CK_MASK_N' -ge 2 ]]"
+assert "arm) G3.5 NEVER echoes a raw channel-key value (no echo of \$APP_CK/\$HOST_CK — AC-NOBODY)" "! grep -qE 'echo[^\"]*\\\$\\{?(APP_CK|HOST_CK)([^_H]|\$)' '$ARM_FILE'"
+# The gate is HARD: a mismatch (or unreadable key) fails op=arm closed.
+assert "arm) G3.5 is a HARD GATE — a divergence exits op=arm non-zero (PARITY_FAIL)" "grep -qE 'PARITY_FAIL' '$ARM_FILE' && grep -qF 'CHANNEL-KEY PARITY GATE FAILED' '$ARM_FILE'"
+assert "arm) G3.5 cites the #6178 cutover-502 condition in its remediation" "grep -qF 'cutover-502' '$ARM_FILE'"
+# The parity gate runs BEFORE the arm writes (G4/G5) — a divergent channel must
+# block the flip, never be written past.
+PARITY_LN=$(grep -nF 'G3.5 CHANNEL-KEY PARITY GATE FAILED' "$ARM_FILE" | head -1 | cut -d: -f1)
+G4_WRITE_LN=$(grep -nE 'secrets set INNGEST_POSTGRES_URI ' "$ARM_FILE" | head -1 | cut -d: -f1)
+assert "arm) G3.5 parity gate precedes the G4 POSTGRES_URI write (blocks before arming)" "[[ -n '$PARITY_LN' && -n '$G4_WRITE_LN' && '$PARITY_LN' -lt '$G4_WRITE_LN' ]]"
+
 # D5/C4 environment required-reviewer gate + C5 conditional token env (repo-level, not in the case body).
 assert "job gates op=arm/op=rollback on the inngest-cutover environment (D5/C4)" "grep -qE \"environment: .*inputs.op == 'arm'.*inputs.op == 'rollback'.*inngest-cutover\" '$WF'"
 assert "DOPPLER_TOKEN_INNGEST_ARM injected conditionally (empty for other ops — C5)" "grep -qE \"DOPPLER_TOKEN_INNGEST_ARM: .*inputs.op == 'arm'.*secrets.DOPPLER_TOKEN_INNGEST_ARM\" '$WF'"

--- a/apps/web-platform/infra/inngest.tf
+++ b/apps/web-platform/infra/inngest.tf
@@ -66,6 +66,18 @@ resource "random_id" "inngest_manual_trigger_secret_dev" {
 
 # ---------------- Doppler secrets (per-env) ----------------
 
+# SHARED-CHANNEL CONTRACT (#6178 durability; ADR-100 §4 Amendment). INNGEST_EVENT_KEY +
+# INNGEST_SIGNING_KEY here (soleur/prd) are the APP's copy of a SHARED app<->host channel
+# auth token — NOT an isolation-sensitive per-host secret. Post-cutover their VALUES MUST
+# EQUAL the dedicated host's keys (random_id.inngest_{event,signing}_key_dedicated →
+# doppler_secret.inngest_{event,signing}_key_dedicated on soleur-inngest/prd, inngest-host.tf),
+# or every app inngest.send() to 10.0.1.40:8288 is rejected (the #6178 op=rearm HTTP 502).
+# ignore_changes=[value] below means a naive `terraform apply` does NOT propagate a host-key
+# change here — reconcile out-of-band (the cutover workflow op=arm G3.5 parity gate refuses to
+# arm on divergence; copy the host value in via `doppler secrets set … -p soleur -c prd`, which
+# ignore_changes explicitly supports, then redeploy). See the runbook §2.4 (key-reconcile) +
+# ADR-100 §4 Amendment. The isolation-sensitive secrets that STAY separate per host are
+# INNGEST_POSTGRES_URI + SUPABASE_SERVICE_ROLE — never these channel keys.
 resource "doppler_secret" "inngest_signing_key_prd" {
   project    = "soleur"
   config     = "prd"

--- a/knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-100-inngest-dedicated-single-host-singleton-control-plane.md
@@ -134,6 +134,29 @@ from web cloud-init.** The following sub-decisions are fixed by this ADR:
    `cron-egress-nftables.sh`.
 4. **Fresh signing/event keys (SEC-H3).** `INNGEST_SIGNING_KEY`/`INNGEST_EVENT_KEY` are freshly
    minted for the new boundary, NOT reused from the co-located host. Blast radius documented below.
+
+   > **Amendment (2026-07-24, Ref #6178 cutover-502 — CORRECTS this decision).** Decision 4 was
+   > **wrong** to treat `INNGEST_EVENT_KEY` / `INNGEST_SIGNING_KEY` as isolation-sensitive and mint
+   > them **separately** per host. They are a **SHARED app↔host CHANNEL auth token**: the app
+   > (`inngest.send()` / the `serve()` handler) and the dedicated host authenticate the SAME channel
+   > with them, so they **MUST be common** across `soleur/prd` (the app) and `soleur-inngest/prd`
+   > (the host). The #6178 host-cutover minted fresh host keys per this decision but **never
+   > reconciled** them into `soleur/prd`; after the 2.4 app-repoint (`INNGEST_BASE_URL` →
+   > `http://10.0.1.40:8288`) every app-originated send to the host was rejected against the stale
+   > event key → the app route returned **HTTP 502** (`op=rearm` failed). The live fix copied the
+   > host's event+signing key values into `soleur/prd` (out-of-band, which the `ignore_changes=[value]`
+   > lifecycle on those `doppler_secret`s explicitly supports) and redeployed the web app.
+   >
+   > The isolation that actually matters — and **stays separate per host** — is **`INNGEST_POSTGRES_URI`
+   > + `SUPABASE_SERVICE_ROLE`** (Decision 5, the `soleur-inngest` project boundary): those grant
+   > data-plane access and must never be shared. The channel keys are auth for a shared message
+   > channel and confer no such access, so sharing them across the two projects widens nothing.
+   > **Durability (prevents recurrence):** `op=arm` now carries a **G3.5 channel-key parity HARD GATE**
+   > (cutover-inngest.yml) that sha256-compares the app vs host `INNGEST_EVENT_KEY`/`INNGEST_SIGNING_KEY`
+   > (value-silent, AC-NOBODY) and **refuses to arm the flip** if they diverge, with the reconcile +
+   > redeploy remediation. Because `soleur/prd`'s keys carry `ignore_changes=[value]`, reconcile is via
+   > the Doppler copy (or `terraform apply -replace=random_id.inngest_{event,signing}_key_dedicated`
+   > + copy) + a web redeploy — **not** a naive `terraform apply`. See runbook §2.4.
 5. **Secrets on a SEPARATE Doppler project `soleur-inngest`, not a `prd` branch config.** A branch
    config under `prd` resolves the environment's ROOT config as its base and would inherit all
    ~116 `soleur/prd` secrets incl. `SUPABASE_SERVICE_ROLE_KEY`

--- a/knowledge-base/engineering/operations/runbooks/inngest-server.md
+++ b/knowledge-base/engineering/operations/runbooks/inngest-server.md
@@ -705,6 +705,14 @@ merge) — both printed in the SEAM as an out-of-band hand-off.
    - **G3 positive prod-URI assertion (DI-C3):** asserts the value differs from the current dark
      `soleur-inngest/prd` URI, uses the `:5432` session pooler (never `:6543`), and targets the
      prod host — all value-silent.
+   - **G3.5 channel-key parity HARD GATE (#6178 durability):** sha256-compares the app
+     (`soleur/prd`, read-through) vs host (`soleur-inngest/prd`, arm token) `INNGEST_EVENT_KEY`
+     **and** `INNGEST_SIGNING_KEY` — value-silent (AC-NOBODY; only MATCH/MISMATCH reaches the log)
+     — and **refuses to arm** if either diverges. These keys are a **SHARED app↔host channel
+     token** (ADR-100 §4 Amendment), so a mismatch is the exact #6178 cutover-502 (post-repoint
+     every app `inngest.send()` to the host is rejected → `op=rearm` HTTP 502). On MISMATCH,
+     reconcile the app to the host's key + redeploy **before** re-running `op=arm` — see §2.4
+     key-reconcile below.
    - **G4/G5 writes:** `INNGEST_POSTGRES_URI` → `INNGEST_HEARTBEAT_URL` → `INNGEST_CUTOVER_FLIP`
      set to `armed` (last), each via **stdin** (never argv), exit-gated. The enabled 30s poll
      timer then drives the forward FSM **stop → `FLUSHALL` → assert `DBSIZE==0` → start → `done`**.
@@ -755,6 +763,34 @@ merge) — both printed in the SEAM as an out-of-band hand-off.
    change (both the canary and prod sites) and redeploy the web app so the functions re-sync
    (register) onto the dedicated host. `op=rearm`/`op=verify` precondition-check that this
    landed (registry-non-empty).
+
+   > **Channel-key reconcile (#6178 durability — do this as part of 2.4, NOT deferred).** The
+   > app and the dedicated host must share the SAME `INNGEST_EVENT_KEY` + `INNGEST_SIGNING_KEY`
+   > (they are a shared app↔host **channel** auth token, ADR-100 §4 Amendment — the isolation
+   > that stays separate is `INNGEST_POSTGRES_URI` + `SUPABASE_SERVICE_ROLE`, never these). The
+   > #6178 cutover repointed the app to the host but never reconciled the keys, so every
+   > app→host `inngest.send()` was rejected → **HTTP 502** (`op=rearm` failed). `op=arm`'s **G3.5
+   > parity HARD GATE** now blocks the flip if they diverge — so reconcile happens BEFORE `op=arm`
+   > passes, but the invariant belongs to this app-repoint step: the app must adopt the host's key.
+   >
+   > **Because `soleur/prd`'s `INNGEST_EVENT_KEY`/`INNGEST_SIGNING_KEY` carry
+   > `lifecycle.ignore_changes = [value]` (inngest.tf), a naive `terraform apply` does NOT
+   > propagate a host-key change** — reconcile is the Doppler copy the `ignore_changes` lifecycle
+   > explicitly supports (or a `-replace` of the host `random_id` + copy), then a **web redeploy**
+   > (ci-deploy regenerates the env each deploy, so the app only bakes the new key on the next
+   > deploy). No secret value is echoed — read on the arm token, pipe on stdin:
+   > ```bash
+   > # Copy each host channel key INTO soleur/prd (value on STDIN, never argv/log):
+   > for K in INNGEST_EVENT_KEY INNGEST_SIGNING_KEY; do
+   >   DOPPLER_TOKEN="$DOPPLER_TOKEN_INNGEST_ARM" doppler secrets get "$K" -p soleur-inngest -c prd --plain \
+   >     | doppler secrets set "$K" -p soleur -c prd --silent --no-interactive   # DOPPLER_TOKEN_WRITE cannot reach prd root; use a prd-root write token / Doppler console
+   > done
+   > # then redeploy web-platform so the app adopts the shared keys, and re-run op=arm (G3.5 now MATCHes).
+   > ```
+   > (`DOPPLER_TOKEN_WRITE` is scoped to `soleur/prd_terraform` and cannot write the `prd` root
+   > config the app reads; the copy is a `prd`-root write — Doppler console or a prd-root r/w token.
+   > A future full automation would mint a narrow prd-root write token; the G3.5 gate is the
+   > recurrence-prevention that makes the divergence impossible to ship silently.)
 
 5. **`op=rearm`** (re-arm the captured reminders after the flip):
    ```bash


### PR DESCRIPTION
## Why
The #6178 cutover's op=rearm 502 (fixed live this session) was caused by treating `INNGEST_EVENT_KEY`/`INNGEST_SIGNING_KEY` as **isolation-sensitive**: ADR-100 §4 minted them **fresh per host**, but they are a **shared app↔host channel auth token** — the app (`soleur/prd`) and the dedicated host (`soleur-inngest/prd`) MUST share them, or every app `inngest.send()` to `10.0.1.40:8288/e/<key>` is rejected `502`. Cutover step 2.4 repointed `INNGEST_BASE_URL` but never reconciled the keys.

## What (durable recurrence-prevention)
**Not an automated copy-write** — no existing CI token can write `soleur/prd` **root** (`DOPPLER_TOKEN` is read-only `prd_terraform`; `DOPPLER_TOKEN_WRITE` is scoped to the `prd_terraform` branch; `DOPPLER_TOKEN_INNGEST_ARM` is `soleur-inngest/prd` only). Minting a prd-root r/w token would be a standing large-blast-radius credential over `SUPABASE_SERVICE_ROLE` et al. — deliberately avoided. Instead:

- **`op=arm` G3.5 CHANNEL-KEY PARITY HARD GATE** (after G3, before the G4 arm writes): sha256-compares app vs host `INNGEST_EVENT_KEY` + `INNGEST_SIGNING_KEY`, **value-silent** (`::add-mask::` both, prints only MATCH/MISMATCH — AC-NOBODY), and **refuses to arm** (`exit 1`, fail-closed) on divergence or an unreadable key. The #6178 divergence can no longer ship silently — the cutover **cannot complete `op=arm` while the channel keys differ**.
- **ADR-100 §4 amended:** channel keys are shared-by-design; only `INNGEST_POSTGRES_URI` + `SUPABASE_SERVICE_ROLE` are the isolation-sensitive secrets that stay separate. Cites the #6178 cutover-502.
- **Runbook §2.4:** the key-reconcile + redeploy step (Doppler copy, which `ignore_changes=[value]` supports; naive `terraform apply` does NOT propagate) + the G3.5 gate.
- **inngest.tf:** comment on the `soleur/prd` channel-key secrets that their values must equal the host's (→ runbook §2.4 + ADR-100 §4).

## Tests
`cutover-inngest-workflow.test.sh` **+11 assertions** (gate exists, checks both keys, sha256-compares, reads each side with the right token, masks both values, never echoes a raw key, hard-gate `exit 1`, runs **before** the G4 write). **247/247** pass.

## Follow-up (noted inline)
A narrow prd-root write token could later close the last automation gap (auto-copy instead of gate-and-document), but that's a separate blast-radius decision. The gate is the sanctioned minimum and makes the failure impossible to ship silently.

Ref #6178.