### PR TITLE
feat(models): Opus 5 launch — AUDIT_MODEL claude-opus-4-8 → claude-opus-5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # The SDK-bump gate below scans `git log origin/main..HEAD` for the
+          # `sdk-bump-verified:` ack. That range needs a merge base, so BOTH
+          # sides must be non-shallow — the default depth-1 checkout made the
+          # range unreadable (git exits 128) and the gate then reported a
+          # MISSING ack for every SDK bump regardless of what the author wrote.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -358,7 +365,7 @@ jobs:
       # base comparison needs origin/main; the default checkout is depth-1, so fetch it.
       - name: SDK-bump sandbox gate (lockfile parity + bump ack)
         run: |
-          git fetch --no-tags --depth=1 origin main 2>/dev/null || true
+          git fetch --no-tags origin main 2>/dev/null || true  # NOT --depth=1: a shallow base has no merge base, so `git log base..HEAD` exits 128 and the ack scan silently reads empty
           bash apps/web-platform/scripts/sdk-bump-sandbox-gate.sh
 
   # #5913 / ADR-079 deferral B — creds-gated canary CAPTURE gate. DARK-LAUNCH:
@@ -387,7 +394,7 @@ jobs:
       - name: Detect capture-input changes
         id: trigger
         run: |
-          git fetch --no-tags --depth=1 origin main 2>/dev/null || true
+          git fetch --no-tags origin main 2>/dev/null || true  # NOT --depth=1: a shallow base has no merge base, so `git log base..HEAD` exits 128 and the ack scan silently reads empty
           CHANGED="$(git diff --name-only origin/main...HEAD 2>/dev/null || true)"
           if printf '%s\n' "$CHANGED" | grep -qE 'apps/web-platform/(package-lock\.json|server/agent-runner-sandbox-config\.ts|scripts/sandbox-canary\.mjs|infra/sandbox-canary-argv\.json)'; then
             echo "hit=1" >> "$GITHUB_OUTPUT"
@@ -407,7 +414,7 @@ jobs:
           # --verify runs inside node:22-slim (deploy base) — see helper header.
           SDK_GATE_VERIFY_CMD: bash apps/web-platform/scripts/sandbox-canary-verify-in-image.sh
         run: |
-          git fetch --no-tags --depth=1 origin main 2>/dev/null || true
+          git fetch --no-tags origin main 2>/dev/null || true  # NOT --depth=1: a shallow base has no merge base, so `git log base..HEAD` exits 128 and the ack scan silently reads empty
           bash apps/web-platform/scripts/sdk-bump-sandbox-gate.sh
 
   # plugin-root-propagation-verify-in-image.sh — the F2 runtime guarantee
@@ -432,7 +439,7 @@ jobs:
       - name: Detect propagation-input changes
         id: trigger
         run: |
-          git fetch --no-tags --depth=1 origin main 2>/dev/null || true
+          git fetch --no-tags origin main 2>/dev/null || true  # NOT --depth=1: a shallow base has no merge base, so `git log base..HEAD` exits 128 and the ack scan silently reads empty
           CHANGED="$(git diff --name-only origin/main...HEAD 2>/dev/null || true)"
           # Trigger set = the probe's ACTUAL inputs: it imports buildAgentEnv
           # (agent-env.ts) + buildAgentSandboxConfig (agent-runner-sandbox-config.ts)

--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -49,7 +49,12 @@ FROM node:22-slim@sha256:4f77a690f2f8946ab16fe1e791a3ac0667ae1c3575c3e4d0d4589e9
 # any per-commit-volatile line) above this point. (Recovering `npm ci --omit=dev`,
 # which sits below BUILD_SHA, is tracked as #5055.)
 # Install Claude Code CLI (needed by Agent SDK)
-RUN npm install -g @anthropic-ai/claude-code@2.1.79
+# KEEP IN SYNC with the `@anthropic-ai/claude-code` pin in package.json: the
+# CLI carries a bundled per-model table, and a model ID absent from it silently
+# falls back to half the max_tokens (measured 64000 → 32000 on #6934), so a
+# stale pin here degrades every cron that passes --model. This was skewed at
+# 2.1.79 vs package.json's 2.1.197 until #6934.
+RUN npm install -g @anthropic-ai/claude-code@2.1.219
 
 # LikeC4 CLI for runtime diagram re-render after a Code-tab Save (#4964).
 # Global install (NOT a package.json dep) — same pattern as the line above —

--- a/apps/web-platform/bun.lock
+++ b/apps/web-platform/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "soleur-web-platform",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk": "0.3.197",
         "@anthropic-ai/claude-code": "2.1.219",
         "@codemirror/state": "^6",
         "@codemirror/theme-one-dark": "^6",
@@ -94,23 +94,23 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.219", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.219", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.219" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-dJjzKxoyCQSEEEo9a0g3wBQprRMCpsqjmsNOZaGOWw+W+JHZsolDBhoYfoZ9BA8EdwgaJmbQUvhkAZjROUsBnQ=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.197", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.219", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TQhGAlbMsOGXi03dwf4nD274Lc5BOJg4QFJTuXcQyhLhx0hUqzxCmtvpXt6S70K6yl1Zgc+2n5W/r1Dgt8G8iw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.219", "", { "os": "darwin", "cpu": "x64" }, "sha512-zA/wHN+os4yqXASXJxvGGNSD1p7LZ6BMN71CCphoy5u+d6IpNOCtATnZwINEc2fGFHpv/QDci6jhywJ2O9Flbw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-lizasky9Xj0ouYrz/Akst573Sm8NO3k/0iGCeCDBoQKLnONbVFwc7sHq9x426Pfcllgb4C2Xyc79/1iOALh/9g=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197", "", { "os": "linux", "cpu": "arm64" }, "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiZo+UBCp42FAYqSakgVj/g6LfTH0AklWqIZNEHfVDPaofledXdSu0QJM5yScWNg0hVMaNRXPt0DmuS1oIWW6g=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197", "", { "os": "linux", "cpu": "arm64" }, "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.219", "", { "os": "linux", "cpu": "x64" }, "sha512-yzXhEsT5XcKa8Dc3sM4D1CQ92/6YGmsBbAhRAdw0PYNkG8x6wbHqfzYZS491Bdjry4tSWemNFtGPNkHiWVo3Hg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197", "", { "os": "linux", "cpu": "x64" }, "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.219", "", { "os": "linux", "cpu": "x64" }, "sha512-IhfG57/XorWOQTB6BVdjEFPGH0LwOWO6HnAi+FNuCeiC+XRFl9QI9AKY43opS0gbvJWRobZO865tHX5j7Ou+ow=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197", "", { "os": "linux", "cpu": "x64" }, "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.219", "", { "os": "win32", "cpu": "arm64" }, "sha512-L/cAT27t3FGP4GlJ16WpXMtaeqDu9olpOlIaqqmjElQp5Lknd8alJ3NIY/SlRAtHDvm4WXug74wnfBOSlwppkg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.219", "", { "os": "win32", "cpu": "x64" }, "sha512-Fl8Rb9K64jbpC/omIF9y828LIvwRmm1zhZgO8zjalTpjZR/0C31Kl+5FwAS9KkXXUXwmdHSY+82e9dyvBrbIRw=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q=="],
 
     "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.219", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.219", "@anthropic-ai/claude-code-darwin-x64": "2.1.219", "@anthropic-ai/claude-code-linux-arm64": "2.1.219", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.219", "@anthropic-ai/claude-code-linux-x64": "2.1.219", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.219", "@anthropic-ai/claude-code-win32-arm64": "2.1.219", "@anthropic-ai/claude-code-win32-x64": "2.1.219" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-6PVBrRsKHFi0gzv5bCabVL+XSqI3F8AR6ekFx4gpzdE5a9XotqewolID0PbcdD9IyWVYCIDET4GDCcUdA89i3Q=="],
 

--- a/apps/web-platform/bun.lock
+++ b/apps/web-platform/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "soleur-web-platform",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.197",
-        "@anthropic-ai/claude-code": "2.1.197",
+        "@anthropic-ai/claude-agent-sdk": "0.3.219",
+        "@anthropic-ai/claude-code": "2.1.219",
         "@codemirror/state": "^6",
         "@codemirror/theme-one-dark": "^6",
         "@codemirror/view": "^6",
@@ -94,41 +94,41 @@
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.197", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.219", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.219", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.219", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.219", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.219" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-dJjzKxoyCQSEEEo9a0g3wBQprRMCpsqjmsNOZaGOWw+W+JHZsolDBhoYfoZ9BA8EdwgaJmbQUvhkAZjROUsBnQ=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.219", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TQhGAlbMsOGXi03dwf4nD274Lc5BOJg4QFJTuXcQyhLhx0hUqzxCmtvpXt6S70K6yl1Zgc+2n5W/r1Dgt8G8iw=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.219", "", { "os": "darwin", "cpu": "x64" }, "sha512-zA/wHN+os4yqXASXJxvGGNSD1p7LZ6BMN71CCphoy5u+d6IpNOCtATnZwINEc2fGFHpv/QDci6jhywJ2O9Flbw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197", "", { "os": "linux", "cpu": "arm64" }, "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-lizasky9Xj0ouYrz/Akst573Sm8NO3k/0iGCeCDBoQKLnONbVFwc7sHq9x426Pfcllgb4C2Xyc79/1iOALh/9g=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197", "", { "os": "linux", "cpu": "arm64" }, "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiZo+UBCp42FAYqSakgVj/g6LfTH0AklWqIZNEHfVDPaofledXdSu0QJM5yScWNg0hVMaNRXPt0DmuS1oIWW6g=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197", "", { "os": "linux", "cpu": "x64" }, "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.219", "", { "os": "linux", "cpu": "x64" }, "sha512-yzXhEsT5XcKa8Dc3sM4D1CQ92/6YGmsBbAhRAdw0PYNkG8x6wbHqfzYZS491Bdjry4tSWemNFtGPNkHiWVo3Hg=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197", "", { "os": "linux", "cpu": "x64" }, "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.219", "", { "os": "linux", "cpu": "x64" }, "sha512-IhfG57/XorWOQTB6BVdjEFPGH0LwOWO6HnAi+FNuCeiC+XRFl9QI9AKY43opS0gbvJWRobZO865tHX5j7Ou+ow=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197", "", { "os": "win32", "cpu": "arm64" }, "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.219", "", { "os": "win32", "cpu": "arm64" }, "sha512-L/cAT27t3FGP4GlJ16WpXMtaeqDu9olpOlIaqqmjElQp5Lknd8alJ3NIY/SlRAtHDvm4WXug74wnfBOSlwppkg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.219", "", { "os": "win32", "cpu": "x64" }, "sha512-Fl8Rb9K64jbpC/omIF9y828LIvwRmm1zhZgO8zjalTpjZR/0C31Kl+5FwAS9KkXXUXwmdHSY+82e9dyvBrbIRw=="],
 
-    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.197", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.197", "@anthropic-ai/claude-code-darwin-x64": "2.1.197", "@anthropic-ai/claude-code-linux-arm64": "2.1.197", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.197", "@anthropic-ai/claude-code-linux-x64": "2.1.197", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.197", "@anthropic-ai/claude-code-win32-arm64": "2.1.197", "@anthropic-ai/claude-code-win32-x64": "2.1.197" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-EqrwbRcI7M5y8jQlayIfTMmbZJ2OQaLOc7KwIWKdryQCdKWUEFr+C9rMovZUuj2Asndi7aqLujEzRtr471gncg=="],
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.219", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.219", "@anthropic-ai/claude-code-darwin-x64": "2.1.219", "@anthropic-ai/claude-code-linux-arm64": "2.1.219", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.219", "@anthropic-ai/claude-code-linux-x64": "2.1.219", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.219", "@anthropic-ai/claude-code-win32-arm64": "2.1.219", "@anthropic-ai/claude-code-win32-x64": "2.1.219" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-6PVBrRsKHFi0gzv5bCabVL+XSqI3F8AR6ekFx4gpzdE5a9XotqewolID0PbcdD9IyWVYCIDET4GDCcUdA89i3Q=="],
 
