### PR TITLE
feat(observability): ship sshd auth events to Better Stack

### DIFF
--- a/apps/web-platform/infra/vector.toml
+++ b/apps/web-platform/infra/vector.toml
@@ -220,6 +220,27 @@ include_matches.SYSLOG_IDENTIFIER = [
   "inngest-redis",
   "inngest-nftables",
   "inngest-server-probe",
+  # (2026-07-28 incident) sshd AUTH events. During a laptop compromise the operator
+  # question that decided the whole response was "did anyone authenticate to prod during
+  # the window?" — and it was NOT answerable from Better Stack. Source 2's PRIORITY 0-2
+  # (CRIT+) cut drops `Accepted publickey` (PRIORITY 6) and `Failed publickey` (4-5), so
+  # the ONLY way to answer was a live SSH session into the host, which is exactly what
+  # hr-no-ssh-fallback-in-runbooks forbids. An empty query result was also indistinguishable
+  # from "no intrusion" vs "not instrumented" — the worse failure of the two.
+  #
+  # Quota (measured on web-1, 2026-07-28, not estimated): 375 rows/7d = ~53/day total for
+  # the tag, of which 62/7d are Accepted/Failed. The comment above warns that widening
+  # Source 2's PRIORITY filter would ship "every host NOTICE+ line (sshd, cron, systemd
+  # units, fail2ban)" and blow quota — that reasoning is sound and NOT contradicted here:
+  # this is an exact-value SYSLOG_IDENTIFIER match on ONE identifier, not a priority widen,
+  # and ~53 rows/day sits inside the same headroom the other 14 tags occupy.
+  #
+  # Identifier is native, not declared: sshd(8) sets SYSLOG_IDENTIFIER=sshd itself, so
+  # unlike the tags above there is no SyslogIdentifier= line in infra/*.sh to mirror.
+  # Verified on web-1: 193/200 sampled auth records carry exactly `sshd`. It is therefore
+  # registered in vector-pii-scrub.test.sh's SYSTEMD_UNIT_IDENTIFIERS (same mechanism as
+  # `webhook`), NOT derivable by AC3 — the two must stay in lockstep.
+  "sshd",
 ]
 journal_directory = "/var/log/journal"
 batch_size = 16

--- a/apps/web-platform/test/infra/vector-pii-scrub.test.sh
+++ b/apps/web-platform/test/infra/vector-pii-scrub.test.sh
@@ -445,7 +445,17 @@ EXPECTED_TAGS=$(
 # binary basename). Fold these into EXPECTED so AC3 still enforces logger-tag lockstep
 # (a new/removed logger tag not mirrored here fails CI) without flagging the binary
 # channel. Keep this list to genuine unit-binary identifiers, not a drift-guard bypass.
-SYSTEMD_UNIT_IDENTIFIERS="webhook"
+#
+# `sshd` (2026-07-28 incident): sshd(8) sets SYSLOG_IDENTIFIER=sshd natively — there is no
+# SyslogIdentifier= line in infra/*.sh to derive it from, because the unit ships with the OS
+# rather than being one of ours. Same category as `webhook`, opposite reason: webhook inherits
+# its tag from the ExecStart basename, sshd sets its own. Verified on web-1: 193/200 sampled
+# auth records carry exactly `sshd`. Its vector.toml entry exists so "did anyone authenticate
+# to prod?" is answerable from Better Stack instead of requiring an SSH session into the host
+# (hr-no-ssh-fallback-in-runbooks). Removing it here without removing it from vector.toml — or
+# vice versa — fails AC3; they are a lockstep pair.
+SYSTEMD_UNIT_IDENTIFIERS="webhook
+sshd"
 EXPECTED_TAGS=$(printf '%s\n%s\n' "$EXPECTED_TAGS" "$SYSTEMD_UNIT_IDENTIFIERS" | grep -v '^$' | sort -u)
 # Array entries are quoted strings on their own lines inside the include_matches
 # block; pull the bare tag from each.


### PR DESCRIPTION
## Problem

During the 2026-07-28 laptop-compromise response, the question that decided the entire incident was:

> **Did anyone authenticate to prod during the window?**

It was **not answerable from Better Stack.**

- Source 2 `system_journald` filters `PRIORITY 0-2` (CRIT+). `Accepted publickey` is PRIORITY 6, `Failed publickey` is 4–5 → both dropped.
- Source 4 is an exact-value `SYSLOG_IDENTIFIER` allowlist, and `sshd` was not in it.
- Source 3 is container-scoped.

So the only way to answer was **SSHing into the host** — precisely what `hr-no-ssh-fallback-in-runbooks` exists to prevent.

The sharper failure: an empty query would have been **indistinguishable between "no intrusion" and "not instrumented."** Silence could not be read as safety. That ambiguity is the actual defect.

## Change

Adds `sshd` to the Source 4 `SYSLOG_IDENTIFIER` allowlist.

## Quota — measured, not estimated

On `web-1`:

| window | rows | rate |
|---|---|---|
| 7d | 375 | **~53/day** |
| of which `Accepted`/`Failed` | 62 | ~9/day |

The existing comment warns that widening Source 2's PRIORITY filter would ship *"every host NOTICE+ line (sshd, cron, systemd units, fail2ban)"* and blow quota. **That reasoning is sound and this change does not contradict it** — this is an exact-value match on *one* identifier, not a priority widen. ~53 rows/day sits inside the same headroom the other 14 tags occupy.

## Why the test changes too

`sshd(8)` sets `SYSLOG_IDENTIFIER=sshd` **natively**. Unlike every other tag in the allowlist there is no `SyslogIdentifier=` line in `infra/*.sh` for AC3 to derive it from — the unit ships with the OS rather than being one of ours.

So it's registered in `SYSTEMD_UNIT_IDENTIFIERS`, the same mechanism `webhook` uses (opposite reason: `webhook` inherits its tag from the ExecStart basename, `sshd` sets its own). Without this, AC3 fails with `tag-set drift`. The two files are a **lockstep pair**.

## Verification

- Identifier confirmed on host: **193/200** sampled auth records carry exactly `sshd`
- AC3 re-derived after the change: **22 expected == 22 actual**, diff empty

## What this buys

Next time, "did anyone log into prod?" is a Better Stack query instead of an SSH session — and an empty result means *no auth events*, not *no instrumentation*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)