### PR TITLE
fix(review): record review coverage, and define what happens when agents cannot run

### DIFF
--- a/knowledge-base/engineering/architecture/decisions/ADR-127-review-evidence-trailer-is-a-boolean-not-a-content-attestation.md
+++ b/knowledge-base/engineering/architecture/decisions/ADR-127-review-evidence-trailer-is-a-boolean-not-a-content-attestation.md
@@ -4,6 +4,7 @@ status: accepted
 date: 2026-07-20
 issue: 6724
 supersedes: null
+amended_by: "#7066 follow-up (Reviewed-Coverage, 2026-07-29)"
 ---
 
 # ADR-127: the review-evidence trailer is a boolean, not a content attestation
@@ -46,6 +47,47 @@ Consequences of that split are stated in the script header and in
 corrected: the gate went from *structurally incapable of denying* to *capable of
 denying*, which is the whole of what #6724 required. It did not become
 unfalsifiable, and nothing shipping says it did.
+
+## Amendment — `Reviewed-Coverage:` (2026-07-29, PR #7066 follow-up)
+
+**A second field, on a DIFFERENT axis, and this decision is unchanged.** ADR-127 settled
+whether the trailer binds to a tree (it does not, and content-binding was rejected).
+`Reviewed-Coverage:` records HOW MUCH review ran. Both questions were previously
+unanswerable from the trailer; this amendment answers only the second.
+
+The gap was measured, not anticipated. `review/SKILL.md`'s Rate Limit Fallback gate reads
+"if ANY agent returned substantive output: proceed normally with available results" — the
+right call, and silent about which agents did not. So a 9-agent review where every agent
+concurred and a review where 7 of 9 died on `529 Overloaded` — losing `security-sentinel`,
+`test-design-reviewer` and `architecture-strategist` — emitted a **byte-identical** trailer,
+and `/ship` merges on that boolean. Observed 2026-07-29 during the review of PR #7066: 7 of
+9 agents terminated early on 529s and nothing in the repo recorded it.
+
+The worse shape the same amendment covers: a review that could not spawn agents AT ALL. That
+gate is defined over agents which *completed*, so it cannot see the state where none ever
+started (a harness withholding the Agent tool, a headless run, `wg-zero-agents-until-user-confirms`
+before the operator has opted in). The reviewer then either does an inline pass or skips
+review, and both emitted the full-strength trailer.
+
+**Emitted with no consumer, by this ADR's own argument for `Reviewed-Commit:`** — adding a
+field once the key is in `main`'s permanent history and read by three consumers is the
+expensive part; recording it now is cheap.
+
+Two properties make it non-decorative:
+
+- An absent measurement records `unknown`, **never `full`**. Every legacy call site omits the
+  flags, so defaulting to the strongest value would make the field meaningless on exactly the
+  calls that predate it.
+- The mode is **derived from the counts**, so a caller passing `--mode full` alongside
+  `--agents-ran 2 --agents-expected 10` gets `degraded`. The field cannot overclaim by
+  accident.
+
+It is **not** a quality score. Ten agents returning nothing useful outranks two that found a
+P1 on every axis this field measures. It answers one narrow question: how many of the intended
+reviewers actually ran.
+
+Pinned by `plugins/soleur/skills/review/test/emit-review-trailer.test.sh` (12 assertions,
+5 mutations verified load-bearing against a green baseline).
 
 ## Rejected alternatives
 

--- a/plugins/soleur/skills/review/SKILL.md
+++ b/plugins/soleur/skills/review/SKILL.md
@@ -324,12 +324,59 @@ Use `gdpr-gate` for deterministic Art. 9 / RoPA / lawful-basis pattern checks; u
 
 <decision_gate>
 
+**Gate 2a — CAN agents be spawned at all? (evaluate BEFORE the spawn, not after.)**
+
+Gate 2b below is defined over agents that **completed**. That makes it structurally blind
+to the state where agents were never spawned: a harness that withholds the Agent tool, a
+headless run with no agent surface, or a session-level constraint requiring explicit user
+opt-in (`wg-zero-agents-until-user-confirms`). Nothing ever completes, so no branch fires,
+and the reviewer improvises — historically by skipping review while the pipeline continues
+as though it ran.
+
+If agent spawning is unavailable or unauthorized:
+
+1. Do the inline review described in 2b. It is the sanctioned degraded path, not a failure.
+2. **Say so in the first line of the summary.** "Reviewed with 0 of N agents (spawning
+   unavailable: <reason>)" — never a bare "Review complete".
+3. Pass the coverage to the evidence trailer (Step 6): `--agents-ran 0 --agents-expected
+   <N> --mode inline-fallback`. A degraded review that emits a full-strength trailer is
+   worse than no trailer, because `/ship` reads that boolean and merges on it.
+4. Do NOT mark the PR ready on a `single-user incident` brand-survival threshold with zero
+   agents. Surface the choice to the operator: degraded review is adequate evidence for a
+   docs PR and is not adequate for an irreversible-blast-radius surface.
+
+**Gate 2b — did the agents that WERE spawned return?**
+
 After all parallel and conditional agents complete, check their outputs:
 
 - **If ALL agents returned empty output or rate-limit errors** (e.g., "out of extra usage", "rate limit exceeded", zero findings across every agent): perform an inline review in the main context covering all four core dimensions — security, architecture, performance, and simplicity. This is expected fallback behavior during high-usage periods, not an error condition.
 - **If ANY agent returned substantive output**: proceed normally with available results. No fallback needed — partial coverage from real agents is better than duplicating their work inline.
 
