### PR TITLE
fix(infra): make the CF Access service tokens rotatable via Terraform

### DIFF
--- a/apps/web-platform/infra/tunnel.tf
+++ b/apps/web-platform/infra/tunnel.tf
@@ -143,6 +143,24 @@ resource "cloudflare_zero_trust_access_application" "deploy" {
 resource "cloudflare_zero_trust_access_service_token" "deploy" {
   account_id = var.cf_account_id
   name       = "github-actions-deploy"
+
+  # Without this, the token is UNROTATABLE via Terraform. `-replace` defaults to
+  # destroy-then-create, and Cloudflare rejects the destroy while an Access policy
+  # still references the token:
+  #   access.api.error.service_token_in_use: cannot delete service token because it
+  #   is used by a policy, group, or app SCIM configuration (12139)
+  # `cloudflare_zero_trust_access_policy.deploy_service_token` holds exactly such a
+  # reference, so the apply fails after planning 3-add/3-destroy and changes nothing.
+  # create_before_destroy inverts the order: new token → policy repointed to it →
+  # old token destroyed, all in one apply.
+  #
+  # Safe on the name collision this implies (both tokens exist briefly): Cloudflare
+  # permits duplicate service-token names — probed 2026-07-29 against the live account
+  # by creating two tokens with an identical name (both succeeded, both deleted), so
+  # no unique-name suffix is required.
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "cloudflare_zero_trust_access_policy" "deploy_service_token" {
@@ -181,6 +199,12 @@ resource "cloudflare_zero_trust_access_application" "ssh" {
 resource "cloudflare_zero_trust_access_service_token" "ci_ssh" {
   account_id = var.cf_account_id
   name       = "github-actions-ci-ssh"
+
+  # See the rationale on `.deploy` above — destroy-then-create is rejected while
+  # `cloudflare_zero_trust_access_policy.ci_ssh_service_token` references this token.
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "cloudflare_zero_trust_access_policy" "ci_ssh_service_token" {
@@ -213,6 +237,17 @@ resource "cloudflare_zero_trust_access_application" "registry" {
 resource "cloudflare_zero_trust_access_service_token" "registry_push" {
   account_id = var.cf_account_id
   name       = "github-actions-registry-push"
+
+  # See the rationale on `.deploy` above. This one is load-bearing beyond rotation
+  # ergonomics: `doppler_secret.registry_push_access_token_{id,secret}` derive from
+  # this resource's client_id/client_secret, so Terraform is the ONLY safe way to roll
+  # it. Rotating it out-of-band (the Cloudflare `/rotate` endpoint) leaves the old
+  # client_secret in state, and the next apply pushes that stale value back into
+  # Doppler — breaking registry pushes with no signal saying why. `.deploy` and
+  # `.ci_ssh` are exempt from that trap because they are `output`s, not doppler_secrets.
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "cloudflare_zero_trust_access_policy" "registry_push_service_token" {


### PR DESCRIPTION
## Problem

All three `cloudflare_zero_trust_access_service_token` resources lack `create_before_destroy`, which makes them **unrotatable through Terraform**.

`-replace` defaults to destroy-then-create, and Cloudflare rejects the destroy while an Access policy references the token:

```
access.api.error.service_token_in_use: cannot delete service token because it is
used by a policy, group, or app SCIM configuration (12139)
```

Every token has exactly such a reference — `cloudflare_zero_trust_access_policy.{deploy,ci_ssh,registry_push}_service_token` each name it via `include { service_token = [...id] }`.

**Confirmed live, 2026-07-29:** the apply planned `3 to add, 0 to change, 3 to destroy`, failed all three destroys, and changed nothing.

## Fix

`create_before_destroy` inverts the order: new token → policy repointed → old token destroyed, in one apply.

## Why the name collision is safe

`create_before_destroy` means both tokens exist briefly with the same `name`. **Cloudflare permits duplicate service-token names** — probed against the live account by creating two tokens with an identical name (both succeeded; both deleted afterwards). No unique-name suffix required.

I checked this rather than assuming, because if names *were* unique-constrained the fix would silently trade one failure mode for another.

## Why this matters beyond ergonomics

`registry_push` feeds `doppler_secret.registry_push_access_token_{id,secret}`, so **Terraform is the only safe way to roll it**.

The out-of-band Cloudflare `/rotate` endpoint leaves the old `client_secret` in state, and the next apply pushes that stale value straight back into Doppler — breaking registry pushes with no signal saying why.

`deploy` and `ci_ssh` escape that trap only because they are `output`s rather than `doppler_secret`s. That asymmetry is exactly why, during the 2026-07-28 incident response, those two could be rotated out-of-band and `registry_push` could not.

## Follow-up after merge

`registry_push` is **still on its original credential**. Once this lands:

```bash
terraform apply -replace=cloudflare_zero_trust_access_service_token.registry_push \
  -target=cloudflare_zero_trust_access_service_token.registry_push \
  -target=doppler_secret.registry_push_access_token_id \
  -target=doppler_secret.registry_push_access_token_secret
```

Terraform updates Doppler atomically, so CI picks the new value up on its next run.

## Verification

- `terraform fmt -check` — clean
- `terraform validate` — `Success! The configuration is valid.`
- Duplicate-name behaviour probed live (see above)

## Context

Same defect class as #7038: a rotation mechanism that exists in the code but doesn't work when exercised. Both surfaced the same way — by actually attempting the rotation rather than trusting that it would work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)