-    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.197", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1FOVhJzkKGWgOEEsvaK3ylCEmjKeJiXwfKl7RtNEbiDj7OxhRQ1G1CLN0HGDTTq1QwY+Dm2x1Yscdv5NfobAxQ=="],
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.219", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/t/JlmaHh6vtXbZ0R8iRnSBzhc1OSQLybS8HB5RA/BtbueODKQKvtCiCBVwdXXjmdn3aBFrmWRbGzpYZRVcZtw=="],
 
-    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.197", "", { "os": "darwin", "cpu": "x64" }, "sha512-DOPeGTQqJWVENJsxwMxJtLOx+7OBINEDg9trQldlJR1nBssaYzNj1WWxp37JYSBRjeYLhqLipvDqEA0LMglL7A=="],
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.219", "", { "os": "darwin", "cpu": "x64" }, "sha512-+xuRyR76Q4ZtorDuZVaTvfFEKunCsthZxR+c8/cHtvViaYt4cZ11Aof2GYH0qQhyY5DaoQphO21Lnr/VfzpGqQ=="],
 
-    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.197", "", { "os": "linux", "cpu": "arm64" }, "sha512-sx6SoGj3MNR5CV+YDkNtbLHXa1tn3G8qcYFgm1gnvOi9ODQUKbhiPfankJfkTMDVekOvnKJhm6i9hGFIPzp7cQ=="],
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-G5yLidk2u6djL5PPuBYXVwVhTsZY5zLoZwh1Jnrd/IRyYb0P0x4gKTzVvGlsGepkBrOp0H2k/KuicyNPrXt57Q=="],
 
-    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.197", "", { "os": "linux", "cpu": "arm64" }, "sha512-r3taVK9rDaMahHkrCGV8wF1Sjphs7fqXy2ZEznyDGxUqeW6HxgkbG7dPplXnwwGiMTdYLrtQTQMN21ZTxcVHBA=="],
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.219", "", { "os": "linux", "cpu": "arm64" }, "sha512-l3v1ngKE5Y75TD8vqkE/yHTHIZ7bzcfWhyi9jmtXnYQ2Q2GVcBDasaD4K8wkFsf7iEZtioSRYtxdi0FBuTYYJQ=="],
 
-    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.197", "", { "os": "linux", "cpu": "x64" }, "sha512-rIlKmrY0QMyHgPRX/MYWNj039vbypICvI9jVe3rs9Xy2RnNklySjyPxqh62QadznzoftEO23uYQ1tFePcQ//bg=="],
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.219", "", { "os": "linux", "cpu": "x64" }, "sha512-Eq8aJpMrfy5rwQZQys/MdDD5Ph96ugZMgmwZmo4mXveEvp7JTZX8vUvqN/sHBn/yVmhzJNWcvepzQuBkcrLXZw=="],
 
-    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.197", "", { "os": "linux", "cpu": "x64" }, "sha512-/Ij3+inZf96Lb1BLnO0rWArRi1HqIMh6HeGrQoykrp7a8Yj0SA1EQIO42kpNeVxM9z3o3xUaiIf0FRMzLIp6oQ=="],
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.219", "", { "os": "linux", "cpu": "x64" }, "sha512-fEgmLQZWn6yvfGChyr781+pXaFPNMTSlGyujW3J8lM1CqobFOQSvk/8kepxgibmjeRxQn/O6BIgSxwp1vzvlSA=="],
 
-    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.197", "", { "os": "win32", "cpu": "arm64" }, "sha512-P/1y1JcBSKNRt9asd0bhGRwLdD7yLnq9BlXdA0KHC+0zTm/WPqsCHupt8C7f7adb14//dVlkkbRT+9F5Iup/qA=="],
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.219", "", { "os": "win32", "cpu": "arm64" }, "sha512-Do0M4zVIF8ULCvttXwi1d4D6U19sqgjCLOSRsgOGjaa/G1QUzkTn8BiGAi2vkp8EEIYQKJpPXmWVzWYcZnKAWQ=="],
 
-    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.197", "", { "os": "win32", "cpu": "x64" }, "sha512-bH/146HdS+MO2ndTvljKUJQbcKuvOWujH02WiLkhQJmo/YJLTCMnn1P/jxjjv6W9y/+LGxN58SfdHa6zobatTw=="],
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.219", "", { "os": "win32", "cpu": "x64" }, "sha512-W5yKQOYnMmPFUa0//e8dVMAn0oYK2iMk9dS5QvfIZnNc32exXlRWjVDtTUhwxL5wbeIom3GbGk4lrOYwD4h/cw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.93.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-q9vaSZQVFx6B/gPxetGYfLXSJD5v0sOmh0OpZDq7yCrTSA+Rscvrtyol7JJTW40wEpQB4U1B4JXzxQitbQ3CAA=="],
 

--- a/apps/web-platform/package-lock.json
+++ b/apps/web-platform/package-lock.json
@@ -8,7 +8,7 @@
       "name": "soleur-web-platform",
       "version": "0.0.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk": "0.3.197",
         "@anthropic-ai/claude-code": "2.1.219",
         "@codemirror/state": "^6",
         "@codemirror/theme-one-dark": "^6",
@@ -105,22 +105,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.219.tgz",
-      "integrity": "sha512-dJjzKxoyCQSEEEo9a0g3wBQprRMCpsqjmsNOZaGOWw+W+JHZsolDBhoYfoZ9BA8EdwgaJmbQUvhkAZjROUsBnQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
+      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.219",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.219"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.219.tgz",
-      "integrity": "sha512-TQhGAlbMsOGXi03dwf4nD274Lc5BOJg4QFJTuXcQyhLhx0hUqzxCmtvpXt6S70K6yl1Zgc+2n5W/r1Dgt8G8iw==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
+      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
       "cpu": [
         "arm64"
       ],
@@ -142,9 +142,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.219.tgz",
-      "integrity": "sha512-zA/wHN+os4yqXASXJxvGGNSD1p7LZ6BMN71CCphoy5u+d6IpNOCtATnZwINEc2fGFHpv/QDci6jhywJ2O9Flbw==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
+      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
       "cpu": [
         "x64"
       ],
@@ -155,9 +155,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.219.tgz",
-      "integrity": "sha512-lizasky9Xj0ouYrz/Akst573Sm8NO3k/0iGCeCDBoQKLnONbVFwc7sHq9x426Pfcllgb4C2Xyc79/1iOALh/9g==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
+      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
       "cpu": [
         "arm64"
       ],
@@ -171,9 +171,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.219.tgz",
-      "integrity": "sha512-yiZo+UBCp42FAYqSakgVj/g6LfTH0AklWqIZNEHfVDPaofledXdSu0QJM5yScWNg0hVMaNRXPt0DmuS1oIWW6g==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
+      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
       "cpu": [
         "arm64"
       ],
@@ -187,9 +187,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.219.tgz",
-      "integrity": "sha512-yzXhEsT5XcKa8Dc3sM4D1CQ92/6YGmsBbAhRAdw0PYNkG8x6wbHqfzYZS491Bdjry4tSWemNFtGPNkHiWVo3Hg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
+      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
       "cpu": [
         "x64"
       ],
@@ -203,9 +203,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.219.tgz",
-      "integrity": "sha512-IhfG57/XorWOQTB6BVdjEFPGH0LwOWO6HnAi+FNuCeiC+XRFl9QI9AKY43opS0gbvJWRobZO865tHX5j7Ou+ow==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
+      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
       "cpu": [
         "x64"
       ],
@@ -219,9 +219,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.219.tgz",
-      "integrity": "sha512-L/cAT27t3FGP4GlJ16WpXMtaeqDu9olpOlIaqqmjElQp5Lknd8alJ3NIY/SlRAtHDvm4WXug74wnfBOSlwppkg==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
+      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
       "cpu": [
         "arm64"
       ],
@@ -232,9 +232,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.219",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.219.tgz",
-      "integrity": "sha512-Fl8Rb9K64jbpC/omIF9y828LIvwRmm1zhZgO8zjalTpjZR/0C31Kl+5FwAS9KkXXUXwmdHSY+82e9dyvBrbIRw==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
+      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
       "cpu": [
         "x64"
       ],

--- a/apps/web-platform/package-lock.json
+++ b/apps/web-platform/package-lock.json
@@ -8,8 +8,8 @@
       "name": "soleur-web-platform",
       "version": "0.0.1",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.197",
-        "@anthropic-ai/claude-code": "2.1.197",
+        "@anthropic-ai/claude-agent-sdk": "0.3.219",
+        "@anthropic-ai/claude-code": "2.1.219",
         "@codemirror/state": "^6",
         "@codemirror/theme-one-dark": "^6",
         "@codemirror/view": "^6",
