### PR TITLE
docs(adr-114): wrap the scope-correction prose in a lint-infra-ignore region

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-114-one-tunnel-many-connectors-ingress-must-be-origin-relative.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-114-one-tunnel-many-connectors-ingress-must-be-origin-relative.md
@@ -367,6 +367,7 @@ and those 12 are `-target`ed by the per-PR merge apply, so main wedges.
 > the change to image-bake sequencing: a host created after the apply but before `:latest`
 > carries the matching bootstrap aborts its entire runcmd at `stage=verify`.
 >
+> <!-- lint-infra-ignore start -->
 > **[Scope corrected 2026-07-20, #6575 — the hazard survives; only its scope statement changes.]**
 > This bullet previously said the coherence preflight covered **only** the web-2-recreate dispatch.
 > That scoping is gone with the dispatch job. The verifier is retained, renamed host-agnostic
@@ -374,6 +375,12 @@ and those 12 are `-target`ed by the per-PR merge apply, so main wedges.
 > host through a documented operator procedure: the `host_creates` HALT runbook now carries the
 > complete `crane digest` → preflight → `terraform apply -var image_name=<pinned>` chain. So the
 > preflight is no longer web-2-scoped and no longer callerless.
+> <!-- lint-infra-ignore end -->
+>
+> <!-- The region above DESCRIBES the operator-local birth path that exists today; it does not
+>      prescribe a new manual step. That path having no automated equivalent IS the open defect,
+>      tracked by #6730. The ignore region is the sanctioned wrapper for deferred-orchestrator
+>      prose (see hr-no-ssh-fallback-in-runbooks) — remove it when #6730 lands an automated path. -->
 >
 > **What did not change is the hazard itself.** The verifier still requires a pinned `@sha256` ref
 > while the default `var.image_name` is the mutable `:latest`, so the routine merge apply is still


### PR DESCRIPTION
## Summary

Recovered from a worktree whose PR (#6744) had **already merged without it** — this edit was sitting uncommitted after a Warp crash and is not on `main`.

`ADR-114:374` trips `lint-infra-no-human-steps`: the 2026-07-20 scope-correction paragraph names an actor and an imperative in the same breath while *describing* the operator-local host-birth procedure. It does not prescribe a new manual step — the absence of an automated equivalent is the open defect, tracked by #6730 — so the sanctioned wrapper is the ignore region, not a rewrite.

## Two changes from the recovered patch

Both are about not breaking the rendered page:

- **Markers are `>`-prefixed.** The original placed bare `<!-- ... -->` lines inside a blockquote, which terminates the quote and restarts it — the paragraph would have rendered as three separate blockquotes. `IGNORE_START_RE`/`IGNORE_END_RE` search anywhere in the line, so the prefix costs nothing and keeps the quote whole.
- **The explanatory comment is `>`-prefixed** and moved inside the quote, for the same reason.

## Verification

| Check | Result |
|---|---|
| Linter before | flags `ADR-114:374` |
| Linter after | clean |
| **Mutation** — strip the region | flags again, so the region is load-bearing, not decorative |
| Blockquote integrity | no non-`>` lines across the edited span |
| `check-adr-ordinals.sh` | clean |

## Changelog

- Fixed: ADR-114's scope-correction paragraph no longer trips the infra-routing linter, wrapped in a `lint-infra-ignore` region that keeps the enclosing blockquote intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)