### PR TITLE
docs(6969): mark the post-mortem resolved and stop the probe judging a host by job conclusion

### DIFF
--- a/knowledge-base/engineering/operations/post-mortems/2026-07-26-web-2-dark-boot-doppler-download-postmortem.md
+++ b/knowledge-base/engineering/operations/post-mortems/2026-07-26-web-2-dark-boot-doppler-download-postmortem.md
@@ -108,6 +108,16 @@ discriminating datum was never captured.
 > Fix: #6981 / PR #6984. `soleur-web-2` remains dark until a post-fix replace runs — `runcmd` is
 > once-per-instance, so the current instance cannot be repaired by reboot.
 
+> **RESOLVED 2026-07-27.** `soleur-web-2` (instance `155786558`, created `11:00:53Z`) booted clean
+> on the third attempt — `cloud_init_complete` at `11:05:58Z`, `fresh_boot_ready` at `11:06:03Z`,
+> **0 fatals** for the current instance. The first fresh web host in the fleet's history to complete
+> cloud-init. Root cause and fix: #6981 / PR #6984. Issue #6969 closed with the evidence trail.
+>
+> The line below is the original status, preserved unedited. It is superseded in full — do NOT read
+> it as current. (This status line and the UPDATE block near the top are the same claim in two
+> places; marking one and not the other is the defect class recorded in
+> `2026-07-21-i-marked-one-block-and-not-its-twin-in-the-file-whose-purpose-was-removing-that-defect.md`.)
+
 `unresolved but ended` — the boot failure is not recurring (no further host births have been
 attempted), but the root cause is UNDETERMINED and `soleur-web-2` is still dark.
 

--- a/scripts/followthroughs/web-host-replace-rebirth-6969.sh
+++ b/scripts/followthroughs/web-host-replace-rebirth-6969.sh
@@ -47,6 +47,28 @@ for id in $ids; do
             --jq '[.jobs[] | select(.name == "'"$JOB_NAME"'")] | .[0].conclusion // empty' 2>/dev/null) || continue
   [ -n "$concl" ] || continue          # this run was some other apply_target
   saw_job=1
+  # (#6995) THE JOB CONCLUSION IS NOT THE BOOT VERDICT. The 2026-07-27 rebirth booted
+  # CLEAN — cloud_init_complete + fresh_boot_ready, 0 fatals — and the job still
+  # concluded `failure`, because the boot-trail reader's terminal check was wrong. A
+  # conclusion-only predicate would have reported that clean boot as a failed
+  # follow-through and told the operator to investigate a healthy host. The apply and
+  # the boot are separate facts; a job can fail for a reader defect, a post-apply step,
+  # or a runner fault while the host is fine.
+  #
+  # So: `success` still PASSes outright, but a non-success run is only FAILed after the
+  # boot trail has been checked for a terminal `::error::...booted DARK`. Absent that,
+  # the run is TRANSIENT (needs a human look) rather than a verdict on the host.
+  if [ "$concl" != "success" ]; then
+    if gh run view "$id" --log 2>/dev/null | grep -qF 'booted DARK at stage'; then
+      echo "FAIL: ${JOB_NAME} run ${id} concluded '${concl}' AND the boot trail names a dark boot."
+      echo "      gh run view ${id} --log | grep 'booted DARK'"
+      exit 1
+    fi
+    echo "TRANSIENT: ${JOB_NAME} run ${id} concluded '${concl}' but the boot trail shows no dark boot."
+    echo "           The job failed for a reason other than the host's boot — inspect before judging the host."
+    echo "           gh run view ${id}"
+    exit 2
+  fi
   if [ "$concl" = "success" ]; then
     echo "PASS: ${JOB_NAME} succeeded in run ${id} — web-2 rebirth dispatch completed."
     echo "      Confirm the boot trail reached cloud_init_complete, update the post-mortem,"


### PR DESCRIPTION
## Summary

Closes the two loose ends named in the #6969 close comment, so neither is left as a stale artifact.

Ref #6969. Ref #6995.

## 1. The post-mortem's status line was the unmarked twin

The UPDATE block near the top recorded the resolved root cause. `## Status`, 70 lines below, still read:

> `unresolved but ended` — … the root cause is UNDETERMINED and `soleur-web-2` is still dark.

Same claim, two places, one marked. That is precisely the defect class recorded in `2026-07-21-i-marked-one-block-and-not-its-twin-in-the-file-whose-purpose-was-removing-that-defect.md` — and I reproduced it in a post-mortem I was editing hours after writing that learning up. Marking one block and leaving its twin is worse than marking neither: a reader infers unmarked = still live.

A superseded banner now sits above the original text, which is preserved unedited.

## 2. The follow-through probe judged the host by the job conclusion

Run [30259798197](https://github.com/jikig-ai/soleur/actions/runs/30259798197) booted **clean** — `cloud_init_complete`, `fresh_boot_ready`, 0 fatals for the instance — and still concluded `failure`, because of the #6995 boot-trail reader defect.

The probe's predicate was `concl == "success"`. It would have reported that clean boot as a **failed follow-through** and sent the operator to investigate a healthy host.

**The apply and the boot are separate facts.** A job can fail for a reader defect, a post-apply step, or a runner fault while the host is fine. So a non-success run is now `FAIL` only when the boot trail carries a terminal `booted DARK at stage` marker; otherwise it is `TRANSIENT` — needs a human look, not a verdict on the host.

Verified against the real run: **0 dark-boot markers**, so it now classifies `TRANSIENT` where it previously would have said `FAIL`.

#6969 is closed, so the sweeper no longer runs this probe against it. The fix matters for the next replace and for anyone copying the pattern — a probe that conflates "the job went red" with "the host is dark" is wrong independently of which issue it is wired to.

## Test plan

- [x] `bash -n` + `shellcheck -S warning` — clean
- [x] Probe exercised against the real run (`30259798197`): 0 `booted DARK` markers → classifies `TRANSIENT`, not `FAIL`
- [x] Script still present and executable, so the follow-through directive gate is satisfied
- [x] Post-mortem original status text preserved unedited beneath the banner

Generated with [Claude Code](https://claude.com/claude-code)