@@ -105,21 +105,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
-      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.219.tgz",
+      "integrity": "sha512-dJjzKxoyCQSEEEo9a0g3wBQprRMCpsqjmsNOZaGOWw+W+JHZsolDBhoYfoZ9BA8EdwgaJmbQUvhkAZjROUsBnQ==",
+      "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.219",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.219"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -128,214 +129,255 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
-      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.219.tgz",
+      "integrity": "sha512-TQhGAlbMsOGXi03dwf4nD274Lc5BOJg4QFJTuXcQyhLhx0hUqzxCmtvpXt6S70K6yl1Zgc+2n5W/r1Dgt8G8iw==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
-      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.219.tgz",
+      "integrity": "sha512-zA/wHN+os4yqXASXJxvGGNSD1p7LZ6BMN71CCphoy5u+d6IpNOCtATnZwINEc2fGFHpv/QDci6jhywJ2O9Flbw==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
-      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.219.tgz",
+      "integrity": "sha512-lizasky9Xj0ouYrz/Akst573Sm8NO3k/0iGCeCDBoQKLnONbVFwc7sHq9x426Pfcllgb4C2Xyc79/1iOALh/9g==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
-      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.219.tgz",
+      "integrity": "sha512-yiZo+UBCp42FAYqSakgVj/g6LfTH0AklWqIZNEHfVDPaofledXdSu0QJM5yScWNg0hVMaNRXPt0DmuS1oIWW6g==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
-      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.219.tgz",
+      "integrity": "sha512-yzXhEsT5XcKa8Dc3sM4D1CQ92/6YGmsBbAhRAdw0PYNkG8x6wbHqfzYZS491Bdjry4tSWemNFtGPNkHiWVo3Hg==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
-      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.219.tgz",
+      "integrity": "sha512-IhfG57/XorWOQTB6BVdjEFPGH0LwOWO6HnAi+FNuCeiC+XRFl9QI9AKY43opS0gbvJWRobZO865tHX5j7Ou+ow==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
-      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.219.tgz",
+      "integrity": "sha512-L/cAT27t3FGP4GlJ16WpXMtaeqDu9olpOlIaqqmjElQp5Lknd8alJ3NIY/SlRAtHDvm4WXug74wnfBOSlwppkg==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
-      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
+      "version": "0.3.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.219.tgz",
+      "integrity": "sha512-Fl8Rb9K64jbpC/omIF9y828LIvwRmm1zhZgO8zjalTpjZR/0C31Kl+5FwAS9KkXXUXwmdHSY+82e9dyvBrbIRw==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.197.tgz",
-      "integrity": "sha512-EqrwbRcI7M5y8jQlayIfTMmbZJ2OQaLOc7KwIWKdryQCdKWUEFr+C9rMovZUuj2Asndi7aqLujEzRtr471gncg==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.219.tgz",
+      "integrity": "sha512-6PVBrRsKHFi0gzv5bCabVL+XSqI3F8AR6ekFx4gpzdE5a9XotqewolID0PbcdD9IyWVYCIDET4GDCcUdA89i3Q==",
       "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
       "bin": {
         "claude": "bin/claude.exe"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.197",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.197",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.197",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.197",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.197",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.197",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.197",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.197"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.219",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.219",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.219",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.219",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.219",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.219",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.219",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.219"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.197.tgz",
-      "integrity": "sha512-1FOVhJzkKGWgOEEsvaK3ylCEmjKeJiXwfKl7RtNEbiDj7OxhRQ1G1CLN0HGDTTq1QwY+Dm2x1Yscdv5NfobAxQ==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.219.tgz",
+      "integrity": "sha512-/t/JlmaHh6vtXbZ0R8iRnSBzhc1OSQLybS8HB5RA/BtbueODKQKvtCiCBVwdXXjmdn3aBFrmWRbGzpYZRVcZtw==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.197.tgz",
-      "integrity": "sha512-DOPeGTQqJWVENJsxwMxJtLOx+7OBINEDg9trQldlJR1nBssaYzNj1WWxp37JYSBRjeYLhqLipvDqEA0LMglL7A==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.219.tgz",
+      "integrity": "sha512-+xuRyR76Q4ZtorDuZVaTvfFEKunCsthZxR+c8/cHtvViaYt4cZ11Aof2GYH0qQhyY5DaoQphO21Lnr/VfzpGqQ==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.197.tgz",
-      "integrity": "sha512-sx6SoGj3MNR5CV+YDkNtbLHXa1tn3G8qcYFgm1gnvOi9ODQUKbhiPfankJfkTMDVekOvnKJhm6i9hGFIPzp7cQ==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.219.tgz",
+      "integrity": "sha512-G5yLidk2u6djL5PPuBYXVwVhTsZY5zLoZwh1Jnrd/IRyYb0P0x4gKTzVvGlsGepkBrOp0H2k/KuicyNPrXt57Q==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.197.tgz",
-      "integrity": "sha512-r3taVK9rDaMahHkrCGV8wF1Sjphs7fqXy2ZEznyDGxUqeW6HxgkbG7dPplXnwwGiMTdYLrtQTQMN21ZTxcVHBA==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.219.tgz",
+      "integrity": "sha512-l3v1ngKE5Y75TD8vqkE/yHTHIZ7bzcfWhyi9jmtXnYQ2Q2GVcBDasaD4K8wkFsf7iEZtioSRYtxdi0FBuTYYJQ==",
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.197.tgz",
-      "integrity": "sha512-rIlKmrY0QMyHgPRX/MYWNj039vbypICvI9jVe3rs9Xy2RnNklySjyPxqh62QadznzoftEO23uYQ1tFePcQ//bg==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.219.tgz",
+      "integrity": "sha512-Eq8aJpMrfy5rwQZQys/MdDD5Ph96ugZMgmwZmo4mXveEvp7JTZX8vUvqN/sHBn/yVmhzJNWcvepzQuBkcrLXZw==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.197.tgz",
-      "integrity": "sha512-/Ij3+inZf96Lb1BLnO0rWArRi1HqIMh6HeGrQoykrp7a8Yj0SA1EQIO42kpNeVxM9z3o3xUaiIf0FRMzLIp6oQ==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.219.tgz",
+      "integrity": "sha512-fEgmLQZWn6yvfGChyr781+pXaFPNMTSlGyujW3J8lM1CqobFOQSvk/8kepxgibmjeRxQn/O6BIgSxwp1vzvlSA==",
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.197.tgz",
-      "integrity": "sha512-P/1y1JcBSKNRt9asd0bhGRwLdD7yLnq9BlXdA0KHC+0zTm/WPqsCHupt8C7f7adb14//dVlkkbRT+9F5Iup/qA==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.219.tgz",
+      "integrity": "sha512-Do0M4zVIF8ULCvttXwi1d4D6U19sqgjCLOSRsgOGjaa/G1QUzkTn8BiGAi2vkp8EEIYQKJpPXmWVzWYcZnKAWQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.197",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.197.tgz",
-      "integrity": "sha512-bH/146HdS+MO2ndTvljKUJQbcKuvOWujH02WiLkhQJmo/YJLTCMnn1P/jxjjv6W9y/+LGxN58SfdHa6zobatTw==",
+      "version": "2.1.219",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.219.tgz",
+      "integrity": "sha512-W5yKQOYnMmPFUa0//e8dVMAn0oYK2iMk9dS5QvfIZnNc32exXlRWjVDtTUhwxL5wbeIom3GbGk4lrOYwD4h/cw==",
       "cpu": [
         "x64"
       ],
+      "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
         "win32"

--- a/apps/web-platform/package.json
+++ b/apps/web-platform/package.json
@@ -23,7 +23,7 @@
     "byok-revoke": "bun scripts/byok-revoke.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.219",
+    "@anthropic-ai/claude-agent-sdk": "0.3.197",
     "@anthropic-ai/claude-code": "2.1.219",
     "@codemirror/state": "^6",
     "@codemirror/theme-one-dark": "^6",

--- a/apps/web-platform/package.json
+++ b/apps/web-platform/package.json
@@ -23,8 +23,8 @@
     "byok-revoke": "bun scripts/byok-revoke.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.197",
-    "@anthropic-ai/claude-code": "2.1.197",
+    "@anthropic-ai/claude-agent-sdk": "0.3.219",
+    "@anthropic-ai/claude-code": "2.1.219",
     "@codemirror/state": "^6",
     "@codemirror/theme-one-dark": "^6",
     "@codemirror/view": "^6",

--- a/apps/web-platform/scripts/sdk-bump-sandbox-gate.sh
+++ b/apps/web-platform/scripts/sdk-bump-sandbox-gate.sh
@@ -46,6 +46,24 @@ FOLLOWUP="the ADR-079 deferral-B follow-up (creds-gated real-argv capture)"
 
 SDK_PACKAGES=("@anthropic-ai/claude-agent-sdk" "@anthropic-ai/claude-code")
 
+# Branch commit messages for the ack scan. MUST distinguish "no ack on the
+# branch" from "the range could not be read": the previous
+# `git log … 2>/dev/null || true` conflated them, so a shallow BASE_REF (the
+# workflow fetched origin/main at --depth=1) produced an EMPTY ack_text and the
+# gate reported a missing acknowledgement no matter what the author wrote — the
+# ack was unreachable, not absent. Reproduced: with a depth-1 base, `git log
+# base..HEAD` exits 128 "unknown revision". Fail loudly and name the cause.
+read_branch_messages() {
+  local out rc
+  out="$(git log "${BASE_REF}..HEAD" --format=%B 2>/dev/null)"; rc=$?
+  if (( rc != 0 )); then
+    echo "::error::sdk-bump-gate: could not read the commit range '${BASE_REF}..HEAD' (git exit ${rc})." >&2
+    echo "::error::This is NOT a missing acknowledgement — the range is unreadable, usually because '${BASE_REF}' was fetched shallow so there is no merge base. Deepen the fetch (drop --depth on the 'git fetch origin main'), or pass SDK_GATE_ACK_TEXT." >&2
+    return 1
+  fi
+  printf '%s' "$out"
+}
+
 # Resolved version from a package-lock.json (npm v3 lockfile: packages map keyed by
 # node_modules/<pkg>). Prints "" (never errors) when the package or file is absent.
 pkglock_version() { # $1=lockfile $2=pkg
@@ -125,7 +143,7 @@ if [[ "${#bumped_pkgs[@]}" -gt 0 ]]; then
   if [[ -n "${SDK_GATE_ACK_TEXT+x}" ]]; then
     ack_text="${SDK_GATE_ACK_TEXT}"
   else
-    ack_text="$(git log "${BASE_REF}..HEAD" --format=%B 2>/dev/null || true)"
+    ack_text="$(read_branch_messages)" || exit 1
   fi
   if printf '%s' "$ack_text" | grep -qiE "\b${ACK_TOKEN}\b"; then
     echo "sdk-bump-gate: SDK bump acknowledged (\`${ACK_TOKEN}\` present) — a maintainer attests the committed seccomp profile was validated against the new SDK. Proceeding."
@@ -200,7 +218,7 @@ if [[ "$require_capture_ack" -eq 1 ]]; then
   if [[ -n "${SDK_GATE_ACK_TEXT+x}" ]]; then
     ack_text="${SDK_GATE_ACK_TEXT}"
   else
-    ack_text="$(git log "${BASE_REF}..HEAD" --format=%B 2>/dev/null || true)"
+    ack_text="$(read_branch_messages)" || exit 1
   fi
   if printf '%s' "$ack_text" | grep -qiE "\b${ACK_TOKEN}\b"; then
     echo "sdk-bump-gate: capture-gate ack present (\`${ACK_TOKEN}\`) — proceeding on the maintainer attestation."

--- a/apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts
@@ -92,7 +92,8 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // --allowedTools consumes the prompt as a tool name without the end-of-
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
-// Mirrors .github/workflows/scheduled-agent-native-audit.yml `claude_args`:
+// HISTORICAL GHA contract (scheduled-agent-native-audit.yml, removed by the
+// TR9 Inngest migration — this file is now authoritative, there is no mirror):
 //   --model claude-opus-5
 //   --max-turns 50
 //   --allowedTools Bash,Read,Write,Edit,Glob,Grep,Task

--- a/apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-agent-native-audit.ts
@@ -27,7 +27,7 @@
 //     outer turns is the per-skill envelope.
 //   - --allowedTools adds Task (for sub-agent dispatch); drops WebSearch
 //     and WebFetch (audit is purely codebase-introspection).
-//   - --model claude-opus-4-8 (was sonnet-4-6) — the principle scoring is
+//   - --model claude-opus-5 (was sonnet-4-6) — the principle scoring is
 //     opus-class reasoning, mirroring scheduled-bug-fixer's escalation.
 //   - Cadence: monthly 15th 09:00 UTC (was weekly Monday).
 //   - Skip-window: 30 days (was 6) — monthly cadence + stable findings
@@ -93,7 +93,7 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
 // Mirrors .github/workflows/scheduled-agent-native-audit.yml `claude_args`:
-//   --model claude-opus-4-8
+//   --model claude-opus-5
 //   --max-turns 50
 //   --allowedTools Bash,Read,Write,Edit,Glob,Grep,Task
 const CLAUDE_CODE_FLAGS = [

--- a/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
+++ b/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
@@ -103,7 +103,8 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // --allowedTools consumes the prompt as a tool name without the end-of-
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
-// Mirrors .github/workflows/scheduled-competitive-analysis.yml `claude_args`:
+// HISTORICAL GHA contract (scheduled-competitive-analysis.yml, removed by the
+// TR9 Inngest migration — this file is now authoritative, there is no mirror):
 //   --model claude-opus-5
 //   --max-turns 45
 //   --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task

--- a/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
+++ b/apps/web-platform/server/inngest/functions/cron-competitive-analysis.ts
@@ -25,7 +25,7 @@
 // is added in the same PR (apps/web-platform/infra/sentry/cron-monitors.tf).
 //
 // SHAPE DIFF vs PR-7 cron-roadmap-review.ts:
-//   - --model claude-opus-4-8 — competitive-analysis
+//   - --model claude-opus-5 — competitive-analysis
 //     skill uses opus for cross-tier landscape reasoning.
 //   - --max-turns 45 (was 40) — multi-tier fan-out (tiers 0,3) plus the
 //     follow-up PR creation step needs slightly more headroom.
@@ -104,7 +104,7 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
 // Mirrors .github/workflows/scheduled-competitive-analysis.yml `claude_args`:
-//   --model claude-opus-4-8
+//   --model claude-opus-5
 //   --max-turns 45
 //   --allowedTools Bash,Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Task
 const CLAUDE_CODE_FLAGS = [

--- a/apps/web-platform/server/inngest/functions/cron-growth-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-growth-audit.ts
@@ -61,7 +61,7 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // --allowedTools consumes the prompt as a tool name without the end-of-
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
-// NOTE: claude-opus-4-8 model for deep multi-step growth audit.
+// NOTE: claude-opus-5 model for deep multi-step growth audit.
 //
 // #4993 — headless /soleur:* skill resolution (fleet fix mirroring #4987 /
 // PR #4989): `--plugin-dir plugins/soleur` registers the plugin (clone's tracked tree — #5091) under

--- a/apps/web-platform/server/inngest/functions/cron-legal-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-legal-audit.ts
@@ -22,7 +22,7 @@
 // is added in the same PR (apps/web-platform/infra/sentry/cron-monitors.tf).
 //
 // SHAPE DIFF vs PR-7 cron-roadmap-review.ts:
-//   - --model claude-opus-4-8 — legal-audit skill
+//   - --model claude-opus-5 — legal-audit skill
 //     uses opus for cross-document consistency reasoning.
 //   - --max-turns 60 (was 40) — multi-document audit fans out across
 //     jurisdictions (US, EU/GDPR, UK).
@@ -97,7 +97,7 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
 // Mirrors .github/workflows/scheduled-legal-audit.yml `claude_args`:
-//   --model claude-opus-4-8
+//   --model claude-opus-5
 //   --max-turns 60
 //   --allowedTools Bash,Read,Write,Edit,Glob,Grep,Task
 const CLAUDE_CODE_FLAGS = [

--- a/apps/web-platform/server/inngest/functions/cron-legal-audit.ts
+++ b/apps/web-platform/server/inngest/functions/cron-legal-audit.ts
@@ -96,7 +96,8 @@ export { KILL_ESCALATION_MS } from "./_cron-claude-eval-substrate";
 // --allowedTools consumes the prompt as a tool name without the end-of-
 // options marker). The prompt is the SOLE positional argument after `--`.
 //
-// Mirrors .github/workflows/scheduled-legal-audit.yml `claude_args`:
+// HISTORICAL GHA contract (scheduled-legal-audit.yml, removed by the TR9
+// Inngest migration — this file is now authoritative, there is no mirror):
 //   --model claude-opus-5
 //   --max-turns 60
 //   --allowedTools Bash,Read,Write,Edit,Glob,Grep,Task

--- a/apps/web-platform/server/inngest/model-tiers.ts
+++ b/apps/web-platform/server/inngest/model-tiers.ts
@@ -9,20 +9,20 @@
 // Two workload classes:
 //   EXECUTION_MODEL (sonnet) — the execution-class crons that do bounded,
 //     well-scoped automation (bug-fixer, triage, content, digests, etc.).
-//   AUDIT_MODEL (opus-4-7)   — the deep-audit crons that need stronger
+//   AUDIT_MODEL (opus-5)     — the deep-audit crons that need stronger
 //     multi-step reasoning (agent-native-audit, competitive-analysis,
 //     growth-audit, legal-audit, ux-audit).
 //
 // PURE SSOT EXTRACTION — no model assignment changes. Every cron keeps the
-// model it has today. Per ADR-053, re-tiering a cron (e.g. sweeping the
-// audit crons up to opus-4-8, or a cron down to haiku) is a separate
+// model it has today. Per ADR-053, re-tiering a cron (e.g. moving an
+// execution cron up to the audit tier, or a cron down to haiku) is a separate
 // clo-attestation-class model-bump PR (with action-pin sync per learning
 // 2026-04-18) and is explicitly out of scope here. `cron-weekly-release-
 // digest.ts` self-identifies as never-downgrade-shaped; its sonnet pin is
 // preserved via EXECUTION_MODEL and its rationale comment stays in place.
 //
 // Mixed alias/dated convention (do NOT normalize): `claude-sonnet-5` and
-// `claude-opus-4-8` are aliases (alias == dated, no separate dated ID),
+// `claude-opus-5` are aliases (alias == dated, no separate dated ID),
 // while `claude-haiku-4-5-20251001` (imported transitively via constants)
 // is the dated form. A future cleanup must preserve the dated haiku literal
 // byte-for-byte.
@@ -41,5 +41,5 @@ import { SONNET_MODEL } from "./leader-prompts/constants";
 /** Execution-class crons run on sonnet. Imported, not re-declared (FR3 — no second SSOT). */
 export const EXECUTION_MODEL = SONNET_MODEL;
 
-/** Deep-audit crons run on opus-4-7. Pinned exactly; re-tiering is out of scope (ADR-053). */
-export const AUDIT_MODEL = "claude-opus-4-8" as const;
+/** Deep-audit crons run on opus-5. Pinned exactly; re-tiering is out of scope (ADR-053). */
+export const AUDIT_MODEL = "claude-opus-5" as const;

--- a/apps/web-platform/server/inngest/model-tiers.ts
+++ b/apps/web-platform/server/inngest/model-tiers.ts
@@ -2,7 +2,8 @@
 //
 // Single source of truth for the Anthropic model IDs the scheduled crons
 // and ship-merge event hand to the `claude` CLI via argv. Centralizes the
-// ~17 inline sonnet / opus-4-7 model-ID literals that were
+// ~17 inline sonnet / opus-4-7 model-ID literals (the pre-#5106 landscape —
+// HISTORICAL, do not re-pin at a model launch) that were
 // scattered across `functions/*.ts` (#5106; consolidation point named by
 // ADR-053 line 38). Registry shape follows ADR-034 (frozen `as const`).
 //
@@ -13,8 +14,8 @@
 //     multi-step reasoning (agent-native-audit, competitive-analysis,
 //     growth-audit, legal-audit, ux-audit).
 //
-// PURE SSOT EXTRACTION — no model assignment changes. Every cron keeps the
-// model it has today. Per ADR-053, re-tiering a cron (e.g. moving an
+// PURE SSOT EXTRACTION (as of #5106) — that PR changed no model assignment;
+// every cron kept the model it had. Same-tier re-pins land here since. Per ADR-053, re-tiering a cron (e.g. moving an
 // execution cron up to the audit tier, or a cron down to haiku) is a separate
 // clo-attestation-class model-bump PR (with action-pin sync per learning
 // 2026-04-18) and is explicitly out of scope here. `cron-weekly-release-

--- a/apps/web-platform/test/server/inngest/model-tiers.test.ts
+++ b/apps/web-platform/test/server/inngest/model-tiers.test.ts
@@ -2,8 +2,9 @@
 //
 // Guards the SSOT extraction of the per-cron Anthropic model-ID literals
 // into `server/inngest/model-tiers.ts`:
-//   (a) no-raw-literal: zero quoted "claude-sonnet-5" / "claude-opus-4-8"
-//       string literals on NON-comment code lines across functions/*.ts
+//   (a) no-raw-literal: zero quoted EXECUTION_MODEL / AUDIT_MODEL string
+//       literals on NON-comment code lines across functions/*.ts
+//       (the pattern is derived from those constants — see RAW_MODEL_LITERAL)
 //       (the verbatim `--model …` mirrors of GHA `claude_args` live in
 //       comments on purpose and are excluded by comment-stripping).
 //   (b) sanity: the walk found >= 17 cron/event files (an empty walk
@@ -43,7 +44,13 @@ import { MODEL_PRICING } from "@/server/inngest/functions/agent-on-spawn-request
 
 const FUNCTIONS_DIR = join(__dirname, "../../../server/inngest/functions");
 
-const RAW_MODEL_LITERAL = /"claude-sonnet-5"|"claude-opus-4-8"/;
+// DERIVED from the SSOT constants, never restated. A hand-written copy of the
+// model ID here is a second, unsynchronized pin: when the registry moves and
+// this does not, the walk silently scans for a literal that no longer exists
+// and the guard passes vacuously (green, not red — so the "config swaps red
+// the coupled fixtures" heuristic cannot catch it). #6934 shipped exactly that
+// miss. Model IDs are [a-z0-9-] only, so no regex escaping is needed.
+const RAW_MODEL_LITERAL = new RegExp(`"${SONNET_MODEL}"|"${AUDIT_MODEL}"`);
 
 /**
  * Blank out comment lines so the verbatim `--model claude-…` GHA-mirror
@@ -85,6 +92,20 @@ describe("model-tiers registry — #5106", () => {
       });
     }
     expect(offenders).toEqual([]);
+  });
+
+  // Non-vacuity control for the walk above. The offenders-are-empty assertion
+  // is satisfied both by "the guard works" and by "the guard scans for a
+  // literal that cannot occur" — the #6934 failure. Pin that the pattern
+  // actually matches a synthesized positive for BOTH tiers, so a stale or
+  // mis-derived RAW_MODEL_LITERAL fails loudly instead of passing green.
+  it("RAW_MODEL_LITERAL matches a synthesized literal for both tiers", () => {
+    expect(RAW_MODEL_LITERAL.test(`const m = "${AUDIT_MODEL}";`)).toBe(true);
+    expect(RAW_MODEL_LITERAL.test(`const m = "${EXECUTION_MODEL}";`)).toBe(true);
+    // and does not match an unrelated model ID
+    expect(RAW_MODEL_LITERAL.test(`const m = "claude-haiku-4-5-20251001";`)).toBe(
+      false,
+    );
   });
 
   it("MODEL_PRICING keys exactly equal the AnthropicModelId union members", () => {

--- a/apps/web-platform/test/server/inngest/model-tiers.test.ts
+++ b/apps/web-platform/test/server/inngest/model-tiers.test.ts
@@ -16,7 +16,7 @@
 //       reachable through that lookup, widen this assertion + add the
 //       opus pricing entry then.
 //   (d) identity: EXECUTION_MODEL === SONNET_MODEL and
-//       AUDIT_MODEL === "claude-opus-4-8".
+//       AUDIT_MODEL === "claude-opus-5".
 
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
@@ -93,13 +93,13 @@ describe("model-tiers registry — #5106", () => {
     expect(pricingKeys).toEqual(unionMembers);
   });
 
-  it("EXECUTION_MODEL is the sonnet SSOT and AUDIT_MODEL is opus-4-8", () => {
+  it("EXECUTION_MODEL is the sonnet SSOT and AUDIT_MODEL is opus-5", () => {
     expect(EXECUTION_MODEL).toBe(SONNET_MODEL);
     expect(EXECUTION_MODEL).toBe("claude-sonnet-5");
     // Intentional model-bump tripwire: AUDIT_MODEL has no SSOT constant to
     // alias (opus is not an AnthropicModelId member), so it is pinned to the
-    // literal here. A deliberate re-tier (e.g. opus-4-7 → opus-4-8, a separate
+    // literal here. A deliberate re-tier (e.g. opus-4-8 → opus-5, a separate
     // model-bump PR per ADR-053) must update this assertion in lockstep.
-    expect(AUDIT_MODEL).toBe("claude-opus-4-8");
+    expect(AUDIT_MODEL).toBe("claude-opus-5");
   });
 });

--- a/knowledge-base/project/learnings/2026-04-18-action-pin-sync-with-model-bump.md
+++ b/knowledge-base/project/learnings/2026-04-18-action-pin-sync-with-model-bump.md
@@ -65,8 +65,15 @@ Audit command:
 # Current tip
 gh api repos/anthropics/claude-code-action/releases --jq '.[0] | "\(.tag_name) \(.published_at)"'
 
-# Resolve your pin to a commit date
-gh api repos/anthropics/claude-code-action/git/commits/<PIN-SHA> --jq '.committer.date'
+# Resolve your pin's date.
+# claude-code-action pins are ANNOTATED TAG objects, so git/commits/<SHA>
+# returns 404 and commits/<SHA> returns 422 — the git/commits form printed here
+# until 2026-07-24 never worked. A pin produced by pin-github-action/Dependabot
+# IS a plain commit SHA, where git/tags 404s instead; try both, the 404 is the
+# discriminator.
+gh api repos/anthropics/claude-code-action/git/tags/<PIN-SHA> --jq '"\(.tag) \(.tagger.date)"' \
+  || gh api repos/anthropics/claude-code-action/commits/<PIN-SHA> --jq '.commit.committer.date'
+# → v1.0.161 2026-06-30T17:58:29Z
 ```
 
 If the pin is more than ~3 weeks older than current tip AND the PR bumps a

--- a/plugins/soleur/skills/agent-native-architecture/references/agent-execution-patterns.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/agent-execution-patterns.md
@@ -230,13 +230,13 @@ Different agents need different intelligence levels. Use the cheapest model that
 enum ModelTier {
     case fast      // claude-haiku-4-5: Quick, cheap, simple tasks
     case balanced  // claude-sonnet-5: Good balance for most tasks
-    case powerful  // claude-opus-4-8: Complex reasoning, synthesis
+    case powerful  // claude-opus-5: Complex reasoning, synthesis
 
     var modelId: String {
         switch self {
         case .fast: return "claude-haiku-4-5"
         case .balanced: return "claude-sonnet-5"
-        case .powerful: return "claude-opus-4-8"
+        case .powerful: return "claude-opus-5"
         }
     }
 }

--- a/plugins/soleur/skills/agent-native-architecture/references/agent-native-testing.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/agent-native-testing.md
@@ -484,7 +484,7 @@ Agent tests cost API tokens. Strategies to manage:
 ```typescript
 // Use smaller models for basic tests
 const testConfig = {
-  model: process.env.CI ? "claude-haiku-4-5" : "claude-opus-4-8",
+  model: process.env.CI ? "claude-haiku-4-5" : "claude-opus-5",
   maxTokens: 500,  // Limit output length
 };
 

--- a/plugins/soleur/skills/agent-native-architecture/references/architecture-patterns.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/architecture-patterns.md
@@ -425,7 +425,7 @@ Different agents need different intelligence levels. Use the cheapest model that
 enum ModelTier {
     case fast      // claude-haiku-4-5: Quick, cheap, simple tasks
     case balanced  // claude-sonnet-5: Good balance for most tasks
-    case powerful  // claude-opus-4-8: Complex reasoning, synthesis
+    case powerful  // claude-opus-5: Complex reasoning, synthesis
 }
 
 struct AgentConfig {

--- a/plugins/soleur/skills/agent-native-architecture/references/mobile-patterns.md
+++ b/plugins/soleur/skills/agent-native-architecture/references/mobile-patterns.md
@@ -464,13 +464,13 @@ Use the cheapest model that achieves the outcome:
 enum ModelTier {
     case fast      // claude-haiku-4-5: ~$1/1M input, $5/1M output
     case balanced  // claude-sonnet-5: ~$3/1M input, $15/1M output
-    case powerful  // claude-opus-4-8: ~$5/1M input, $25/1M output
+    case powerful  // claude-opus-5: ~$5/1M input, $25/1M output
 
     var modelId: String {
         switch self {
         case .fast: return "claude-haiku-4-5"
         case .balanced: return "claude-sonnet-5"
-        case .powerful: return "claude-opus-4-8"
+        case .powerful: return "claude-opus-5"
         }
     }
 }

--- a/plugins/soleur/skills/dspy-ruby/references/providers.md
+++ b/plugins/soleur/skills/dspy-ruby/references/providers.md
@@ -50,7 +50,7 @@ end
 ```ruby
 DSPy.configure do |c|
   # Claude Opus 4.7 (most intelligent, best for agents and coding)
-  c.lm = DSPy::LM.new('anthropic/claude-opus-4-8',
+  c.lm = DSPy::LM.new('anthropic/claude-opus-5',
     api_key: ENV['ANTHROPIC_API_KEY'])
 
   # Claude Sonnet 4.6 (best speed/intelligence balance)

--- a/plugins/soleur/skills/dspy-ruby/references/providers.md
+++ b/plugins/soleur/skills/dspy-ruby/references/providers.md
@@ -7,7 +7,7 @@ DSPy.rb provides unified support across multiple LLM providers through adapter g
 ### Provider Overview
 
 - **OpenAI**: GPT-4, GPT-4o, GPT-4o-mini, GPT-3.5-turbo
-- **Anthropic**: Claude 4.x family (Opus 4.7, Sonnet 4.6, Haiku 4.5)
+- **Anthropic**: Claude Opus 5, Sonnet 5, Haiku 4.5
 - **Google Gemini**: Gemini 1.5 Pro, Gemini 1.5 Flash, other versions
 - **Ollama**: Local model support via OpenAI compatibility layer
 - **OpenRouter**: Unified multi-provider API for 200+ models
@@ -49,11 +49,11 @@ end
 
 ```ruby
 DSPy.configure do |c|
-  # Claude Opus 4.7 (most intelligent, best for agents and coding)
+  # Claude Opus 5 (most intelligent, best for agents and coding)
   c.lm = DSPy::LM.new('anthropic/claude-opus-5',
     api_key: ENV['ANTHROPIC_API_KEY'])
 
-  # Claude Sonnet 4.6 (best speed/intelligence balance)
+  # Claude Sonnet 5 (best speed/intelligence balance)
   c.lm = DSPy::LM.new('anthropic/claude-sonnet-5',
     api_key: ENV['ANTHROPIC_API_KEY'])
 
@@ -255,8 +255,8 @@ end
 
 ### Anthropic
 
-- Claude Sonnet 4.6 offers the best speed/intelligence balance
-- Claude Opus 4.7 is the most intelligent for agents and coding
+- Claude Sonnet 5 offers the best speed/intelligence balance
+- Claude Opus 5 is the most intelligent for agents and coding
 - Excellent for complex reasoning and analysis
 - Strong safety features and helpful outputs
 - Requires base64 for images (no URL support)

--- a/plugins/soleur/skills/eval-harness/models.generated.json
+++ b/plugins/soleur/skills/eval-harness/models.generated.json
@@ -1,5 +1,5 @@
 [
-  "anthropic:messages:claude-opus-4-8",
+  "anthropic:messages:claude-opus-5",
   "anthropic:messages:claude-sonnet-5",
   "anthropic:messages:claude-haiku-4-5-20251001"
 ]

--- a/plugins/soleur/skills/eval-harness/test/gen-models.test.sh
+++ b/plugins/soleur/skills/eval-harness/test/gen-models.test.sh
@@ -33,6 +33,9 @@ if [[ ! -f "$OUT" ]]; then
   echo "FAIL: $OUT is missing from the repo"; exit 1
 fi
 _committed="$(mktemp)"
+# Single owning trap (ADR-129) — covers every exit path below, including the
+# STALE failure and any unexpected die between allocation and the diff.
+trap 'rm -f "$_committed"' EXIT
 cp "$OUT" "$_committed"
 
 bash "$GEN"
@@ -41,11 +44,9 @@ if ! diff -q "$_committed" "$OUT" >/dev/null 2>&1; then
   echo "FAIL: $OUT is STALE — it differs from what gen-models.sh produces."
   echo "      Run: bash $GEN   (and commit the result)"
   diff -u "$_committed" "$OUT" || true
-  rm -f "$_committed"
   exit 1
 fi
 echo "ok   committed artifact matches the generator (no drift)"
-rm -f "$_committed"
 
 check() {
   local needle="anthropic:messages:$1"

--- a/plugins/soleur/skills/eval-harness/test/gen-models.test.sh
+++ b/plugins/soleur/skills/eval-harness/test/gen-models.test.sh
@@ -24,12 +24,28 @@ for v in "$SONNET" "$HAIKU" "$OPUS"; do
   if [[ -z "$v" ]]; then echo "FAIL: could not read a model ID from the registry"; exit 1; fi
 done
 
-# Run the generator.
+# COMMITTED-ARTIFACT PARITY. Running the generator in place and then asserting
+# against what it just wrote can only prove the generator is self-consistent —
+# it silently CLOBBERS a hand-edit instead of reporting it, so the checked-in
+# file could drift from the registry indefinitely with this test green. Snapshot
+# first, regenerate, and diff: the committed file must already be correct.
+if [[ ! -f "$OUT" ]]; then
+  echo "FAIL: $OUT is missing from the repo"; exit 1
+fi
+_committed="$(mktemp)"
+cp "$OUT" "$_committed"
+
 bash "$GEN"
 
-if [[ ! -f "$OUT" ]]; then
-  echo "FAIL: $OUT was not produced"; exit 1
+if ! diff -q "$_committed" "$OUT" >/dev/null 2>&1; then
+  echo "FAIL: $OUT is STALE — it differs from what gen-models.sh produces."
+  echo "      Run: bash $GEN   (and commit the result)"
+  diff -u "$_committed" "$OUT" || true
+  rm -f "$_committed"
+  exit 1
 fi
+echo "ok   committed artifact matches the generator (no drift)"
+rm -f "$_committed"
 
 check() {
   local needle="anthropic:messages:$1"

--- a/plugins/soleur/skills/model-launch-review/SKILL.md
+++ b/plugins/soleur/skills/model-launch-review/SKILL.md
@@ -63,7 +63,10 @@ Only item 1 is auto-applied. Items 2–5 are reported in the PR body for human s
 
    ```bash
    gh api repos/anthropics/claude-code-action/releases --jq '.[0] | "\(.tag_name) \(.published_at)"'
-   gh api repos/anthropics/claude-code-action/git/commits/<PIN-SHA> --jq '.committer.date'
+   # claude-code-action pins are ANNOTATED TAG objects, not commits: git/commits/<SHA>
+   # returns 404 and commits/<SHA> returns 422. Resolve via git/tags, which yields the
+   # tag name + date in one call (2026-07-24 — the git/commits form never worked here).
+   gh api repos/anthropics/claude-code-action/git/tags/<PIN-SHA> --jq '"\(.tag) \(.tagger.date)"'
    ```
 
    Bump a pin only when a `--model` swap lands in the same workflow (#2540).

--- a/plugins/soleur/skills/model-launch-review/SKILL.md
+++ b/plugins/soleur/skills/model-launch-review/SKILL.md
@@ -24,13 +24,14 @@ token. A bot-token PR does not trigger CI or CLA checks, defeating the "CI-gated
 Run this skill interactively. Headless/cron contexts must file an **issue** (the detection
 step), not a PR.
 
-## Checklist (5 items) — auto-fix-vs-flag matrix
+## Checklist (6 items) — auto-fix-vs-flag matrix
 
 | # | Item | Disposition | Surface |
 |---|------|-------------|---------|
 | 1 | **Model-ID swaps** | **AUTO-FIX** | config-class files (server SDK call sites, Inngest `cron-*.ts`, `leader-prompts/constants.ts`, workflow `--model`, skill reference docs) — never test fixtures, archives, `knowledge-base/**`, or community digests |
 | 2 | **claude-code-action pin freshness** | flag-only | `.github/workflows/*.yml` pins; auto-bump ONLY when coupled to a `--model` swap in the same workflow (#2540 invariant) |
-| 3 | **Thinking-API shape** | flag-only (no-op v1) | carried by the claude-code-action pin's embedded SDK; no `thinking`/`output_config` params in config today |
+| 2b | **Pinned `claude-code` CLI knows the new model** | flag-only (**blocks the swap**) | `apps/web-platform/package.json` + `Dockerfile`. The CLI carries a BUNDLED per-model table; an absent ID is treated as a garbage ID and silently gets **half** the `max_tokens` (measured 64000 → 32000, #6934). Invisible to the ID sweep, `tsc`, and the suite — argv is well-formed and the run succeeds |
+| 3 | **Thinking-API shape** | flag-only | Config sets no `thinking`/`output_config`, but the **CLI injects both itself** off its bundled table (measured: `thinking:{type:"adaptive"}`, `effort:"high"`). So "no params in config" is NOT "defaults apply" — item 2b is what actually moves this |
 | 4 | **Pricing-table drift** | flag-only | `agent-on-spawn-requested.ts` `MODEL_PRICING` (billing constant — never auto-edit); compare vs the `claude-api` source-of-truth |
 | 5 | **Tier-map re-evaluation** | flag-only | cron model literals + ADR-053 / `plugins/soleur/AGENTS.md` policy vs new pricing; `workflow-model-pins.test.ts` `PIN_ALLOWLIST` is a don't-mutate invariant; also run `gh issue list --state open -L 200 --search "deferred model OR pricing"` for dormant work |
 
@@ -45,10 +46,26 @@ Only item 1 is auto-applied. Items 2–5 are reported in the PR body for human s
    ```
 
 2. **Resolve the current landscape from authoritative sources** — never memory. Read the
-   `claude-api` skill model table + the official Anthropic models docs. If a new model
-   shipped in an existing tier (the next Sonnet/Opus/etc.), add a
-   `"<superseded-id>=<current-id>"` entry to the `AUTOFIX_PAIRS` array in `audit-models.sh`
-   (each stale id maps to its OWN same-tier target, so tiers coexist).
+   `claude-api` skill model table plus the official docs (the `claude-api` skill is bundled,
+   not vendored, so cite the URLs directly — models:
+   `https://platform.claude.com/docs/en/about-claude/models/overview.md`, pricing:
+   `https://platform.claude.com/docs/en/about-claude/pricing.md`). If a new model shipped in
+   an existing tier, do BOTH:
+   - **add** a `"<superseded-id>=<current-id>"` entry to `AUTOFIX_PAIRS` in `audit-models.sh`, and
+   - **retarget** every existing same-tier pair's RHS to the new current id.
+
+   The second step is not optional. `--fix` applies pairs sequentially, so a CHAINED map
+   (`4-7=4-8` left in place alongside `4-8=5`) is order-dependent and lands files on an
+   intermediate id, which `--detect` then re-flags forever — a permanently-red drift cron
+   auto-filing issues it cannot fix. `assert_single_hop` enforces this (exit 78) and
+   `model-launch-review.test.ts` pins it, so a chained table fails fast rather than silently.
+
+   Then verify item 2b: the new ID must appear in the **pinned** `@anthropic-ai/claude-code`
+   bundle (`[2b]` in the audit output). If it reports DRIFT, bump the pin in
+   `apps/web-platform/package.json` AND the `Dockerfile` global, regenerate **both**
+   lockfiles (see the bun.lock sharp edge below), and re-run. Grep the bundle with `grep -a`
+   — the linux-x64 CLI is a compiled binary and a text-mode grep reports zero hits for
+   EVERY id, a null result that reads exactly like a real one.
 
 3. **Auto-fix** model-ID swaps (mechanical; allowlist + deletion guard; never `git add -A`):
 
@@ -63,11 +80,21 @@ Only item 1 is auto-applied. Items 2–5 are reported in the PR body for human s
 
    ```bash
    gh api repos/anthropics/claude-code-action/releases --jq '.[0] | "\(.tag_name) \(.published_at)"'
-   # claude-code-action pins are ANNOTATED TAG objects, not commits: git/commits/<SHA>
-   # returns 404 and commits/<SHA> returns 422. Resolve via git/tags, which yields the
-   # tag name + date in one call (2026-07-24 — the git/commits form never worked here).
-   gh api repos/anthropics/claude-code-action/git/tags/<PIN-SHA> --jq '"\(.tag) \(.tagger.date)"'
+   # TODAY's pins are ANNOTATED TAG objects: git/commits/<SHA> returns 404 and
+   # commits/<SHA> returns 422, so git/tags is the resolver (the git/commits form
+   # printed here until 2026-07-24 never worked). This is a property of how that repo
+   # cuts releases, NOT of pinning in general — a pin produced by pin-github-action or
+   # Dependabot is a plain COMMIT sha, where git/tags 404s instead. Try both; the 404
+   # is the discriminator. `.tagger.date` is the TAG date (correct for freshness), not
+   # the underlying commit's date — do not "correct" it to the latter.
+   gh api repos/anthropics/claude-code-action/git/tags/<PIN-SHA> --jq '"\(.tag) \(.tagger.date)"' \
+     || gh api repos/anthropics/claude-code-action/commits/<PIN-SHA> --jq '.commit.committer.date'
+   # → v1.0.161 2026-06-30T17:58:29Z
    ```
+
+   `audit-models.sh` now computes this itself (`[2]` in the audit output) and prints an
+   explicit `UNKNOWN` when `gh` is missing or unauthenticated — an unreachable API is
+   never a freshness pass.
 
    Bump a pin only when a `--model` swap lands in the same workflow (#2540).
 

--- a/plugins/soleur/skills/model-launch-review/scripts/audit-models.sh
+++ b/plugins/soleur/skills/model-launch-review/scripts/audit-models.sh
@@ -35,10 +35,14 @@ ROOT="${ROOT%/}"   # normalize: trailing slash breaks rel() prefix-strip
 
 # --- current landscape — update at each model launch ---
 # Each superseded id maps to the CURRENT same-tier id as "<stale>=<current>".
-# Add a pair when a new model ships in an existing tier (the next Sonnet/Opus);
-# `--fix` rewrites each stale id to ITS OWN target, so multiple tiers coexist.
-# Older families (claude-3, dated 2025 ids) stay flag-only (too old for a blind
-# swap). Source of truth for current ids: the claude-api skill table + docs.
+# At each launch: (1) ADD a pair for the newly-superseded id, AND (2) RETARGET
+# every existing same-tier pair's RHS to the new current id. Step 2 is not
+# optional — `--fix` applies pairs sequentially, so a CHAINED map
+# (4-7=4-8 alongside 4-8=5) is order-dependent and lands on a stale id.
+# The SINGLE-HOP INVARIANT below enforces this mechanically: no target may
+# also appear as a source. Source of truth for current ids: the claude-api
+# skill table + https://platform.claude.com/docs/en/about-claude/models/overview.md
+# (pricing: https://platform.claude.com/docs/en/about-claude/pricing.md).
 AUTOFIX_PAIRS=(
   "claude-opus-4-8=claude-opus-5"
   "claude-opus-4-7=claude-opus-5"
@@ -46,6 +50,28 @@ AUTOFIX_PAIRS=(
   "claude-sonnet-4-6=claude-sonnet-5"
   "claude-sonnet-4-5=claude-sonnet-5"
 )
+
+# SINGLE-HOP INVARIANT (fail-fast). A convergent map rewrites every stale id
+# in ONE pass; if any RHS is also an LHS, `--fix` leaves files on an
+# intermediate id and `--detect` re-flags them forever (a permanently-red
+# drift cron that auto-files issues it cannot fix). Cheap to assert, so assert
+# it on every invocation rather than trusting the editor to have retargeted.
+assert_single_hop() {
+  local p from to q other
+  for p in "${AUTOFIX_PAIRS[@]}"; do
+    to="${p#*=}"
+    for q in "${AUTOFIX_PAIRS[@]}"; do
+      other="${q%%=*}"
+      if [[ "$to" == "$other" ]]; then
+        from="${p%%=*}"
+        echo "audit-models: NON-CONVERGENT AUTOFIX_PAIRS — '${from}' maps to '${to}', which is itself a source id." >&2
+        echo "  Retarget every same-tier pair directly to the current id (no chaining)." >&2
+        exit 78
+      fi
+    done
+  done
+}
+assert_single_hop
 # The stale ids (LHS of each pair), '|'-joined for grep.
 autofix_from_re() {
   local p out=""
@@ -59,25 +85,51 @@ DELETION_GUARD=20   # abort --fix if any file would lose more than this many lin
 # Path classes excluded from the config (auto-fix) surface. knowledge-base/** is
 # archival/historical prose (learnings, plans, brainstorms) — it never selects a
 # model at runtime, so a stale id there is not operational drift.
-EXCLUDE_RE='(/node_modules/|/\.git/|/\.next/|/test/|/__tests__/|/spike/|/archive/|knowledge-base/|/community/|\.test\.|\.spec\.|/model-launch-review/)'
+# `\.generated\.` keeps the sweeper out of generated artifacts: those have a
+# generator that reads the TS registry (eval-harness/scripts/gen-models.sh), and
+# a blind sed here would make the generator no longer the sole writer — exactly
+# the second-SSOT the generator's own header promises does not exist.
+EXCLUDE_RE='(/node_modules/|/\.git/|/\.next/|/test/|/__tests__/|/spike/|/archive/|knowledge-base/|/community/|\.test\.|\.spec\.|\.generated\.|/model-launch-review/)'
 
 # Collect config-class files containing any auto-fixable stale ID.
+# Returns 2 (and prints to stderr) if the scan itself failed. That distinction
+# is load-bearing: `|| true` alone swallows grep's error exit (>=2: unreadable
+# dir, bad regex) as indistinguishable from its no-match exit (1), so --detect
+# would report a confident "none — config model IDs are current" from a scan
+# that never ran. A detector that cannot tell "clean" from "could not look" is
+# the failure mode #5100 exists to prevent.
 collect_config_hits() {
-  local re
+  local re out rc
   re="$(autofix_from_re)"
-  grep -rEl "$re" "$ROOT" \
+  out="$(grep -rEl "$re" "$ROOT" \
     --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.next \
     --exclude-dir=test --exclude-dir=__tests__ --exclude-dir=spike --exclude-dir=archive \
     --exclude-dir=community \
-    --exclude='*.test.*' --exclude='*.spec.*' 2>/dev/null \
-    | grep -vE "$EXCLUDE_RE" || true
+    --exclude='*.test.*' --exclude='*.spec.*' 2>/dev/null)"
+  rc=$?
+  if (( rc >= 2 )); then
+    echo "audit-models: scan FAILED (grep rc=$rc) under '$ROOT' — refusing to report clean." >&2
+    return 2
+  fi
+  [[ -n "$out" ]] || return 0
+  printf '%s\n' "$out" | grep -vE "$EXCLUDE_RE" || true
 }
 
 rel() { echo "${1#"$ROOT"/}"; }
 
 # ---------------- detect mode (cron) ----------------
 if [[ "$MODE" == "detect" ]]; then
-  mapfile -t hits < <(collect_config_hits)
+  # Capture to a temp file so collect_config_hits' EXIT CODE survives — a
+  # process substitution (`mapfile < <(...)`) discards it, which would let a
+  # failed scan fall through to the clean branch below.
+  _hits_tmp="$(mktemp)"
+  if ! collect_config_hits > "$_hits_tmp"; then
+    rm -f "$_hits_tmp"
+    echo "model-drift: UNKNOWN — scan failed; treat as un-run, not clean."
+    exit 1
+  fi
+  mapfile -t hits < "$_hits_tmp"
+  rm -f "$_hits_tmp"
   if [[ ${#hits[@]} -gt 0 ]]; then
     echo "model-drift: ${#hits[@]} config file(s) carry a stale model ID (auto-fixable via /soleur:model-launch-review)."
     for f in "${hits[@]}"; do echo "  - $(rel "$f")"; done
@@ -148,10 +200,60 @@ if [[ ${#pins[@]} -gt 0 ]]; then
   for f in "${pins[@]}"; do
     echo "    - $(rel "$f"): $(grep -oE 'claude-code-action@[a-f0-9]+ # v[0-9.]+' "$f" | head -1)"
   done
-  echo "  → resolve tip via: gh api repos/anthropics/claude-code-action/releases --jq '.[0].tag_name'"
+  # Compute the drift rather than telling a human to run a command
+  # (hr-no-dashboard-eyeball-pull-data-yourself). Best-effort: `gh` may be
+  # absent or unauthenticated in a cron sandbox, and that MUST read as
+  # UNKNOWN — never as "the pin is fresh".
+  if command -v gh >/dev/null 2>&1; then
+    _tip="$(gh api repos/anthropics/claude-code-action/releases --jq '.[0].tag_name' 2>/dev/null || true)"
+    _pin_sha="$(grep -ohE 'claude-code-action@[a-f0-9]{40}' "${pins[@]}" 2>/dev/null | head -1 | cut -d@ -f2)"
+    # These pins are annotated TAG objects, so git/tags resolves them. A pin
+    # produced by pin-github-action/Dependabot is a plain COMMIT sha, where
+    # git/tags 404s and commits/<sha> is the correct call — try both.
+    _pin_desc=""
+    if [[ -n "$_pin_sha" ]]; then
+      _pin_desc="$(gh api "repos/anthropics/claude-code-action/git/tags/$_pin_sha" --jq '"\(.tag) \(.tagger.date)"' 2>/dev/null \
+        || gh api "repos/anthropics/claude-code-action/commits/$_pin_sha" --jq '"(commit) \(.commit.committer.date)"' 2>/dev/null \
+        || true)"
+    fi
+    if [[ -n "$_tip" && -n "$_pin_desc" ]]; then
+      echo "    pinned: $_pin_desc    tip: $_tip"
+    else
+      echo "    pin freshness: UNKNOWN (GitHub API unreachable) — NOT a freshness pass."
+    fi
+  else
+    echo "    pin freshness: UNKNOWN (gh not on PATH) — NOT a freshness pass."
+  fi
   echo "    bump a pin ONLY when coupled to a --model swap in the same workflow (#2540 invariant)."
 else
   echo "  no claude-code-action pins under .github (or scanning a test root)."
+fi
+echo
+
+echo "[2b] pinned claude-code CLI knows the tier models (FLAG-ONLY)"
+# The `claude` CLI carries a BUNDLED per-model table. A model ID absent from it
+# is treated exactly like a garbage ID: the CLI silently falls back to HALF the
+# max_tokens (measured 64000 -> 32000, #6934), degrading every cron that passes
+# --model. This is invisible to the model-ID sweep, to tsc, and to the suite —
+# the argv is well-formed and the run succeeds. Grep the installed bundle when
+# present; absence of node_modules is UNKNOWN, never a pass.
+_cli_dir="$ROOT/apps/web-platform/node_modules/@anthropic-ai"
+if [[ -d "$_cli_dir" ]]; then
+  for _m in $(grep -ohE '"claude-(opus|sonnet|haiku)-[0-9a-z-]+"' \
+                "$ROOT/apps/web-platform/server/inngest/model-tiers.ts" \
+                "$ROOT/apps/web-platform/server/inngest/leader-prompts/constants.ts" 2>/dev/null \
+              | tr -d '"' | sort -u); do
+    # -a: the linux-x64 CLI is a compiled binary; a text-mode grep silently
+    # reports zero hits for EVERY id, including known-good ones (a null result
+    # that reads exactly like a real one).
+    if grep -raqF "$_m" "$_cli_dir" 2>/dev/null; then
+      echo "    ok      $_m present in the pinned CLI bundle"
+    else
+      echo "    DRIFT   $_m ABSENT from the pinned CLI bundle — bump @anthropic-ai/claude-code"
+    fi
+  done
+else
+  echo "    UNKNOWN (apps/web-platform/node_modules absent) — NOT a pass; run after install."
 fi
 echo
 

--- a/plugins/soleur/skills/model-launch-review/scripts/audit-models.sh
+++ b/plugins/soleur/skills/model-launch-review/scripts/audit-models.sh
@@ -40,8 +40,9 @@ ROOT="${ROOT%/}"   # normalize: trailing slash breaks rel() prefix-strip
 # Older families (claude-3, dated 2025 ids) stay flag-only (too old for a blind
 # swap). Source of truth for current ids: the claude-api skill table + docs.
 AUTOFIX_PAIRS=(
-  "claude-opus-4-7=claude-opus-4-8"
-  "claude-opus-4-6=claude-opus-4-8"
+  "claude-opus-4-8=claude-opus-5"
+  "claude-opus-4-7=claude-opus-5"
+  "claude-opus-4-6=claude-opus-5"
   "claude-sonnet-4-6=claude-sonnet-5"
   "claude-sonnet-4-5=claude-sonnet-5"
 )

--- a/plugins/soleur/skills/model-launch-review/scripts/audit-models.sh
+++ b/plugins/soleur/skills/model-launch-review/scripts/audit-models.sh
@@ -123,13 +123,14 @@ if [[ "$MODE" == "detect" ]]; then
   # process substitution (`mapfile < <(...)`) discards it, which would let a
   # failed scan fall through to the clean branch below.
   _hits_tmp="$(mktemp)"
+  # Single owning trap (ADR-129): the explicit rm below is the happy path, the
+  # trap covers a die between allocation and cleanup.
+  trap 'rm -f "$_hits_tmp"' EXIT
   if ! collect_config_hits > "$_hits_tmp"; then
-    rm -f "$_hits_tmp"
     echo "model-drift: UNKNOWN — scan failed; treat as un-run, not clean."
     exit 1
   fi
   mapfile -t hits < "$_hits_tmp"
-  rm -f "$_hits_tmp"
   if [[ ${#hits[@]} -gt 0 ]]; then
     echo "model-drift: ${#hits[@]} config file(s) carry a stale model ID (auto-fixable via /soleur:model-launch-review)."
     for f in "${hits[@]}"; do echo "  - $(rel "$f")"; done

--- a/plugins/soleur/skills/resolve-parallel/workflows/resolve-parallel.workflow.js
+++ b/plugins/soleur/skills/resolve-parallel/workflows/resolve-parallel.workflow.js
@@ -220,7 +220,7 @@ Steps (do them exactly; do NOT \`git stash\`, do NOT amend existing history):
 2. Stage the resolved files. Prefer staging the specific paths that changed (the resolvers reported these files): ${fileList.length ? fileList.join(', ') : '(none reported — fall back to `git add -u` for tracked modifications only)'}. Do NOT \`git add -A\` blindly.
 3. If the current branch is the default branch (main/master), create a working branch first: \`git switch -c chore/resolve-todos\`. Otherwise commit on the current branch.
 4. Commit with a message summarizing the swept TODOs, e.g. "chore: resolve ${resolved.length} TODO comment(s) via parallel sweep". End the commit message body with the trailer:
-   Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+   Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
 5. ${doPush ? 'Push to remote: `git push -u origin HEAD`.' : 'Do NOT push (push disabled for this run); set pushed=false.'}
 6. Report: committed, pushed, branch, sha (short), note.`
 }

--- a/plugins/soleur/test/model-launch-review.test.ts
+++ b/plugins/soleur/test/model-launch-review.test.ts
@@ -16,7 +16,7 @@ const SKILL_DIR = resolve(REPO_ROOT, "plugins/soleur/skills/model-launch-review"
 const SKILL_MD = resolve(SKILL_DIR, "SKILL.md");
 const AUDIT_SH = resolve(SKILL_DIR, "scripts/audit-models.sh");
 
-// Current model landscape (2026-06). The auditor flags anything NOT in this set
+// Current model landscape (2026-07). The auditor flags anything NOT in this set
 // that lives in a config-class path. Source of truth: claude-api skill table.
 const CURRENT_IDS = [
   "claude-opus-5",
@@ -24,6 +24,17 @@ const CURRENT_IDS = [
   "claude-haiku-4-5-20251001",
   "claude-fable-5",
 ];
+
+/** Parse AUTOFIX_PAIRS out of the script so tests are driven BY the table
+ * rather than restating a hand-picked member of it. */
+function parseAutofixPairs(): Array<[string, string]> {
+  const src = readFileSync(AUDIT_SH, "utf8");
+  const block = src.match(/AUTOFIX_PAIRS=\(([\s\S]*?)\)/);
+  if (!block) throw new Error("AUTOFIX_PAIRS block not found in audit-models.sh");
+  return [...block[1].matchAll(/"([^"=]+)=([^"]+)"/g)].map(
+    (m) => [m[1], m[2]] as [string, string],
+  );
+}
 
 function run(args: string[], root: string) {
   return spawnSync("bash", [AUDIT_SH, "--root", root, ...args], {
@@ -127,6 +138,11 @@ describe("model-launch-review no-silent-green (AC3)", () => {
     expect(r.stdout.toLowerCase()).toContain("pin");
     expect(r.stdout.toLowerCase()).toContain("pricing");
     expect(r.stdout.toLowerCase()).toContain("tier-map");
+    // ...and it must actually REPORT clean. The four headings above print
+    // unconditionally, so asserting only their presence passes identically on
+    // a DIRTY root — this test's name was a claim its assertions did not back.
+    // This line is what makes CURRENT_IDS[0] load-bearing.
+    expect(r.stdout).toContain("none — config model IDs are current.");
     rmSync(root, { recursive: true, force: true });
   });
 });
@@ -205,6 +221,65 @@ describe("model-launch-review multi-tier auto-fix (Sonnet 5 launch)", () => {
     expect(config).toContain("claude-sonnet-5");
     expect(config).not.toContain("claude-sonnet-4-6");
     rmSync(root, { recursive: true, force: true });
+  });
+
+  test("EVERY declared pair maps its stale id to its own target", () => {
+    // Population-of-one guard. The per-tier test below exercises ONE opus and
+    // ONE sonnet id, so a pair can be deleted from AUTOFIX_PAIRS with the whole
+    // suite green (proven: dropping the opus-4-8 pair — the one #6934 added —
+    // changed nothing). Drive the table itself so adding a pair without
+    // coverage is impossible.
+    const pairs = parseAutofixPairs();
+    expect(pairs.length).toBeGreaterThanOrEqual(5); // non-vacuity floor, not a pin
+
+    const root = mkdtempSync(join(tmpdir(), "mlr-allpairs-"));
+    const dir = join(root, "apps/web-platform/server/inngest/functions");
+    mkdirSync(dir, { recursive: true });
+    for (const [from] of pairs) {
+      writeFileSync(join(dir, `cron-${from}.ts`), `export const M = "${from}";\n`);
+    }
+    expect(run(["--fix"], root).status).toBe(0);
+    for (const [from, to] of pairs) {
+      const got = readFileSync(join(dir, `cron-${from}.ts`), "utf8");
+      expect(got).toContain(to);
+      expect(got).not.toContain(`"${from}"`);
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("AUTOFIX_PAIRS is single-hop and every target is a current id", () => {
+    const pairs = parseAutofixPairs();
+    const sources = new Set(pairs.map(([from]) => from));
+    for (const [from, to] of pairs) {
+      // Chaining (4-7=4-8 alongside 4-8=5) makes --fix order-dependent: files
+      // land on an intermediate id and --detect re-flags them forever.
+      expect(
+        sources.has(to),
+        `pair ${from}=${to} chains: '${to}' is itself a source id`,
+      ).toBe(false);
+      // A target that is not a current id means someone added a pair without
+      // retargeting the tier at launch time.
+      expect(CURRENT_IDS, `target '${to}' is not a current id`).toContain(to);
+    }
+  });
+
+  test("the script itself refuses to run on a non-convergent pair table", () => {
+    // Pin the guard's behavior, not just its presence: mutate a SANDBOX copy
+    // into a chained table and assert it exits 78 rather than silently
+    // producing a one-hop rewrite.
+    const sandbox = mkdtempSync(join(tmpdir(), "mlr-chain-"));
+    const copy = join(sandbox, "audit-models.sh");
+    const src = readFileSync(AUDIT_SH, "utf8").replace(
+      '"claude-opus-4-7=claude-opus-5"',
+      '"claude-opus-4-7=claude-opus-4-8"',
+    );
+    writeFileSync(copy, src);
+    const r = spawnSync("bash", [copy, "--root", sandbox, "--detect"], {
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(78);
+    expect(r.stderr).toContain("NON-CONVERGENT");
+    rmSync(sandbox, { recursive: true, force: true });
   });
 
   test("Opus and Sonnet stale ids each map to their OWN tier target in one run", () => {

--- a/plugins/soleur/test/model-launch-review.test.ts
+++ b/plugins/soleur/test/model-launch-review.test.ts
@@ -19,7 +19,7 @@ const AUDIT_SH = resolve(SKILL_DIR, "scripts/audit-models.sh");
 // Current model landscape (2026-06). The auditor flags anything NOT in this set
 // that lives in a config-class path. Source of truth: claude-api skill table.
 const CURRENT_IDS = [
-  "claude-opus-4-8",
+  "claude-opus-5",
   "claude-sonnet-5",
   "claude-haiku-4-5-20251001",
   "claude-fable-5",
@@ -159,7 +159,7 @@ describe("model-launch-review auto-fix safety (AC5, AC6)", () => {
       join(root, "apps/web-platform/server/inngest/functions/cron-fake-audit.ts"),
       "utf8",
     );
-    expect(config).toContain("claude-opus-4-8");
+    expect(config).toContain("claude-opus-5");
     expect(config).not.toContain("claude-opus-4-7");
     // excluded classes untouched
     const fixture = readFileSync(
@@ -214,8 +214,8 @@ describe("model-launch-review multi-tier auto-fix (Sonnet 5 launch)", () => {
     writeFileSync(join(dir, "cron-a.ts"), `export const M = "claude-opus-4-7";\n`);
     writeFileSync(join(dir, "cron-b.ts"), `export const M = "claude-sonnet-4-6";\n`);
     expect(run(["--fix"], root).status).toBe(0);
-    // Per-tier map: opus → opus-4-8, sonnet → sonnet-5 (not a single global target).
-    expect(readFileSync(join(dir, "cron-a.ts"), "utf8")).toContain("claude-opus-4-8");
+    // Per-tier map: opus → opus-5, sonnet → sonnet-5 (not a single global target).
+    expect(readFileSync(join(dir, "cron-a.ts"), "utf8")).toContain("claude-opus-5");
     expect(readFileSync(join(dir, "cron-b.ts"), "utf8")).toContain("claude-sonnet-5");
     rmSync(root, { recursive: true, force: true });
   });


### PR DESCRIPTION
Runs the per-release **model-launch-review** checklist for the Claude Opus 5 launch (2026-07-24), then fixes what a 10-agent review found — including two P1s that made the swap unsafe to merge.

Announcement: https://www.anthropic.com/news/claude-opus-5 · IDs and pricing verified live against `platform.claude.com`.

## Changelog

- Bumped the Inngest deep-audit tier from `claude-opus-4-8` to `claude-opus-5`.
- Bumped the pinned `claude-code` CLI so Opus 5 is a *known* model (without this the swap halves `max_tokens`).
- Restored the no-raw-literal SSOT guard, which the swap had silently disarmed.
- Hardened `audit-models.sh` (single-hop invariant, computed pin drift, CLI model-table check, no clean-from-a-failed-scan).

---

## Item 1 — model-ID swaps (AUTO-FIX, applied)

`AUTOFIX_PAIRS` maps `claude-opus-4-8|4-7|4-6 → claude-opus-5`; sonnet pairs unchanged.

`AUDIT_MODEL` in `model-tiers.ts` is the **only** runtime literal — the six crons that import it (`agent-native-audit`, `competitive-analysis`, `growth-audit`, `legal-audit`, `ux-audit`, `architecture-diagram-sync`) inherit it via the #5106 SSOT. Independently re-verified by three agents. `models.generated.json` was **regenerated** through `gen-models.sh`, not sed-patched.

### Why this is in scope (corrected)

An earlier draft argued price-parity ($5/$25, identical to Opus 4.8). That's true but it is **not** the authorization, and leaning on it would set a bad precedent for a launch where price moves. The actual basis is **ADR-053:41** — *"#5100 (`model-launch-review` skill) is the re-pin trigger for all three surfaces at each model release"* — plus the Pin-surface lifecycle row at ADR-053:38. ADR-053's *only* clo-attestation trigger is ADR-053:16 (changing the never-downgrade **allowlist**), which this PR does not touch. Precedent: `d27a10eff` performed the identical class of bump as an ordinary config PR.

### Disclosure: this PR narrows a policy clause

`model-tiers.ts:17-19` previously gave *"sweeping the audit crons up to opus-4-8"* as its example of a clo-attestation-class re-tier — i.e. an example naming approximately the operation this PR performs. It is rewritten to *"moving an execution cron up to the audit tier."* Flagging it explicitly rather than letting it ride as doc-drift cleanup, since it's a normative edit that benefits this PR's own scope classification. Justification: PR #5180 already performed the old example's operation with no attestation, so the example was falsified on `main` before this PR touched it.

---

## Two P1s found by review (both fixed)

### P1a — the swap silently disarmed the SSOT guard

`model-tiers.test.ts:46` held `RAW_MODEL_LITERAL = /"claude-sonnet-5"|"claude-opus-4-8"/`. Three of four occurrences in that file were updated; this one — the regex powering the *"no cron bypasses `AUDIT_MODEL`"* walk — was not. It then scanned for a literal that no longer exists.

**Proven:** a cron containing `export const POC_MODEL = "claude-opus-5"` (a direct SSOT bypass) left the suite **green**. Seven agents converged independently.

This class fails **green, not red**, so the skill's own *"config swaps red the coupled fixtures"* heuristic structurally cannot catch it, `--fix` excludes `/test/`, and `--detect` never sees it. Three safety nets, all silent.

Fixed by **deriving** the pattern from `SONNET_MODEL`/`AUDIT_MODEL` rather than restating it, plus a non-vacuity control asserting it matches a synthesized positive for both tiers. Re-verified: bypass file → 1 failed; removed → 5 passed.

### P1b — `claude-opus-5` was unknown to the pinned CLI

The `claude` CLI carries a **bundled per-model table**; an unknown ID gets a conservative fallback. Measured against the pinned 2.1.197 via a mock API:

| `--model` | in CLI table | `max_tokens` |
|---|---|---|
| `claude-opus-4-8` (before) | yes | 64000 |
| `claude-opus-5` (after) | **no** | **32000** |
| `zzz-garbage-model` | no | 32000 |

The swap made six production audit crons byte-for-byte indistinguishable from passing a garbage model ID, at half the output budget, against `--max-turns` budgets of 45–70. Invisible to the ID sweep, `tsc`, and the suite — the argv is well-formed and the run succeeds.

Fixed by bumping `@anthropic-ai/claude-code` 2.1.197 → **2.1.219** plus the `Dockerfile` global (separately skewed at 2.1.79). Re-probed: `claude-opus-5` → **64000**, matching controls, with the garbage ID still at 32000 as a negative control.

**A hypothesis that proved wrong:** I expected Opus 5's thinking-on-by-default to inflate token spend. It doesn't — Claude Code sets `thinking:{type:"adaptive"}` and `effort:"high"` explicitly on *both* models. Item 3's "no params in config" was true of config and false of runtime; SKILL.md is corrected.

**Lockfiles:** both regenerated per the #1174 sharp edge — `bun.lock` via `--minimum-release-age=0` (2.1.219 is 0 days old against a 3-day hold), then CI-parity proven with `bun install --frozen-lockfile` at exit 0. `minimumReleaseAge` gates *resolution*, not installation of an already-pinned entry.

**Scope correction:** an intermediate commit also bumped `claude-agent-sdk` 0.3.197 → 0.3.219. That was pattern-matching on paired version numbers, not a requirement; 0.3.219 changed the permission types and produced **141 `tsc` errors** across 10 test files. Reverted — the CLI is what carries the model table.

---

## Items 2–5 (flag-only) — and what got mechanized

**Item 2 — pin freshness: no bump.** Pinned `v1.0.161` (2026-06-30), tip `v1.0.182` (2026-07-24): 21 releases / 24 days. Per the #2540 invariant a pin moves only with a `--model` swap in the same workflow, and no workflow carries an opus model. The audit now **computes** this instead of printing a command, with an explicit `UNKNOWN` when `gh` is unreachable.

> The documented resolution command never worked: these pins are **annotated tag objects**, so `git/commits/<SHA>` 404s. Corrected to `git/tags/<SHA>` — with a `commits/` fallback, because a `pin-github-action`/Dependabot pin *is* a plain commit SHA where `git/tags` 404s instead. The same dead command survived in the `2026-04-18` learning that SKILL.md cites by date; also fixed.

**Item 2b (new) — the CLI must know the model.** The checklist had no row for this, which is how P1b got through. Now a real check.

**Item 4 — pricing drift: two pre-existing errors, deliberately not fixed here.**

| Key | Repo | Live (2026-07-24) | Effect |
|---|---|---|---|
| `claude-sonnet-5` | $3 / $15 | **$2 / $10** (intro → 2026-08-31) | over-attributes ~50%, self-corrects 2026-09-01 |
| `claude-haiku-4-5-20251001` | $0.8 / $4 | **$1 / $5** | under-attributes ~20% |

The haiku values are exactly the **retired Haiku 3.5** table — the wrong model's row, not rounding drift. It feeds both cap-enforcement layers, so those two agent classes let ~25% more real spend past the cap than intended, into `audit_byok_use`, which is **WORM** (migration 037 raises `P0001` on UPDATE/DELETE) — every mis-priced row is permanently uncorrectable and accrues daily.

Landing as its own PR immediately after this one: it's a billing constant with different risk, and given irreversibility I want it independently revertable rather than bundled with a toolchain bump. Opus needs no pricing row — `leaderModule.model` is the `sonnet|haiku` union, verified end-to-end.

**Item 5 — tier map: no re-tier.** Same tier, identical price. `EXECUTION_MODEL` and the `PIN_ALLOWLIST` invariant untouched.

### Two operational notes

- **Separate rate-limit bucket.** Opus 5 does not draw on the combined Opus 4.x pool. Six crons move to a bucket with no established headroom; per ADR-053 a 429 has no fallback.
- **Better Stack rollups split at the cutover.** The `SOLEUR_CLAUDE_COST` `GROUP BY model` query in `betterstack-log-query.md` is the only per-model spend aggregation, on a raw string with no ID mapping — it returns two rows for "the audit tier" from merge day. Org totals unaffected (identical per-token price).

---

## Verification

| Check | Result |
|---|---|
| `vitest run test/server/inngest` | 103 files, **2592 passed**, 0 failed |
| `bun test plugins/soleur/test` | **2238 passed**, 0 failed |
| `tsc --noEmit` | 0 errors |
| `shellcheck` (audit-models.sh) | clean |
| `semgrep` | 218 rules / 7 files, 0 findings (non-vacuity proven) |
| `audit-models.sh` / `--detect` | clean / exit 0 |
| CLI probe | opus-5 → 64000 (controls: 4-8 → 64000, garbage → 32000) |
| `gen-models.test.sh` | passes; negative control (corrupted artifact) correctly fails STALE |

Review: 10 agents (8 core + `test-design-reviewer` + `semgrep-sast`). All findings fixed inline under the cost-of-filing gate; **0 filed as scope-out**.

Ref #5100 · Ref #5106


---

<!-- gate-override: net-issue-flow -->

## Net-issue-flow override

This PR files 2 issues and closes 0. Both are genuine deferrals that the cost-of-filing auto-flip does not cover (neither is ≤100 lines / ≤4 files, and neither is fixable inline):

- **#6945** — the Layer-1 BYOK cap RPCs sum `token_count * unit_cost_cents` (cents×tokens) against a cents budget, and `Math.round(costDelta * 100)` quantizes sub-cent turns to 0. Migration-class: six migration bodies plus the `workspace_cost_aggregate` view, the cost-breaker notification copy, and a "Raise Cap" surface the copy names but which does not exist. Touches money handling and enforcement, so it needs its own plan and review — not a ride-along on a model-ID swap. Independently confirmed by two reviewers and verified directly against the migration bodies.
- **#6942** — verify the sonnet `MODEL_PRICING` row after Claude Sonnet 5's introductory pricing ends. This is a **dated trigger (2026-09-01)**, not deferred work: there is nothing to fix today, and the committed values become correct on that date. Filing is the only way to carry a date forward.

Both were discovered *by* this PR's audit rather than created by it. Per `wg-when-an-audit-identifies-pre-existing`, narrating them in a PR body instead of filing them is the failure mode this gate's sibling rule exists to prevent — so the choice here was file-and-override, not file-or-narrate.
