### PR TITLE
fix(web-platform): unblock deploys — the gh apt pin aged out of a rolling repo

### DIFF
--- a/apps/web-platform/Dockerfile
+++ b/apps/web-platform/Dockerfile
@@ -91,13 +91,38 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # GitHub CLI (needed by cron-follow-through-monitor gh label/issue commands
 # and event-ship-merge gh pr checkout). Not in default Debian repos.
+#
+# THE PIN IS PREFERRED, NOT REQUIRED — and that distinction is load-bearing.
+# `cli.github.com/packages` is a ROLLING repo: it carries only recent versions
+# and drops older ones with no deprecation window. An exact `gh=<version>` pin
+# therefore has a silent expiry date, and when it passes, `apt-get install`
+# exits 100, the image build fails, and the release job's `deploy` step is
+# SKIPPED — so production keeps serving the last good image while every merge
+# reports a failed release. Observed 2026-07-25: `gh=2.93.0` aged out (upstream
+# had moved to 2.96.0) and blocked EVERY deploy for ~17 hours. Nothing about
+# that failure names the pin, which is why this comment does.
+#
+# So: try the pin for build reproducibility; if the repo no longer carries it,
+# install the newest available rather than failing the build, and say so LOUDLY
+# in the build log. A silent fallback here would trade a visible outage for an
+# invisible version drift, which is worse — the `::warning::` is the signal that
+# GH_VERSION needs re-pinning, and `SOLEUR_GH_INSTALLED` records what actually
+# landed in the image on every build, pinned or not.
+ARG GH_VERSION=2.96.0
 RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
        > /etc/apt/sources.list.d/github-cli.list \
-    && apt-get update && apt-get install -y --no-install-recommends gh=2.93.0 \
+    && apt-get update \
+    && if apt-get install -y --no-install-recommends "gh=${GH_VERSION}"; then \
+         echo "SOLEUR_GH_PIN_OK requested=${GH_VERSION}"; \
+       else \
+         echo "::warning::SOLEUR_GH_PIN_UNAVAILABLE requested=${GH_VERSION} — the rolling GitHub CLI apt repo no longer carries this version. Installing the newest available so the deploy is not blocked; re-pin ARG GH_VERSION in apps/web-platform/Dockerfile to the version reported below."; \
+         apt-get install -y --no-install-recommends gh; \
+       fi \
+    && echo "SOLEUR_GH_INSTALLED version=$(gh --version | head -1)" \
     && rm -rf /var/lib/apt/lists/*
 
 # Playwright Chromium system deps + browser binary (TR9 PR-11).


### PR DESCRIPTION
## Summary

**Production deploys have been blocked for ~17 hours** (since 2026-07-24 22:50). The web-platform image build fails, so the release job's `deploy` step is **skipped** on every merge — prod keeps serving the last good image while each release reports failure. `app.soleur.ai` stayed healthy (200) the whole time, which is why it went unnoticed. #6947 merged today and never shipped.

## Cause

`cli.github.com/packages` is a **rolling** apt repo: it carries only recent versions and drops older ones with no deprecation window. `gh=2.93.0` was pinned in `apps/web-platform/Dockerfile`; upstream has since reached 2.96.0, so the pin aged out:

```
apt-get install -y --no-install-recommends gh=2.93.0
E: Version '2.93.0' for 'gh' was not found     ->  exit 100
```

An exact pin against a rolling repo has a **silent expiry date**, and nothing in the resulting build failure names the pin as the cause.

## Fix

Keep the pin **preferred, not required**. Try the exact version for build reproducibility; if the repo no longer carries it, install the newest available rather than failing the build — and say so loudly.

- `::warning::SOLEUR_GH_PIN_UNAVAILABLE` — the signal that `ARG GH_VERSION` needs re-pinning.
- `SOLEUR_GH_INSTALLED` — records what actually landed in the image on **every** build, pinned or not.

A silent fallback would trade a visible outage for invisible version drift. This trades it for a visible warning. The pin moved to `ARG GH_VERSION=2.96.0`, so re-pinning is a one-line change.

## Verification

Built the real layer against the same digest-pinned base image, three arms:

| Arm | Input | Result |
|---|---|---|
| 1 | `GH_VERSION=2.96.0` | `SOLEUR_GH_PIN_OK`, gh 2.96.0 installed, exit 0 |
| 2 | `GH_VERSION=2.93.0` (the outage version) | apt reports missing → `SOLEUR_GH_PIN_UNAVAILABLE` → gh 2.96.0 installed, **exit 0** |
| 3 | **positive control** — today's `main` line verbatim | **exit code 100**, byte-identical to the failing CI log |

Arm 3 confirms this pin is the cause, not a symptom. Arm 2 confirms the outage scenario now survives.

## Changelog

- Fixed: web-platform image build no longer fails when the pinned `gh` version ages out of the rolling GitHub CLI apt repo, which had blocked all production deploys for ~17 hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)