### PR TITLE
fix(cost): haiku MODEL_PRICING row carried retired Haiku 3.5 rates

### DIFF
--- a/apps/web-platform/server/inngest/functions/agent-on-spawn-requested.ts
+++ b/apps/web-platform/server/inngest/functions/agent-on-spawn-requested.ts
@@ -83,9 +83,25 @@ function uuidv5(name: string, namespace: string): string {
 }
 
 // Per-model unit pricing in USD per token. Cache-read tokens bill at
-// ~10% of input; cache-creation tokens at ~125% of input. Pulled from
-// Anthropic public pricing pages 2026-05-25; CFO refreshes via cap
-// follow-through.
+// ~10% of input; cache-creation tokens at ~125% of input. Verified against
+// https://platform.claude.com/docs/en/about-claude/pricing.md on 2026-07-24.
+//
+// VERIFY EACH ROW AGAINST ITS KEY, not against the previous row. The haiku
+// entry carried Haiku *3.5*'s retired table ($0.80/$4/$0.08/$1) under the
+// Haiku *4.5* key from 2026-05-25 until 2026-07-24 — a whole wrong model's
+// row, not rounding drift, uniformly under-attributing 20%. These values
+// flow through `write_byok_audit` into `audit_byok_use`, which is WORM
+// (migration 037 raises P0001 on UPDATE/DELETE), so a wrong row is not just
+// wrong going forward: every row already written is permanently
+// uncorrectable, and both BYOK cap layers sum that column.
+//
+// SONNET IS TIME-VARYING: Claude Sonnet 5 bills $2/$10 under introductory
+// pricing through 2026-08-31, then $3/$15 from 2026-09-01. The values below
+// are the POST-INTRO rates — deliberately, since a static constant cannot
+// express the window and over-attribution is the safe direction for a cap
+// (it trips early rather than overshooting). Correct as of 2026-09-01.
+//
+// Values are pinned by model-tiers.test.ts so a drift must be deliberate.
 interface ModelPricing {
   inputPerToken: number;
   outputPerToken: number;
@@ -106,11 +122,12 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
     cacheReadPerToken: 0.3 / 1_000_000,
     cacheCreatePerToken: 3.75 / 1_000_000,
   },
+  // Claude Haiku 4.5: $1 input / $5 output / $0.10 cache-read / $1.25 5m cache-write.
   [HAIKU_MODEL]: {
-    inputPerToken: 0.8 / 1_000_000,
-    outputPerToken: 4 / 1_000_000,
-    cacheReadPerToken: 0.08 / 1_000_000,
-    cacheCreatePerToken: 1 / 1_000_000,
+    inputPerToken: 1 / 1_000_000,
+    outputPerToken: 5 / 1_000_000,
+    cacheReadPerToken: 0.1 / 1_000_000,
+    cacheCreatePerToken: 1.25 / 1_000_000,
   },
 };
 

--- a/apps/web-platform/server/inngest/functions/agent-on-spawn-requested.ts
+++ b/apps/web-platform/server/inngest/functions/agent-on-spawn-requested.ts
@@ -82,9 +82,15 @@ function uuidv5(name: string, namespace: string): string {
   return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
 }
 
-// Per-model unit pricing in USD per token. Cache-read tokens bill at
-// ~10% of input; cache-creation tokens at ~125% of input. Verified against
-// https://platform.claude.com/docs/en/about-claude/pricing.md on 2026-07-24.
+// Per-model unit pricing in USD per token. Cache-read tokens bill at ~10% of
+// input; cache-creation tokens at 125% of input FOR THE 5-MINUTE TTL used at
+// the call site below — the 1-hour TTL bills at 200% instead. Anthropic's
+// `usage.cache_creation_input_tokens` does not distinguish the two, so if any
+// call here ever passes `cache_control: { ttl: "1h" }` this row silently
+// under-attributes cache writes by 37.5% with the pinning test still green.
+// (Checked: no `ttl` is passed today, so the 5m default applies.)
+// Verified against https://platform.claude.com/docs/en/about-claude/pricing.md
+// on 2026-07-24.
 //
 // VERIFY EACH ROW AGAINST ITS KEY, not against the previous row. The haiku
 // entry carried Haiku *3.5*'s retired table ($0.80/$4/$0.08/$1) under the
