### PR TITLE
fix(ci): the rung-2 suite did not run when the workflows it guards were edited

### DIFF
--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -30,6 +30,21 @@ on:
       # never run the guard that catches it.
       - ".github/workflows/apply-inngest-rls.yml"
       - ".github/workflows/apply-inngest-rls-dev.yml"
+      # (#7025) git-data-rung2-rehearsal.test.sh reads THREE workflows and asserts ~64
+      # properties across them: the rehearsal route's dispatch contract, its errexit posture
+      # (arm 13d), the behavioural capture-poll arms that EXECUTE the real step body, the
+      # concurrency-group literal shared with the birth/replace jobs in the apply workflow,
+      # and the orphan sweep in the drift workflow. None of the three was covered here, so a
+      # PR editing ONLY one of them skipped the suite that guards it -- the same defect the
+      # #6454 and #6178 comments describe, on the route that gates the birth of the host
+      # holding every connected user's source code.
+      #
+      # Measured: the suite's own WF/APPLY_WF/DRIFT_WF variables resolve to exactly these
+      # three paths, and PR #7094 ran this job only incidentally, because it also touched
+      # apps/web-platform/infra/ (already covered by the first glob above).
+      - ".github/workflows/git-data-rung2-rehearsal.yml"
+      - ".github/workflows/apply-web-platform-infra.yml"
+      - ".github/workflows/scheduled-terraform-drift.yml"
       # (#6178) cutover-inngest-workflow.test.sh asserts ~90 properties OF cutover-inngest.yml
       # -- the anchor derivation, the non-vacuity gate, the per-arm window split, the null-safe
       # bucketing, and the emitter-parity of the flip-FSM reason set. Without this path a PR that

--- a/apps/web-platform/infra/git-data-rung2-rehearsal.test.sh
+++ b/apps/web-platform/infra/git-data-rung2-rehearsal.test.sh
@@ -1235,12 +1235,44 @@ else
   fail "the orphan sweep does not query the Hetzner API"
 fi
 
+# ── 14. THIS SUITE RUNS WHEN THE WORKFLOWS IT GUARDS ARE EDITED ────────────────────
+#
+# infra-validation.yml is `paths:`-filtered. Every assertion above reads one of three
+# workflows, and NONE of the three was in that filter until #7025 -- so a PR editing only
+# `git-data-rung2-rehearsal.yml` did not run the suite whose entire job is protecting it.
+# PR #7094 ran it only incidentally, because it also touched apps/web-platform/infra/.
+#
+# That is the same defect the #6454 and #6178 comments in infra-validation.yml already
+# describe ("the job that proves the gate works would be skipped by the very PR changing the
+# gate") -- patched three times for other workflows and still open for this one. Derived from
+# the SUITE's own variables rather than a hardcoded list, so adding a fourth workflow to this
+# file reds here until its path is registered.
+INFRA_VALIDATION_WF="${ROOT}/.github/workflows/infra-validation.yml"
+if [[ ! -f "$INFRA_VALIDATION_WF" ]]; then
+  fail "infra-validation.yml is missing — cannot verify this suite is registered against the workflows it reads"
+else
+  _unregistered=""
+  _checked_paths=0
+  for _guarded in "$WF" "$APPLY_WF" "$DRIFT_WF"; do
+    _rel=".github/workflows/$(basename "$_guarded")"
+    _checked_paths=$((_checked_paths + 1))
+    grep -qF ""${_rel}"" "$INFRA_VALIDATION_WF" || _unregistered="${_unregistered} ${_rel}"
+  done
+  if [[ "$_checked_paths" -lt 3 ]]; then
+    fail "path-coverage arm derived only ${_checked_paths} guarded workflow(s), expected 3"       "the WF/APPLY_WF/DRIFT_WF variables drifted; this arm is comparing against an incomplete set"
+  elif [[ -z "$_unregistered" ]]; then
+    pass "all ${_checked_paths} workflows this suite reads are in infra-validation.yml's paths filter (editing one runs this suite)"
+  else
+    fail "workflow(s) this suite guards are NOT in infra-validation.yml's paths filter:${_unregistered}"       "a PR editing only that workflow would skip this suite entirely — the guard would not run on the change it exists to catch"
+  fi
+fi
+
 # ── Minimum-cardinality floor ──────────────────────────────────────────────────────
 # A floor, not an equality: developer-incremented, so `-eq` would redden the suite on every
 # legitimately added arm and train the next person to bump it unread. Counts passes+fails so
 # a genuine failure reports as a failure rather than as an empty suite.
 #
-# RAISED 28 -> 39 -> 43 -> 64 WITH THE ARMS THAT MADE IT NECESSARY (#7025 R7; the 43 -> 56
+# RAISED 28 -> 39 -> 43 -> 65 WITH THE ARMS THAT MADE IT NECESSARY (#7025 R7; the 43 -> 56
 # step is the behavioural capture-poll block, arms 13/13b/13c/13d/13e). At 28 the slack had grown
 # to exceed the work it was guarding: deleting arms 6, 7, 7b, 7c and 7d — every arm that
 # compares the two roots, i.e. the suite's entire reason for existing — landed on exactly 28