-This is a binary gate: all-failed triggers the fallback; any-succeeded means continue.
+This is a binary gate for the FALLBACK decision: all-failed triggers the inline pass;
+any-succeeded means continue.
+
+**It is NOT a binary gate for what you REPORT.** Partial coverage is the common case under
+load, and the two states are not interchangeable:
+
+- **Retry agents that died on a transient error before accepting partial coverage.** A
+  `529 Overloaded` is server-side and usually clears. Resume in small batches (3–4) with
+  backoff between batches — re-spawning ten at once is what caused the cascade in the first
+  place. Accept partial coverage only once retries stop helping.
+- **Name the missing agents** in the summary and pass them to the trailer
+  (`--agents-missing security-sentinel,test-design-reviewer`). The agents that die are not
+  correlated with the ones you needed least: losing `security-sentinel` on a
+  credential-handling diff, or `test-design-reviewer` on a diff whose central claim is
+  "the guards are mutation-proven", changes what the review is worth.
+- **The reviewer's own prior verification does not substitute.** This skill's defect-class
+  catalogue is a list of things that passed a green suite and the author's own self-review.
+  An agent that did not run did not check them.
+
+**Why this exists (measured, not hypothetical):** 2026-07-29 on PR #7066 — 7 of 9 review
+agents terminated early on `529 Overloaded`, including `security-sentinel`,
+`test-design-reviewer` and `architecture-strategist`. Gate 2b's "if ANY agent returned
+substantive output, proceed normally" was satisfied by the one that survived, and nothing
+in the repo recorded which were missing. The trailer `/ship` consumes would have been
+byte-identical to a full-coverage review's.
 
 </decision_gate>
 
@@ -925,8 +972,18 @@ After emitting the marker, the calling skill's continuation gate takes over — 
    [emit-review-trailer.sh](./scripts/emit-review-trailer.sh).
 
    ```bash
-   bash "${CLAUDE_PLUGIN_ROOT:-./plugins/soleur}/skills/review/scripts/emit-review-trailer.sh" --findings <n>
+   bash "${CLAUDE_PLUGIN_ROOT:-./plugins/soleur}/skills/review/scripts/emit-review-trailer.sh" \
+     --findings <n> \
+     --agents-ran <how many returned substantive output> \
+     --agents-expected <how many the classification gate called for> \
+     --agents-missing <comma-separated names, omit if none>
    ```
+
+   **The coverage flags are not optional decoration.** Without them the trailer records
+   `Reviewed-Coverage: unknown`, which is honest but leaves nothing downstream able to
+   distinguish a full review from one where the agents that mattered never ran (Gate 2a/2b
+   above). The script DERIVES `--mode` from the two counts, so a caller cannot label a
+   2-of-10 review `full`.
 
    This is a script invocation rather than a described `git commit` line because
    the described form has measured zero compliance on exactly the branches that

--- a/plugins/soleur/skills/review/scripts/emit-review-trailer.sh
+++ b/plugins/soleur/skills/review/scripts/emit-review-trailer.sh
@@ -144,7 +144,6 @@ for _pair in "AGENTS_RAN:$AGENTS_RAN" "AGENTS_EXPECTED:$AGENTS_EXPECTED"; do
     exit 2
   fi
 done
-AGENTS_RAN="${AGENTS_RAN//_/-}"  # no-op for digits; guards a stray underscore in a hand-typed value
 if [[ -n "$MODE" && ! "$MODE" =~ ^(full|degraded|inline-fallback)$ ]]; then
   echo "emit-review-trailer: --mode must be one of full|degraded|inline-fallback (got '${MODE}')" >&2
   exit 2

--- a/plugins/soleur/skills/review/scripts/emit-review-trailer.sh
+++ b/plugins/soleur/skills/review/scripts/emit-review-trailer.sh
@@ -49,8 +49,45 @@
 # warranted. Adding the field later would be the expensive part; enforcing a
 # field already present is cheap.
 #
