### PR TITLE
feat(infra): detect Cloudflare tokens that a rotation failed to propagate

### DIFF
--- a/scripts/check-cloudflare-token-drift.sh
+++ b/scripts/check-cloudflare-token-drift.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Detect Cloudflare API tokens that are DEAD or inconsistent across Doppler configs.
+#
+# WHY THIS EXISTS (2026-07-29 incident response)
+# ----------------------------------------------
+# Every `doppler_secret` that carries a Cloudflare token declares
+# `lifecycle { ignore_changes = [value] }` (cf-cert-reissue-token.tf,
+# tunnel.tf, zot-registry.tf). That rule is deliberate — it stops refresh-time
+# churn — but it has a consequence nothing surfaces: **Terraform can never
+# propagate a rotated token**. `terraform apply` reports `No changes` while the
+# `prd` root config still holds the dead value, and every branch config that
+# inherits from root serves it too.
+#
+# The failure is silent and delayed. Rotating a token in the Cloudflare
+# dashboard and updating `prd_terraform` looks completely successful — the
+# operator verifies the one config they edited, gets a green result, and moves
+# on. The stale copies surface days later as an unrelated-looking 403 in cron,
+# GHCR, or the LUKS workflow, with nothing pointing back at the rotation.
+#
+# Observed three times in a single session, each time only because the fan-out
+# was checked by hand:
+#   - REGISTRY_PUSH_ACCESS_TOKEN_*  — `prd` root stale after a Terraform replace
+#   - CF_API_TOKEN_DNS_EDIT         — 5 of 7 configs stale after a dashboard roll
+#   - CF_API_TOKEN_PURGE            — 6 of 7 configs stale after a dashboard roll
+#
+# This script makes that class fail loudly. It does NOT change the lifecycle
+# rules: removing `ignore_changes` would trade a silent-staleness bug for a
+# churn bug the comments say was hit before. Detection is the safer fix.
+#
+# USAGE
+#   doppler run -p soleur -c prd_terraform -- bash scripts/check-cloudflare-token-drift.sh
+#   bash scripts/check-cloudflare-token-drift.sh --json
+#
+# EXIT CODES
+#   0  every token value resolves LIVE against the Cloudflare API
+#   1  at least one DEAD token value found (rotation did not propagate)
+#   2  preconditions missing (doppler CLI, curl, python3)
+
+set -uo pipefail
+
+PROJECT="${DOPPLER_PROJECT:-soleur}"
+JSON_OUT=0
+[[ "${1:-}" == "--json" ]] && JSON_OUT=1
+
+for bin in doppler curl python3; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "ERROR: $bin not on PATH" >&2; exit 2; }
+done
+
+# Enumerate configs from Doppler rather than hardcoding. A hardcoded list is
+# exactly how CF_API_TOKEN_AUDIT was missed during the incident: it lived only
+# in the dev* configs, which the audit sweep never looked at.
+mapfile -t CONFIGS < <(doppler configs -p "$PROJECT" --json 2>/dev/null |
+  python3 -c 'import json,sys; [print(c["name"]) for c in json.load(sys.stdin)]' 2>/dev/null)
+if [[ ${#CONFIGS[@]} -eq 0 ]]; then
+  echo "ERROR: could not enumerate Doppler configs for project '$PROJECT'" >&2
+  exit 2
+fi
+
+# Enumerate token-shaped keys the same way — never a fixed list.
+declare -A KEYSET=()
+for cfg in "${CONFIGS[@]}"; do
+  while read -r k; do
+    [[ -n "$k" ]] && KEYSET["$k"]=1
+  done < <(doppler secrets -p "$PROJECT" -c "$cfg" --only-names 2>/dev/null |
+    grep -oE 'CF_API_TOKEN[A-Z0-9_]*' || true)
+done
+
+declare -A VERDICT=()   # token value -> LIVE|DEAD  (verify each distinct value once)
+DEAD_ROWS=()
+LIVE_N=0
+DEAD_N=0
+
+verify_value() {
+  local v="$1"
+  if [[ -z "${VERDICT[$v]:-}" ]]; then
+    local ok
+    ok=$(curl -s --max-time 20 -H "Authorization: Bearer $v" \
+      "https://api.cloudflare.com/client/v4/user/tokens/verify" |
+      python3 -c 'import json,sys
+try: print("LIVE" if json.load(sys.stdin).get("success") else "DEAD")
+except Exception: print("DEAD")' 2>/dev/null)
+    VERDICT[$v]="${ok:-DEAD}"
+  fi
+  printf '%s' "${VERDICT[$v]}"
+}
+
+for key in $(printf '%s\n' "${!KEYSET[@]}" | sort); do
+  for cfg in "${CONFIGS[@]}"; do
+    val=$(doppler secrets get "$key" -p "$PROJECT" -c "$cfg" --plain 2>/dev/null)
+    [[ -z "$val" ]] && continue
+    state=$(verify_value "$val")
+    if [[ "$state" == "DEAD" ]]; then
+      DEAD_N=$((DEAD_N + 1)); DEAD_ROWS+=("$key|$cfg")
+    else
+      LIVE_N=$((LIVE_N + 1))
+    fi
+  done
+done
+
+if [[ "$JSON_OUT" -eq 1 ]]; then
+  python3 - "$LIVE_N" "$DEAD_N" "${DEAD_ROWS[@]:-}" <<'PY'
+import json, sys
+live, dead = int(sys.argv[1]), int(sys.argv[2])
+rows = [r for r in sys.argv[3:] if r]
+print(json.dumps({
+    "live": live, "dead": dead,
+    "stale": [{"key": r.split("|")[0], "config": r.split("|")[1]} for r in rows],
+}, indent=2))
+PY
+else
+  echo "Cloudflare token drift check — project '$PROJECT'"
+  echo "  configs scanned: ${#CONFIGS[@]}   token keys: ${#KEYSET[@]}"
+  echo "  live entries: $LIVE_N   dead entries: $DEAD_N"
+  if [[ "$DEAD_N" -gt 0 ]]; then
+    echo
+    echo "STALE — these configs hold a token value Cloudflare no longer accepts:"
+    for r in "${DEAD_ROWS[@]}"; do echo "  ${r%%|*}  in  ${r##*|}"; done
+    echo
+    echo "A rotation did not propagate. Terraform will NOT fix this: the"
+    echo "doppler_secret resources carry lifecycle.ignore_changes = [value], so"
+    echo "'terraform apply' reports 'No changes' while the stale value persists."
+    echo "Set the live value on the 'prd' ROOT config; branch configs inherit it."
+  fi
+fi
+
+[[ "$DEAD_N" -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Problem

Every `doppler_secret` carrying a Cloudflare token declares:

```hcl
lifecycle {
  # ignore_changes prevents refresh-time churn.
  ignore_changes = [value]
}
```

That rule is deliberate and the reasoning is sound. But it has a consequence nothing surfaces: **Terraform can never propagate a rotated token.** `terraform apply` reports `No changes` while the `prd` root config still holds the dead value — and every branch config that inherits from root serves it too.

The failure is **silent and delayed**. Rotate a token in the Cloudflare dashboard, update `prd_terraform`, verify it — green. The stale copies surface days later as an unrelated-looking 403 in cron, GHCR, or the LUKS workflow, with nothing pointing back at the rotation that caused it.

## Observed three times in one session

During the 2026-07-29 incident response, each caught **only** by checking the fan-out by hand:

| Secret | Damage |
|---|---|
| `REGISTRY_PUSH_ACCESS_TOKEN_*` | `prd` root stale after a Terraform replace — CI registry push broken |
| `CF_API_TOKEN_DNS_EDIT` | **5 of 7** configs stale after a dashboard roll |
| `CF_API_TOKEN_PURGE` | **6 of 7** configs stale after a dashboard roll |

In every case the operator-visible signal was success.

## Why detection, not removing `ignore_changes`

Removing the lifecycle rule would trade a silent-staleness bug for the churn bug the existing comments say was already hit once. I don't have enough context on that history to be confident the trade is good, so this PR **makes the failure loud instead of changing behaviour**. If the team later decides `ignore_changes` should go, this check is still the thing that proves it worked.

## What it does

`scripts/check-cloudflare-token-drift.sh` enumerates **configs and token keys from Doppler** — never a fixed list — verifies each distinct value once against the Cloudflare API, and exits `1` if any value is dead.

The no-hardcoded-list point is load-bearing: a fixed list is exactly how `CF_API_TOKEN_AUDIT` was missed during the incident sweep, because it lives only in the `dev*` configs which the hardcoded set never looked at.

## Verification

First live run **found 3 stale entries a manual sweep had missed** — `CF_API_TOKEN` is dead in `dev_personal` and `dev_scheduled`, not just `dev`:

```
configs scanned: 13   token keys: 10
live entries: 24   dead entries: 3

STALE — these configs hold a token value Cloudflare no longer accepts:
  CF_API_TOKEN  in  dev
  CF_API_TOKEN  in  dev_personal
  CF_API_TOKEN  in  dev_scheduled
```

- `shellcheck` clean
- exit `1` with stale entries present, `0` when clean
- `--json` mode emits machine-readable output for a future CI gate

## Follow-ups deliberately not in scope

- Wiring this into a scheduled workflow (needs a Doppler token decision — least-privilege scoping for a read-only checker)
- The 3 stale `dev*` entries it found — those are an operator call: delete, or mint a dev-scoped token. Copying the prod value into `dev` would violate the dev/prd isolation `cf-cert-reissue-token.tf` explicitly pins.

## Context

Third defect of this class found today, after #7038 (`ignore_changes = [ssh_keys]` making a key rotation force-replace prod hosts) and #7065 (service tokens unrotatable via Terraform). Common shape: **a rotation mechanism that exists, reports success, and doesn't do the thing.** All three surfaced the same way — by actually exercising the rotation instead of trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)