### PR TITLE
fix(infra): correct a plugin-seed timeout multiple that CI contradicted

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -593,10 +593,18 @@ jobs:
       # budget. A cold-pull stall must fail naming THIS step rather than let the job ceiling
       # cancel at whatever unrelated step the clock reached.
       #
-      # The multiple IS statable, from CI rather than from the warm local cache: API-measured
-      # across 7 runs on this branch this step costs 0-4s. 60s is therefore ~15-30x, which is
-      # more generous in ratio terms than the ci-deploy.sh tests ceiling above (3min against an
+      # The multiple IS statable, from CI rather than from the warm local cache. API-measured on
+      # this step: 0-4s across the 7 runs that preceded this ceiling, and **6s** on run
+      # 30539863151 — the first run to actually execute under the 60s ceiling. So 60s is ~10x the
+      # observed worst case, comparable to the ci-deploy.sh tests ceiling above (3min against an
       # API-measured 25s, ~7.2x).
+      #
+      # The superseded figure is named rather than quietly overwritten, because the correction is
+      # the point. #7072 set this ceiling and wrote "~15-30x" from the 7-run sample; the very next
+      # run measured 6s and made that false. A multiple quoted from an N-run sample is a claim
+      # with a shelf life — re-derive it (not extrapolate) whenever the fixture image or the
+      # runner class changes. #7072 was the PR about comments that assert untrue things, and it
+      # shipped one; this is the fix.
       #
       # 60s, not the 180s an earlier revision carried, because at 180s the ceiling DEFEATS the
       # attribution it exists to provide. Whole-job is API-measured 242-270s over those same 7


### PR DESCRIPTION
## Summary

Comment-only. #7072 set `timeout-minutes: 1` on the `cloud-init-plugin-seed` step and justified it as **"~15-30x the API-measured 0-4s"**, from a 7-run sample. The very next run — `30539863151`, the first to actually execute under that new ceiling — measured **6s**, making the real figure **~10x** and the comment false.

Ref #7068. (Deliberately `Ref`, not `Closes` — #7068 is already closed by #7072; this is a correction to what that PR shipped.)

## The decision is unchanged and still well-margined

The ceiling exists for **attribution** — a stall should name *this* step rather than let the 480s job ceiling cancel anonymously at whatever step the clock reached:

```
270s job max  -  6s this step  +  60s full-ceiling hang  =  324s   vs  480s job ceiling
                                                          margin:  156s (32%)
```

So the step ceiling still fires first. At the 180s ceiling #7072 replaced, the same arithmetic left only 34s — less than the branch's own 28s job spread, which is why it was lowered.

## Why this is its own PR

The superseded `0-4s` figure is **named rather than quietly overwritten**, because the correction is the point: a multiple quoted from an N-run sample is a claim with a shelf life. #7072 was the PR about comments that assert untrue things — and it shipped one. It was caught by re-deriving from that PR's own CI rather than by restating the number.

The fix missed #7072's merge for a mundane reason worth recording: the correction was committed locally, the `git push` timed out on an intermittently-refusing SSH agent, and auto-merge fired on the previous SHA in that window. The commit was never on the remote head, so the squash could not include it — the `wg-ship-push-before-merge` class, arriving via a push *timeout* rather than a forgotten push.

## Test plan

- [x] Diff is comment-only (mechanically verified: zero non-comment `+`/`-` lines)
- [x] `bash scripts/lint-workflows.sh` → exit 0
- [x] `.github/scripts/test/test-infra-suite-registration.sh` → exit 0 on this tree: `94 suites registered in deploy-script-tests (86 derivable; 7 subdirectories — #7076; 1 excluded)`
- [x] Live ratio claim now reads `60s is ~10x`; the only surviving `15-30x` is the explicit historical quotation at line 603
- [x] Attribution arithmetic re-derived against the observed 6s (above)

Generated with [Claude Code](https://claude.com/claude-code)