@@ -95,11 +101,23 @@ function uuidv5(name: string, namespace: string): string {
 // wrong going forward: every row already written is permanently
 // uncorrectable, and both BYOK cap layers sum that column.
 //
-// SONNET IS TIME-VARYING: Claude Sonnet 5 bills $2/$10 under introductory
-// pricing through 2026-08-31, then $3/$15 from 2026-09-01. The values below
-// are the POST-INTRO rates — deliberately, since a static constant cannot
-// express the window and over-attribution is the safe direction for a cap
-// (it trips early rather than overshooting). Correct as of 2026-09-01.
+// SONNET IS TIME-VARYING, and we deliberately do NOT model the window: Claude
+// Sonnet 5 bills $2/$10 under introductory pricing through 2026-08-31, then
+// $3/$15 from 2026-09-01. The values below are the POST-INTRO rates, so Sonnet
+// is over-attributed by 50% until then (#6942 tracks the expiry).
+//
+// The real justification is NOT "a constant can't express a window" — it
+// trivially could (`Date.now() < Date.parse(...)`). It is that
+// PER_SPAWN_COST_CEILING_CENTS was itself calibrated in $3/$15 space (see its
+// docstring in leader-prompts/constants.ts), so ceiling and attribution share
+// one assumed rate and Layer-2 enforcement stays internally self-consistent;
+// modelling the window would desynchronize them and add a cliff.
+//
+// Be precise about what that buys: over-attribution is conservative for the
+// CAP, but these same cents are written to the WORM `audit_byok_use` ledger
+// and rendered on user-visible cost surfaces (workspace_cost_aggregate, the
+// Today cost route, the audit page) — so the operator sees a permanently
+// inflated Sonnet figure. Safe for enforcement is not the same as correct.
 //
 // Values are pinned by model-tiers.test.ts so a drift must be deliberate.
 interface ModelPricing {

--- a/apps/web-platform/test/server/inngest/model-tiers.test.ts
+++ b/apps/web-platform/test/server/inngest/model-tiers.test.ts
@@ -106,7 +106,10 @@ describe("model-tiers registry — #5106", () => {
   //   Sonnet 5      $3 / $15   cache-read $0.30  5m cache-write $3.75  (post-intro;
   //                 introductory $2/$10 applies through 2026-08-31 — see the
   //                 comment on MODEL_PRICING for why the post-intro rates are used)
-  it("MODEL_PRICING values match published per-MTok rates", () => {
+  // NB: "as committed" not "as published" — the sonnet row intentionally holds
+  // the POST-INTRO rate while introductory pricing runs to 2026-08-31, so for
+  // sonnet this pins the deliberate choice, not today's published price.
+  it("MODEL_PRICING values match the committed per-MTok rates", () => {
     const M = 1_000_000;
     expect(MODEL_PRICING[HAIKU_MODEL]).toEqual({
       inputPerToken: 1 / M,

--- a/apps/web-platform/test/server/inngest/model-tiers.test.ts
+++ b/apps/web-platform/test/server/inngest/model-tiers.test.ts
@@ -93,6 +93,35 @@ describe("model-tiers registry — #5106", () => {
     expect(pricingKeys).toEqual(unionMembers);
   });
 
+  // Pricing-drift tripwire. The keys-match test above guards the SHAPE of
+  // MODEL_PRICING but says nothing about its VALUES — which is how the haiku
+  // row carried retired Haiku 3.5 rates ($0.80/$4/$0.08/$1) under the Haiku
+  // 4.5 key for two months, under-attributing 20% into a WORM ledger that
+  // both BYOK cap layers sum. A test cannot know live prices, so this pins
+  // the published rates with their source; a genuine price change must update
+  // it deliberately rather than drifting in unnoticed.
+  //
+  // Source: https://platform.claude.com/docs/en/about-claude/pricing.md (2026-07-24)
+  //   Haiku 4.5     $1 / $5    cache-read $0.10  5m cache-write $1.25
+  //   Sonnet 5      $3 / $15   cache-read $0.30  5m cache-write $3.75  (post-intro;
+  //                 introductory $2/$10 applies through 2026-08-31 — see the
+  //                 comment on MODEL_PRICING for why the post-intro rates are used)
+  it("MODEL_PRICING values match published per-MTok rates", () => {
+    const M = 1_000_000;
+    expect(MODEL_PRICING[HAIKU_MODEL]).toEqual({
+      inputPerToken: 1 / M,
+      outputPerToken: 5 / M,
+      cacheReadPerToken: 0.1 / M,
+      cacheCreatePerToken: 1.25 / M,
+    });
+    expect(MODEL_PRICING[SONNET_MODEL]).toEqual({
+      inputPerToken: 3 / M,
+      outputPerToken: 15 / M,
+      cacheReadPerToken: 0.3 / M,
+      cacheCreatePerToken: 3.75 / M,
+    });
+  });
+
   it("EXECUTION_MODEL is the sonnet SSOT and AUDIT_MODEL is opus-4-8", () => {
     expect(EXECUTION_MODEL).toBe(SONNET_MODEL);
     expect(EXECUTION_MODEL).toBe("claude-sonnet-5");


### PR DESCRIPTION
`MODEL_PRICING[HAIKU_MODEL]` carried **retired Claude Haiku 3.5's rate table** under the Haiku 4.5 key — the wrong model's row, not rounding drift.

| | repo (before) | published Haiku 4.5 | retired Haiku 3.5 |
|---|---|---|---|
| input | $0.80 | **$1** | $0.80 |
| output | $4 | **$5** | $4 |
| cache read | $0.08 | **$0.10** | $0.08 |
| 5m cache write | $1 | **$1.25** | $1 |

The "before" column matches Haiku 3.5 in all four cells. Uniform **20% under-attribution** from 2026-05-25 until now. Source: https://platform.claude.com/docs/en/about-claude/pricing.md (verified 2026-07-24).

## Why this is worth its own PR

These values are not reporting-only. They flow `persistTurnCostAwaitable` → `write_byok_audit(p_unit_cost_cents)` → `audit_byok_use.unit_cost_cents`, a column **both** BYOK cap layers sum (Layer-1 cap RPC and the Layer-2 per-spawn ceiling). Under-attributing 20% means the two haiku-tier classes — `triage.p0p1_issue` and `knowledge.kb_drift` — have been letting roughly **25% more real spend past the cap** than intended.

`audit_byok_use` is **WORM**: migration `037_audit_byok_use.sql` installs `BEFORE UPDATE` / `BEFORE DELETE` triggers that raise `P0001`. Rows already written are **permanently uncorrectable** — no backfill, no UPDATE, no compensating delete; only a forward-only correcting-entry design could restore them. The error therefore accrues irreversibly per day, which is why this ships now rather than riding along with a toolchain bump.

## The guard that was missing

The pre-existing parity test asserts `MODEL_PRICING` keys === the `AnthropicModelId` union — it guards the **shape** and says nothing about **values**. That is how a whole wrong model's row survived two months with a green suite.

Adds a pricing-drift tripwire pinning the published per-MTok rates with their source URL and date, so a genuine price change has to be a deliberate edit rather than drifting in. **Verified non-vacuous:** reverting the haiku input rate to `0.8` fails it.

## Sonnet deliberately unchanged

Claude Sonnet 5 bills **$2/$10 under introductory pricing through 2026-08-31**, then $3/$15 from 2026-09-01. The committed values are the post-intro rates, left as-is on purpose:

- a static constant cannot express a time-varying window, and
- over-attribution is the safe direction for a cap (it trips early rather than overshooting), whereas the haiku error ran the unsafe way.

Documented inline with the expiry date; tracked separately for the 2026-09-01 re-check.

## Verification

| Check | Result |
|---|---|
| `model-tiers` + `cost-writer` + `claude-cost-marker` | 12 passed |
| `tsc --noEmit` | 0 errors |
| tripwire negative control | reverting haiku input to `0.8` → fails |

Found by the multi-agent review during the Opus 5 model-launch audit (#6934). Opus needs no pricing row — `leaderModule.model` is the `sonnet|haiku` union, verified end-to-end, so opus never reaches this lookup.



## Correction from review

The two cap layers do **not** sum `unit_cost_cents` the same way: Layer 2 sums it correctly, while the Layer-1 RPCs sum `token_count * unit_cost_cents` (cents×tokens) against a cents budget. Pre-existing; tracked as #6945. Both reviewers independently agreed it does not block this PR.