+# WHAT `Reviewed-Coverage:` ADDS, AND WHY IT IS NOT A CONTRADICTION OF ADR-127
+#
+# ADR-127 settled ONE axis: the trailer does not attest that the merged tree is
+# the reviewed tree, and content-binding was rejected. `Reviewed-Coverage:`
+# records a DIFFERENT axis — HOW MUCH review ran — and leaves that decision
+# untouched.
+#
+# The gap it closes is measured, not hypothetical. review/SKILL.md's Rate Limit
+# Fallback gate reads "if ANY agent returned substantive output: proceed
+# normally with available results", which is the right call and is silent about
+# WHICH agents did not. So a 10-agent review where every agent concurred and a
+# review where 7 of 10 died on `529 Overloaded` — losing security-sentinel,
+# test-design-reviewer and architecture-strategist — emit a BYTE-IDENTICAL
+# trailer. Downstream, `/ship` reads that boolean and merges. Observed
+# 2026-07-29 on PR #7066: 7 of 9 agents terminated early on 529s, and nothing
+# in the repo would have recorded it.
+#
+# The worse shape is a review that could not spawn agents AT ALL — a harness
+# constraint, a headless run with no agent surface. The Rate Limit Fallback gate
+# cannot see that state, because it is defined over agents that COMPLETED and
+# nothing ever completes. The reviewer then either does an inline pass (correct)
+# or skips review (silent), and both emit the full-strength trailer.
+#
+# This field is emitted with NO consumer, by exactly the argument ADR-127 used
+# for `Reviewed-Commit:`: adding a field once the key is in main's permanent
+# history and read by three consumers is the expensive part. Recording it now is
+# cheap; a future gate that wants to weight a merge by review strength — or an
+# operator asking "was this PR actually reviewed, or reviewed-shaped?" — needs
+# the data to already be there.
+#
+# It is NOT a quality score. Ten agents returning nothing useful outranks two
+# that found a P1 on every axis this field measures. It answers one narrow
+# question: how many of the intended reviewers actually ran.
+#
 # Usage:
 #   emit-review-trailer.sh [--findings <n>] [--summary <text>]
+#                          [--agents-ran <n>] [--agents-expected <n>]
+#                          [--agents-missing <comma-separated-names>]
+#                          [--mode full|degraded|inline-fallback]
 #
 # Exit codes:
 #   0  trailer committed and verified parseable
@@ -75,17 +112,80 @@ EOF
 }
 
 TRAILER_KEY="Reviewed-By-Soleur"
+COVERAGE_KEY="Reviewed-Coverage"
 FINDINGS=""
 SUMMARY=""
+AGENTS_RAN=""
+AGENTS_EXPECTED=""
+AGENTS_MISSING=""
+MODE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --findings) FINDINGS="${2:?--findings needs a value}"; shift 2 ;;
     --summary)  SUMMARY="${2:?--summary needs a value}";  shift 2 ;;
+    --agents-ran)      AGENTS_RAN="${2:?--agents-ran needs a value}"; shift 2 ;;
+    --agents-expected) AGENTS_EXPECTED="${2:?--agents-expected needs a value}"; shift 2 ;;
+    --agents-missing)  AGENTS_MISSING="${2:?--agents-missing needs a value}"; shift 2 ;;
+    --mode)            MODE="${2:?--mode needs a value}"; shift 2 ;;
     -h|--help)  usage; exit 0 ;;
     *) echo "emit-review-trailer: unknown argument '$1'" >&2; exit 2 ;;
   esac
 done