@@ -1248,11 +1280,11 @@ fi
 # not move with the suite only ever guards the work that predates it, and the deletion it
 # most needs to catch is the one that removes the arms someone just argued for.
 _ran=$((passes + fails))
-if [[ "$_ran" -lt 64 ]]; then
+if [[ "$_ran" -lt 65 ]]; then
   fails=$((fails + 1))
-  printf '  FAIL ANTI-VACUITY: only %s assertions ran, floor is 64. Arms were deleted, skipped, or the suite exited early.\n' "$_ran"
+  printf '  FAIL ANTI-VACUITY: only %s assertions ran, floor is 65. Arms were deleted, skipped, or the suite exited early.\n' "$_ran"
 else
-  printf '  ok   anti-vacuity floor: %s assertions ran (floor 64)\n' "$_ran"
+  printf '  ok   anti-vacuity floor: %s assertions ran (floor 65)\n' "$_ran"
 fi
 
 printf '\n=== git-data-rung2-rehearsal: %d passed, %d failed ===\n\n' "$passes" "$fails"

--- a/apps/web-platform/infra/git-data-rung2-rehearsal.test.sh
+++ b/apps/web-platform/infra/git-data-rung2-rehearsal.test.sh
@@ -1250,20 +1250,82 @@ fi
 INFRA_VALIDATION_WF="${ROOT}/.github/workflows/infra-validation.yml"
 if [[ ! -f "$INFRA_VALIDATION_WF" ]]; then
   fail "infra-validation.yml is missing — cannot verify this suite is registered against the workflows it reads"
+elif ! command -v python3 >/dev/null 2>&1; then
+  fail "python3 absent — the path-registration arm did NOT run" \
+    "a gate that cannot run must not report success"
 else
-  _unregistered=""
-  _checked_paths=0
-  for _guarded in "$WF" "$APPLY_WF" "$DRIFT_WF"; do
-    _rel=".github/workflows/$(basename "$_guarded")"
-    _checked_paths=$((_checked_paths + 1))
-    grep -qF ""${_rel}"" "$INFRA_VALIDATION_WF" || _unregistered="${_unregistered} ${_rel}"
-  done
-  if [[ "$_checked_paths" -lt 3 ]]; then
-    fail "path-coverage arm derived only ${_checked_paths} guarded workflow(s), expected 3"       "the WF/APPLY_WF/DRIFT_WF variables drifted; this arm is comparing against an incomplete set"
-  elif [[ -z "$_unregistered" ]]; then
-    pass "all ${_checked_paths} workflows this suite reads are in infra-validation.yml's paths filter (editing one runs this suite)"
+  # ASK THE OPERATIONAL QUESTION, not a textual one: "would a PR editing ONLY this file
+  # trigger this workflow?" Ten mutations defeated the textual form and every one is
+  # realistic: the path in a COMMENT (this file is dense with comments naming paths, so
+  # deleting an entry while leaving its rationale comment read as registered); the path in
+  # a `run:` body; `- "!<path>"`, GitHub's EXCLUSION idiom used two files away in
+  # apply-web-platform-infra.yml, which makes the entry never fire while the substring is
+  # still present; `paths:` renamed to `paths-ignore:`, inverting the filter for the WHOLE
+  # workflow; and the three entries moved to a `push:` block, so the suite runs only after
+  # merge — when the route is already broken.
+  #
+  # Matching against the PARSED pull_request filter with fnmatch closes all of them by
+  # construction, and mirrors the in-repo instrument infra-validation.yml's own comment
+  # block cites: apply-inngest-rls-dev-workflow.test.sh's `routes()`.
+  #
+  # The guarded set is DERIVED by grepping this file's own `*_WF=` assignments — not a
+  # restated triple. An earlier version hardcoded three variable NAMES while its comment
+  # claimed derivation; adding a fourth `*_WF` left it reporting "all 3" and silently
+  # uncovered, and pointing two vars at one file left it counting 3 distinct when there
+  # were 2.
+  _paths_probe="$(python3 - "$INFRA_VALIDATION_WF" "$0" <<'PY'
+import fnmatch, os, re, sys, yaml
+
+wf_file, suite_file = sys.argv[1], sys.argv[2]
+d = yaml.safe_load(open(wf_file))
+on = d.get(True) or d.get("on") or {}
+pr = on.get("pull_request") or {}
+declared = [str(x) for x in (pr.get("paths") or [])]
+
+def routes(path):
+    """Would a PR whose ONLY changed file is `path` trigger this workflow?"""
+    if any(fnmatch.fnmatch(path, p[1:]) for p in declared if p.startswith("!")):
+        return False                      # an explicit `!` exclusion wins
+    return any(fnmatch.fnmatch(path, p) for p in declared if not p.startswith("!"))
+
+# Derive the guarded workflows from the suite's OWN assignments.
+src = open(suite_file).read()
+guarded = set()
+for m in re.finditer(r'^[A-Z_]*WF="\$\{ROOT\}/(\.github/workflows/[^"]+)"', src, re.M):
+    guarded.add(m.group(1))
+
+print("DECLARED=%d" % len(declared))
+print("GUARDED=%d" % len(guarded))
+for g in sorted(guarded):
+    if not os.path.isfile(os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(wf_file))), g)):
+        print("NOFILE=%s" % g)
+    elif not routes(g):
+        print("MISSING=%s" % g)
+# NEGATIVE CONTROL: a path that must NOT route, so a filter that matched everything
+# (paths-ignore, a stray "**") cannot satisfy this arm vacuously.
+print("CONTROL_ROUTES=%d" % (1 if routes("README.md") else 0))
+PY
+)" || _paths_probe="PROBE_FAILED=1"
+  _pguarded="$(printf '%s\n' "$_paths_probe" | sed -n 's/^GUARDED=//p')"
+  _pmissing="$(printf '%s\n' "$_paths_probe" | sed -n 's/^MISSING=//p' | tr '\n' ' ')"
+  _pnofile="$(printf '%s\n' "$_paths_probe" | sed -n 's/^NOFILE=//p' | tr '\n' ' ')"
+  _pcontrol="$(printf '%s\n' "$_paths_probe" | sed -n 's/^CONTROL_ROUTES=//p')"
+  if printf '%s' "$_paths_probe" | grep -q 'PROBE_FAILED=1'; then
+    fail "could not parse infra-validation.yml's pull_request filter — refusing to read an unparseable filter as coverage"
+  elif [[ "${_pguarded:-0}" -lt 3 ]]; then
+    fail "derived only ${_pguarded:-0} guarded workflow(s) from this suite's own *_WF= assignments (expected >= 3)" \
+      "the extraction drifted; this arm is comparing against an incomplete set and would pass over an unregistered workflow"
+  elif [[ "${_pcontrol:-1}" -ne 0 ]]; then
+    fail "NEGATIVE CONTROL FAILED: a PR touching only README.md would trigger infra-validation" \
+      "the filter matches everything (paths-ignore, or a stray '**'), so this arm's pass would be vacuous"
+  elif [[ -n "$_pnofile" ]]; then
+    fail "a *_WF= assignment names a file that does not exist: ${_pnofile}" \
+      "cannot verify registration for a workflow that is not on disk"
+  elif [[ -z "$_pmissing" ]]; then
+    pass "a PR editing ONLY any of the ${_pguarded} workflows this suite reads WOULD trigger infra-validation (parsed filter, negative control held)"
   else