+
+# Validate the coverage inputs BEFORE committing anything. A malformed count
+# would land in main's permanent history as an unparseable coverage claim, which
+# is the same "looks like evidence to a human, invisible to a consumer" defect
+# the VERIFY block at the bottom exists to prevent — just on a different field.
+for _pair in "AGENTS_RAN:$AGENTS_RAN" "AGENTS_EXPECTED:$AGENTS_EXPECTED"; do
+  _name="${_pair%%:*}"; _val="${_pair#*:}"
+  if [[ -n "$_val" && ! "$_val" =~ ^[0-9]+$ ]]; then
+    echo "emit-review-trailer: --${_name,,} must be a non-negative integer (got '${_val}')" >&2
+    exit 2
+  fi
+done
+AGENTS_RAN="${AGENTS_RAN//_/-}"  # no-op for digits; guards a stray underscore in a hand-typed value
+if [[ -n "$MODE" && ! "$MODE" =~ ^(full|degraded|inline-fallback)$ ]]; then
+  echo "emit-review-trailer: --mode must be one of full|degraded|inline-fallback (got '${MODE}')" >&2
+  exit 2
+fi
+# `ran > expected` is a contradiction, and silently accepting it would let the
+# field overclaim in exactly the direction that matters.
+if [[ -n "$AGENTS_RAN" && -n "$AGENTS_EXPECTED" && "$AGENTS_RAN" -gt "$AGENTS_EXPECTED" ]]; then
+  echo "emit-review-trailer: --agents-ran ($AGENTS_RAN) exceeds --agents-expected ($AGENTS_EXPECTED)" >&2
+  exit 2
+fi
+
+# DERIVE the mode rather than trusting the caller's label where the counts
+# already answer it. A caller that passes `--mode full` alongside `--agents-ran 2
+# --agents-expected 10` is either confused or overclaiming; the counts win.
+if [[ -n "$AGENTS_RAN" && -n "$AGENTS_EXPECTED" ]]; then
+  if [[ "$AGENTS_RAN" -eq 0 ]]; then
+    MODE="inline-fallback"
+  elif [[ "$AGENTS_RAN" -lt "$AGENTS_EXPECTED" ]]; then
+    MODE="degraded"
+  else
+    MODE="full"
+  fi
+fi
+
+# UNKNOWN is the honest default, and it is deliberately not "full". A caller that
+# does not pass the flags has told us nothing about coverage, and defaulting an
+# absent measurement to the strongest value is how a field like this becomes
+# decorative — every legacy call site would silently read as a 10-agent review.
+COVERAGE_VALUE="unknown"
+if [[ -n "$AGENTS_RAN" && -n "$AGENTS_EXPECTED" ]]; then
+  COVERAGE_VALUE="${MODE} ${AGENTS_RAN}/${AGENTS_EXPECTED} agents"
+  if [[ -n "$AGENTS_MISSING" ]]; then
+    # Commas separate names; keep them, they cannot break trailer parsing (only a
+    # newline or a non-`Key: value` line can).
+    COVERAGE_VALUE="${COVERAGE_VALUE} (missing: ${AGENTS_MISSING})"
+  fi
+elif [[ -n "$MODE" ]]; then
+  COVERAGE_VALUE="$MODE"
+fi
+# Newlines would split the final paragraph and void every trailer below this one.
+COVERAGE_VALUE="${COVERAGE_VALUE//$'\n'/ }"
 
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
   echo "emit-review-trailer: not a git repository" >&2
@@ -156,11 +256,12 @@ fi
 # later, once the key is in main's permanent history and read by three
 # consumers, is the expensive part; enforcing a field already present is cheap.
 REVIEWED_SHA=$(git rev-parse HEAD)
-COMMIT_MSG=$(printf '%s\n\n%s\n\n%s: soleur:review\n%s: %s\n' \
+COMMIT_MSG=$(printf '%s\n\n%s\n\n%s: soleur:review\n%s: %s\n%s: %s\n' \
   "review: ${SUMMARY}" \
-  "Records that soleur:review ran on this branch (see issue 6724). Empty by design: a review that finds nothing still needs to prove it ran. This is a boolean, not an attestation that the merged tree is the reviewed tree — see ADR-127." \
+  "Records that soleur:review ran on this branch (see issue 6724). Empty by design: a review that finds nothing still needs to prove it ran. This is a boolean, not an attestation that the merged tree is the reviewed tree — see ADR-127. Reviewed-Coverage records HOW MUCH review ran (a separate axis from ADR-127's tree-binding decision); 'unknown' means the caller did not measure, never that coverage was full." \
   "$TRAILER_KEY" \
-  "Reviewed-Commit" "$REVIEWED_SHA")
+  "Reviewed-Commit" "$REVIEWED_SHA" \
+  "$COVERAGE_KEY" "$COVERAGE_VALUE")
 
 # `--allow-empty` does NOT mean "empty" — it commits the INDEX, so anything
 # staged is silently absorbed into a commit whose subject reads
@@ -193,4 +294,23 @@ if [[ -z "$PARSED" ]]; then
   exit 1
 fi
 
+# Verify the coverage key SEPARATELY. `Reviewed-By-Soleur` parsing does not imply
+# its siblings parse: git needs the whole final paragraph to be `Key: value`
+# lines, but a value containing a newline splits the block and voids only the
+# keys BELOW the split — which is exactly where this one sits. Checking the first
+# key alone would report success while the field this change exists to add is
+# silently absent.
+PARSED_COVERAGE=$(git log -1 --format='%(trailers:key='"$COVERAGE_KEY"',valueonly)' | tr -d '[:space:]')
+if [[ -z "$PARSED_COVERAGE" ]]; then
+  echo "emit-review-trailer: FAILED — commit landed but '$COVERAGE_KEY' does not parse." >&2
+  echo "  It is the LAST trailer, so it is the first casualty of a split final paragraph." >&2
+  echo "  Inspect with: git interpret-trailers --parse < <(git log -1 --format=%B)" >&2
+  exit 1
+fi
+
 echo "emit-review-trailer: emitted $TRAILER_KEY on '$BRANCH' ($(git rev-parse --short HEAD))"
+echo "emit-review-trailer: $COVERAGE_KEY: $COVERAGE_VALUE"
+if [[ "$COVERAGE_VALUE" == "unknown" ]]; then
+  echo "emit-review-trailer: NOTE — coverage is 'unknown' because no --agents-ran/--agents-expected was passed." >&2
+  echo "  This is recorded honestly, but it means nothing downstream can tell a full review from a degraded one." >&2
+fi

--- a/plugins/soleur/skills/review/test/emit-review-trailer.test.sh
+++ b/plugins/soleur/skills/review/test/emit-review-trailer.test.sh
@@ -44,7 +44,17 @@ printf '\n=== emit-review-trailer coverage field ===\n\n'
 new_repo() {
   local d="$TMP/$1"; mkdir -p "$d"
   git -C "$d" init -q -b main
-  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "base"
+  # LOCAL config, not `-c` on our own commits. The SUT runs its OWN `git commit`, so an
+  # identity supplied only via `-c` on the fixture's setup commits does not reach it — it
+  # inherits whatever the ambient environment has. On a developer laptop that is the global
+  # config and every arm passes; on a bare CI runner there is none and the SUT dies with
+  # "Please tell me who you are", which surfaces as `git commit failed` and 8 of 12 arms red.
+  # Measured: this suite was 12/12 locally and 4/8 in CI on its first run (#7070).
+  git -C "$d" config user.email soleur-test@example.invalid
+  git -C "$d" config user.name  "Soleur Test"
+  # Some runners set commit.gpgsign globally; a throwaway repo has no key.
+  git -C "$d" config commit.gpgsign false
+  git -C "$d" commit -q --allow-empty -m "base"
   git -C "$d" checkout -q -b feat-x
   printf '%s' "$d"
 }