-    fail "workflow(s) this suite guards are NOT in infra-validation.yml's paths filter:${_unregistered}"       "a PR editing only that workflow would skip this suite entirely — the guard would not run on the change it exists to catch"
+    fail "editing ONLY these workflow(s) would NOT trigger infra-validation: ${_pmissing}" \
+      "this suite guards them, so a PR changing one would skip the guard entirely — check for a missing entry, a '!' exclusion, paths-ignore, or a push-only block"
   fi
 fi
 


### PR DESCRIPTION
## What this fixes

`infra-validation.yml` is `paths:`-filtered. `git-data-rung2-rehearsal.test.sh` reads **three** workflows and asserts ~65 properties across them:

| workflow | what the suite asserts about it |
|---|---|
| `git-data-rung2-rehearsal.yml` | the dispatch contract, `contents: read`, the dry-run default, the errexit posture (arm 13d), and the behavioural arms that **execute** the real capture-step body |
| `apply-web-platform-infra.yml` | the shared `git-data-state` concurrency literal — a divergent group would let a rehearsal and a birth race the same R2 state, which has no lock |
| `scheduled-terraform-drift.yml` | the orphan sweep that reclaims a leaked paid host the rehearsal state has forgotten |

**None of the three was in the filter.** So a PR editing only one of them skipped the suite whose entire job is protecting it. #7094 ran the suite only *incidentally*, because it also touched `apps/web-platform/infra/`, which the first glob already covers.

This is the same defect the `#6454` and `#6178` comments in that file already describe — *"the job that proves the gate works would be skipped by the very PR changing the gate"* — patched twice for other workflows and still open for the route that gates the birth of the host holding every connected user's source code.

## Why a guard and not just the three lines

Registering the paths fixes today's gap. **Arm 14 stops it recurring**, and it *derives* the guarded set from the suite's own `WF` / `APPLY_WF` / `DRIFT_WF` variables rather than restating a list — so adding a fourth workflow to this suite reds here until its path is registered. A hardcoded triple would have gone stale exactly the way the filter did.

It also asserts the derived set has cardinality **3**, so a variable rename cannot silently shrink what is compared and leave the arm passing over a smaller set.

## Verification

Mutation-proven rather than asserted:

- Remove `git-data-rung2-rehearsal.yml` from the filter → **64 passed, 1 failed**, naming that exact path.
- Restored → **65 passed, 0 failed**.

Registered infra suites **87/87**. YAML parses. `shellcheck` clean beyond the expected SC1090 on the dynamic source.

Anti-vacuity floor 64 → 65.

Ref #7025