--- a/plugins/soleur/skills/review/test/emit-review-trailer.test.sh
+++ b/plugins/soleur/skills/review/test/emit-review-trailer.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Tests for emit-review-trailer.sh's coverage field (#7066 follow-up).
+#
+# WHY THIS SUITE EXISTS. The script's whole value is that a downstream consumer can tell a
+# full review from a degraded one. Every way that can silently stop being true looks like
+# success: a value that does not parse as a trailer is invisible to `git log
+# --format='%(trailers:...)'` while reading fine to a human; an absent measurement defaulting
+# to the strongest value makes the field decorative; and a caller-supplied `--mode full`
+# alongside 2-of-10 counts overclaims in the one direction that matters.
+#
+# EVERY ARM RUNS AGAINST A THROWAWAY REPO, never the real one — the script COMMITS, so a
+# suite that ran in-tree would leave empty commits on whatever branch invoked it.
+set -uo pipefail
+export TMPDIR="${TMPDIR:-/var/tmp}"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# ../scripts/ — this suite deliberately lives in skills/review/test/ and not beside the SUT
+# in skills/review/scripts/, because scripts/test-all.sh discovers
+# `plugins/soleur/skills/*/test/*.test.sh` and NOT `skills/*/scripts/*.test.sh`. Placed next
+# to the SUT it would be silent AND green: never run, never red (#3366).
+SUT="$(cd "${DIR}/../scripts" && pwd)/emit-review-trailer.sh"
+
+TMP="$(mktemp -d -t emitrt.XXXXXXXX)" || { echo "mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TMP"' EXIT
+
+passes=0
+fails=0
+pass() { passes=$((passes + 1)); printf '  ok   %s\n' "$1"; }
+fail() {
+  fails=$((fails + 1))
+  printf '  FAIL %s\n' "$1"
+  [[ -n "${2:-}" ]] && printf '       %s\n' "$2"
+  return 0
+}
+
+printf '\n=== emit-review-trailer coverage field ===\n\n'
+
+[[ -f "$SUT" ]] || { fail "SUT exists at $SUT"; printf '\n=== 0 passed, 1 failed ===\n\n'; exit 1; }
+
+# A fresh repo on a feature branch with a `main` to scope against. The script refuses to run
+# on main/master, and its idempotence check scopes to `origin/main..HEAD`-equivalent, so both
+# refs have to exist for the arms below to exercise the real paths.
+new_repo() {
+  local d="$TMP/$1"; mkdir -p "$d"
+  git -C "$d" init -q -b main
+  git -C "$d" -c user.email=t@t -c user.name=t commit -q --allow-empty -m "base"
+  git -C "$d" checkout -q -b feat-x
+  printf '%s' "$d"
+}
+
+coverage_of() {  # $1 = repo dir -> the parsed Reviewed-Coverage trailer value
+  git -C "$1" log -1 --format='%(trailers:key=Reviewed-Coverage,valueonly)' | tr -d '\n'
+}
+
+# ── ARM 1: full coverage ──────────────────────────────────────────────────────────
+d="$(new_repo full)"
+out="$(cd "$d" && bash "$SUT" --findings 0 --agents-ran 9 --agents-expected 9 2>&1)"; rc=$?
+if [[ "$rc" -eq 0 ]]; then pass "full coverage exits 0"; else fail "full coverage exits 0" "rc=$rc out=$out"; fi
+cov="$(coverage_of "$d")"
+if [[ "$cov" == *"full 9/9 agents"* ]]; then pass "records 'full 9/9 agents'"; else
+  fail "records 'full 9/9 agents'" "got: '$cov'"; fi
+
+# ── ARM 2: degraded coverage, with the missing agents NAMED ───────────────────────
+#
+# This is the shape measured on PR #7066 (7 of 9 died on 529s). The named list is the part a
+# reader needs: "2/9" says how much ran, not WHICH lens is absent, and the agents that die
+# are not the ones you needed least.
+d="$(new_repo degraded)"
+out="$(cd "$d" && bash "$SUT" --findings 3 --agents-ran 2 --agents-expected 9 \
+        --agents-missing security-sentinel,test-design-reviewer 2>&1)"; rc=$?
+cov="$(coverage_of "$d")"
+if [[ "$rc" -eq 0 && "$cov" == *"degraded 2/9 agents"* ]]; then
+  pass "records 'degraded 2/9 agents'"
+else
+  fail "records 'degraded 2/9 agents'" "rc=$rc got: '$cov'"
+fi
+if [[ "$cov" == *"security-sentinel"* && "$cov" == *"test-design-reviewer"* ]]; then
+  pass "names the missing agents in the trailer value"
+else
+  fail "names the missing agents in the trailer value" "got: '$cov'"
+fi
+
+# ── ARM 3: zero agents => inline-fallback ─────────────────────────────────────────
+d="$(new_repo zero)"
+(cd "$d" && bash "$SUT" --findings 1 --agents-ran 0 --agents-expected 8 >/dev/null 2>&1)
+cov="$(coverage_of "$d")"
+if [[ "$cov" == *"inline-fallback 0/8 agents"* ]]; then
+  pass "zero agents records 'inline-fallback'"
+else
+  fail "zero agents records 'inline-fallback'" "got: '$cov'"
+fi
+
+# ── ARM 4: THE COUNTS OVERRIDE A CALLER'S LABEL ───────────────────────────────────
+#
+# A caller passing `--mode full` with 2-of-10 counts is either confused or overclaiming.
+# Deriving the mode from the counts is what makes the field non-forgeable by accident.
+d="$(new_repo overclaim)"
+(cd "$d" && bash "$SUT" --agents-ran 2 --agents-expected 10 --mode full >/dev/null 2>&1)
+cov="$(coverage_of "$d")"
+if [[ "$cov" == *degraded* && "$cov" != *full* ]]; then
+  pass "counts override an overclaiming --mode full"
+else
+  fail "counts override an overclaiming --mode full" "got: '$cov'"
+fi
+
+# ── ARM 5: ABSENT measurement is 'unknown', NOT 'full' ────────────────────────────
+#
+# The load-bearing default. Every legacy call site omits the flags, so defaulting an absent
+# measurement to the strongest value would make the field decorative on exactly the calls
+# that predate it — and would read as a full review having run.
+d="$(new_repo legacy)"
+(cd "$d" && bash "$SUT" --findings 0 >/dev/null 2>&1)
+cov="$(coverage_of "$d")"
+if [[ "$cov" == "unknown" ]]; then pass "absent measurement records 'unknown', not 'full'"; else
+  fail "absent measurement records 'unknown', not 'full'" "got: '$cov'"; fi
+
+# ── ARM 6: the coverage trailer PARSES (it is last, so it splits first) ───────────
+#
+# git needs the whole final paragraph to be `Key: value` lines. Reviewed-Coverage sits LAST,
+# so it is the first casualty of a split — and a value that does not parse is invisible to
+# every consumer while looking like evidence in `git log`.
+d="$(new_repo parse)"
+(cd "$d" && bash "$SUT" --agents-ran 4 --agents-expected 4 >/dev/null 2>&1)
+if [[ -n "$(coverage_of "$d")" ]] \
+   && [[ -n "$(git -C "$d" log -1 --format='%(trailers:key=Reviewed-By-Soleur,valueonly)' | tr -d '[:space:]')" ]]; then
+  pass "both Reviewed-By-Soleur and Reviewed-Coverage parse as trailers"
+else
+  fail "both trailers parse" "$(git -C "$d" log -1 --format=%B)"
+fi
+
+# ── ARM 7: malformed input is REFUSED before any commit ───────────────────────────
+#
+# A bad count must not land in main's permanent history as an unparseable coverage claim.
+# Asserting "no commit was created" is the load-bearing half: exiting 2 while having already
+# committed would be strictly worse than accepting the value.
+for bad in "--agents-ran abc --agents-expected 5" \
+           "--agents-ran 5 --agents-expected 2" \
+           "--mode enthusiastic"; do
+  d="$(new_repo "bad$(echo "$bad" | tr -cd 'a-z0-9')")"
+  before="$(git -C "$d" rev-parse HEAD)"
+  # shellcheck disable=SC2086
+  out="$(cd "$d" && bash "$SUT" $bad 2>&1)"; rc=$?
+  after="$(git -C "$d" rev-parse HEAD)"
+  if [[ "$rc" -eq 2 && "$before" == "$after" ]]; then
+    pass "refuses '$bad' with no commit"
+  else
+    fail "refuses '$bad' with no commit" "rc=$rc committed=$([[ "$before" != "$after" ]] && echo yes || echo no) out=$out"
+  fi
+done
+
+# ── ARM 8: still refuses to run on main ──────────────────────────────────────────
+# Guards against the coverage plumbing having disturbed the pre-existing branch guard.
+d="$(new_repo onmain)"; git -C "$d" checkout -q main
+out="$(cd "$d" && bash "$SUT" --agents-ran 1 --agents-expected 1 2>&1)"; rc=$?
+if [[ "$rc" -eq 0 && "$out" == *"nothing to mark, skipping"* ]]; then
+  pass "still skips on main (pre-existing guard intact)"
+else
+  fail "still skips on main" "rc=$rc out=$out"
+fi
+
+# ── Minimum-cardinality floor ────────────────────────────────────────────────────
+# A floor, not equality: developer-incremented, so `-eq` would redden the suite on every
+# added arm. Counts passes+fails so a genuine failure reports as a failure rather than as an
+# empty suite.
+_ran=$((passes + fails))
+if [[ "$_ran" -lt 12 ]]; then
+  fails=$((fails + 1))
+  printf '  FAIL ANTI-VACUITY: only %s assertions ran, floor is 12.\n' "$_ran"
+else
+  printf '  ok   anti-vacuity floor: %s assertions ran (floor 12)\n' "$_ran"
+fi
+
+printf '\n=== emit-review-trailer coverage: %d passed, %d failed ===\n\n' "$passes" "$fails"
+[[ "$fails" -eq 0 ]]

--- a/plugins/soleur/skills/ship/SKILL.md
+++ b/plugins/soleur/skills/ship/SKILL.md
@@ -70,7 +70,7 @@ pwd
 # The real signal is neither position nor shape: it is whether the key is
 # one a downstream consumer actually reads. Prose keys are not. Extend this
 # list when a new machine-read trailer is introduced.
-KNOWN_TRAILER_KEYS='Co-Authored-By|Signed-off-by|Allowlist-Widened-By|Reviewed-by|Reviewed-By-Soleur|Acked-by|Tested-by|Cc'
+KNOWN_TRAILER_KEYS='Co-Authored-By|Signed-off-by|Allowlist-Widened-By|Reviewed-by|Reviewed-By-Soleur|Reviewed-Coverage|Acked-by|Tested-by|Cc'
 RC=0
 for sha in $(git rev-list origin/main..HEAD); do
   BODY=$(git log -1 --format=%B "$sha")

--- a/plugins/soleur/skills/work/SKILL.md
+++ b/plugins/soleur/skills/work/SKILL.md
@@ -255,7 +255,16 @@ Run these checks before proceeding to Phase 1. A FAIL blocks execution with a re
 
    **Tier B: Subagent Fan-Out** (fire-and-gather, moderate cost)
 
-   **Read `plugins/soleur/skills/work/references/work-subagent-fanout.md` now** for the full Subagent Fan-Out protocol (offer, group/spawn, collect/integrate). If declined, fall through to Tier C.
+   **Read `plugins/soleur/skills/work/references/work-subagent-fanout.md` now** for the full Subagent Fan-Out protocol (offer, group/spawn, collect/integrate). If declined **or failed**, fall through to Tier C.
+
+   The `or failed` is load-bearing and was missing: Tier 0 and Tier A both read "If
+   declined **or failed**, fall through", so a spawn FAILURE at those tiers has a defined
+   next step. Tier B said only "If declined" — leaving a spawn failure (agent tool
+   withheld, `529 Overloaded`, headless run with no agent surface) with no prescribed
+   behavior at the LAST tier that can degrade. Tier C is always available because it is
+   sequential execution in the main context, so the fall-through costs nothing and closes
+   the gap. When it fires, say so: "Tier B fan-out unavailable (<reason>) — executing
+   sequentially" rather than silently running Tier C as though it were the chosen tier.
 
    ---
 


### PR DESCRIPTION
The review pipeline had no defined behavior when its agents do not run, and no way to record that they did not. Three gaps, one seam.

## Measured, not anticipated

During the review of PR #7066 on 2026-07-29, **7 of 9 review agents terminated early on `529 Overloaded`** — including `security-sentinel`, `test-design-reviewer` and `architecture-strategist`, i.e. the three lenses that diff most needed (it touches the last mechanical interlock on birthing a host that stores every user's source code).

`review/SKILL.md` §2 says *"if ANY agent returned substantive output: proceed normally with available results"*. That was satisfied by the one survivor. Nothing in the repo recorded which were missing, and the evidence trailer `/ship` consumes would have been **byte-identical** to a full-coverage review's.

## The three gaps

**1. The gate cannot see "agents never spawned".** §2 was defined over agents that *completed* — "after all agents complete, check their outputs". So the state where none were ever spawned is invisible to it: a harness withholding the Agent tool, a headless run, or `wg-zero-agents-until-user-confirms` before the operator has opted in. Nothing completes, no branch fires, and the reviewer improvises — historically by skipping review while the pipeline continues as though it ran.

Adds **Gate 2a**, evaluated *before* the spawn, with the degraded path spelled out: do the inline pass, say so in the **first line** of the summary, pass the coverage to the trailer, and do not mark a `single-user incident` PR ready on zero agents.

**2. "Proceed normally" was being read as "report normally".** The fallback call is right; what was missing is that partial coverage must be *retried* (small batches, with backoff — re-spawning ten at once is what caused the cascade) and then *named*. The agents that die are not correlated with the ones you needed least.

**3. The trailer was a boolean.** `emit-review-trailer.sh` emitted `Reviewed-By-Soleur:` and nothing about strength. Adds `Reviewed-Coverage:`, e.g. `degraded 2/9 agents (missing: security-sentinel,test-design-reviewer)`.

## Two properties that keep the new field from being decorative

- **An absent measurement records `unknown`, never `full`.** Every legacy call site omits the flags. Defaulting an unmeasured value to the strongest one would make the field meaningless on exactly the calls that predate it — and would read as a full review having run.
- **The mode is derived from the counts.** `--mode full` alongside `--agents-ran 2 --agents-expected 10` yields `degraded`. It cannot overclaim by accident.

It is **not** a quality score. Ten agents returning nothing useful outranks two that found a P1 on every axis this measures. It answers one narrow question: how many of the intended reviewers actually ran.

## ADR-127 is amended, not contradicted

ADR-127 settled whether the trailer binds to a **tree** (it does not; content-binding was rejected). This records **coverage** — a different axis. And it is emitted with no consumer by that ADR's own argument for `Reviewed-Commit:`: adding a field once the key is in `main`'s permanent history and read by three consumers is the expensive part.

## Also in this PR

A real asymmetry in `work/SKILL.md`: Tier 0 and Tier A both read *"If declined **or failed**, fall through"*; Tier B read only *"If declined"*. A spawn failure at the **last** tier that can degrade had no prescribed next step. Tier C is always available (sequential, main context), so the fall-through costs nothing.

## Verification

- 12/12 assertions in `plugins/soleur/skills/review/test/emit-review-trailer.test.sh`.
- **5 mutations each land and redden the suite against a green sandbox baseline**: counts-no-longer-override-mode, `unknown`-default-becomes-`full`, drop the `ran > expected` refusal, drop the `--mode` enum validation, drop the integer validation. Every mutation asserted to have LANDED (anchor must occur exactly once) before its result was read.
- The coverage trailer is verified to **parse separately** from `Reviewed-By-Soleur`. It sits last, so it is the first casualty of a split final paragraph — checking only the first key would report success while the field this PR adds is silently absent.
- `pre-merge-rebase.test.sh` (the trailer's existing consumer) 18/0 · `components.test.ts` 1297/0 · shellcheck clean.

**Cross-consumer sweep:** `Reviewed-Coverage` added to `ship/SKILL.md`'s `KNOWN_TRAILER_KEYS`, or the trailer-hygiene gate flags it as an unknown trailer.

**Suite placement is load-bearing.** It lives in `skills/review/test/`, not beside the SUT in `skills/review/scripts/`, because `test-all.sh` discovers `skills/*/test/*.test.sh` and **not** `skills/*/scripts/`. Next to the SUT it would have been silent AND green (#3366). Verified matched by the glob before committing.

Ref #7066.

## Changelog

- `soleur:review` — added Gate 2a: a defined degraded path for when review agents cannot be spawned at all (harness constraint, headless run, or pre-opt-in). The pre-existing Rate Limit Fallback gate was defined over agents that *completed* and could not see that state.
- `soleur:review` — partial agent coverage must now be retried in small batches with backoff, and the missing agents named, before it is accepted.
- `soleur:review` — `emit-review-trailer.sh` now emits `Reviewed-Coverage:` recording how many of the intended agents actually ran. Absent measurement records `unknown`, never `full`; the mode is derived from the counts so a caller cannot label a 2-of-10 review `full`.
- `soleur:ship` — `Reviewed-Coverage` added to `KNOWN_TRAILER_KEYS` (required, or the trailer-hygiene gate flags it as unknown).
- `soleur:work` — Tier B fan-out now falls through to Tier C on spawn **failure**, not only on decline, matching Tier 0 and Tier A.
- New suite `plugins/soleur/skills/review/test/emit-review-trailer.test.sh` (12 assertions, 5 mutations verified load-bearing).
