### PR TITLE
fix(infra): the drift detector graded the CI-SSH token DEAD forever, and 200 was unreachable

### DIFF
--- a/scripts/check-cloudflare-token-drift.sh
+++ b/scripts/check-cloudflare-token-drift.sh
@@ -282,7 +282,13 @@ UNVERIFIABLE_ROWS=()
 declare -A PAIR_VERDICT=()   # "host|id|secret" -> LIVE|DEAD (verify each distinct pair once)
 
 verify_access_pair() {
-  local host="$1" id="$2" secret="$3" kind="${4:-http}" cache_key="$1|$2|$3"
+  # `kind` is part of the cache key: the same (host,id,secret) triple graded under two
+  # different origin kinds is two different questions with two different answers, and
+  # omitting it would let whichever base was scanned first (bases are iterated in `sort`
+  # order) silently decide the verdict for the other. No two bases map to one host today —
+  # this keeps that from becoming a silent miscarriage the day one does.
+  local host="$1" id="$2" secret="$3" kind="${4:-http}"
+  local cache_key="$1|$2|$3|$kind"
   if [[ -z "${PAIR_VERDICT[$cache_key]:-}" ]]; then
     local code
     code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
@@ -295,18 +301,31 @@ verify_access_pair() {
       # is Access ADMISSION, and that discrimination is sound precisely because Access
       # runs at the EDGE, before the origin is consulted:
       #
-      #   403  only Access can produce it — an ssh origin emits no HTTP status at all
-      #   5xx  Access admitted; cloudflared then failed to speak HTTP to sshd. Healthy.
+      #   5xx  Cloudflare reached the TUNNEL/ORIGIN layer, which sits BEHIND Access, and
+      #        cloudflared then failed to speak HTTP to sshd. Only an ADMITTED request
+      #        gets that far, so this is a POSITIVE proof of admission. Healthy.
+      #   403  Access rejected. Sound here because an ssh origin emits no HTTP status at
+      #        all, so a 403 on this host cannot have come from behind Access.
       #   000  curl never got a definite answer (timeout / DNS / TLS). Learned NOTHING.
       #
-      # Fail-closed is preserved rather than traded away: 000 renders UNVERIFIABLE, which
-      # the caller keeps separate from DEAD and which still exits non-zero. Certifying
-      # "admitted" is weaker than certifying "200" — and it is the strongest claim that is
-      # true of this origin, which is the point.
+      # LIVE is asserted POSITIVELY (5xx), never as "not a rejection". The absence form —
+      # `403|000 -> not-LIVE, everything else -> LIVE` — was the first shape written here
+      # and it is unsafe: Access does not promise 403 as its only rejection. Add an
+      # identity policy to this app and an unauthenticated request becomes a 302 to the
+      # IdP login page; a 429 challenge, a 401, or an interstitial are all rejections too.
+      # Every one of them would have graded LIVE — a dead credential certified healthy,
+      # which is strictly worse than the DEAD-forever bug this function is fixing.
+      # Anything unrecognised therefore renders UNVERIFIABLE (loud, non-zero) rather than
+      # being guessed in either direction.
+      #
+      # Fail-closed is preserved rather than traded away: UNVERIFIABLE is kept separate
+      # from DEAD by the caller and still exits non-zero. Certifying "admitted" is weaker
+      # than certifying "200" — and it is the strongest claim TRUE of this origin, which
+      # is the point.
       case "$code" in
+        5??) PAIR_VERDICT[$cache_key]="LIVE" ;;
         403) PAIR_VERDICT[$cache_key]="DEAD:${code}" ;;
-        000) PAIR_VERDICT[$cache_key]="UNVERIFIABLE:${code}" ;;
-        *)   PAIR_VERDICT[$cache_key]="LIVE" ;;
+        *)   PAIR_VERDICT[$cache_key]="UNVERIFIABLE:${code}" ;;
       esac
     else
       # HTTP origin. Fail CLOSED on anything that is not an explicit 200. A timeout, a DNS

--- a/scripts/check-cloudflare-token-drift.sh
+++ b/scripts/check-cloudflare-token-drift.sh
@@ -246,6 +246,29 @@ access_hostname_for() {
     *) printf '' ;;
   esac
 }
+
+# What the mapped hostname's Cloudflare Tunnel ingress speaks, which decides what a
+# HEALTHY probe looks like. Both values are read off `ingress_rule.service` in
+# apps/web-platform/infra/tunnel.tf:
+#
+#   registry.<base> -> tcp://10.0.1.30:5000   zot answers HTTP over the raw TCP forward
+#   ssh.<base>      -> ssh://<web-1-ip>:22    sshd answers an SSH banner, never HTTP
+#
+# The distinction is load-bearing and was previously absent: the 200-only rule below fits
+# the first origin and CANNOT be satisfied by the second, so CI_SSH_ACCESS_TOKEN graded
+# DEAD on every run regardless of the credential's real state. That is a false positive
+# in the direction that matters — it fired the twice-daily "[TOKEN DRIFT] rotation did not
+# propagate" email whose remediation is to overwrite a healthy secret.
+#
+# A new mapping MUST declare its kind here. `http` is the default only for hosts whose
+# origin genuinely serves HTTP; an unfamiliar origin belongs in `opaque`, which certifies
+# strictly less (Access admission) rather than guessing.
+access_origin_kind_for() {
+  case "$1" in
+    CI_SSH_ACCESS_TOKEN) printf 'opaque' ;;
+    *)                   printf 'http' ;;
+  esac
+}
 # A one-line hint per unmapped base, so the report can say what to DO. Without this the
 # remediation printed for an unverifiable row is the DEAD-token one ("set the live value
 # on the prd ROOT config"), which is wrong twice over: nothing is stale, and no Doppler
@@ -259,20 +282,42 @@ UNVERIFIABLE_ROWS=()
 declare -A PAIR_VERDICT=()   # "host|id|secret" -> LIVE|DEAD (verify each distinct pair once)
 
 verify_access_pair() {
-  local host="$1" id="$2" secret="$3" cache_key="$1|$2|$3"
+  local host="$1" id="$2" secret="$3" kind="${4:-http}" cache_key="$1|$2|$3"
   if [[ -z "${PAIR_VERDICT[$cache_key]:-}" ]]; then
     local code
     code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 20 \
       -H "CF-Access-Client-Id: $id" \
       -H "CF-Access-Client-Secret: $secret" \
       "https://${host}/" 2>/dev/null || printf '000')
-    # Fail CLOSED on anything that is not an explicit 200. A timeout, a DNS failure or a
-    # 5xx means this script did not learn the token is good, and "did not learn" must
-    # never render as LIVE — that is the shape of every silent-green bug in this area.
-    case "$code" in
-      200) PAIR_VERDICT[$cache_key]="LIVE" ;;
-      *)   PAIR_VERDICT[$cache_key]="DEAD:${code}" ;;
-    esac
+    if [[ "$kind" == "opaque" ]]; then
+      # NON-HTTP origin (ssh://). 200 is unreachable here even for a perfect credential,
+      # so the 200-only rule below would report DEAD forever. What this probe CAN certify
+      # is Access ADMISSION, and that discrimination is sound precisely because Access
+      # runs at the EDGE, before the origin is consulted:
+      #
+      #   403  only Access can produce it — an ssh origin emits no HTTP status at all
+      #   5xx  Access admitted; cloudflared then failed to speak HTTP to sshd. Healthy.
+      #   000  curl never got a definite answer (timeout / DNS / TLS). Learned NOTHING.
+      #
+      # Fail-closed is preserved rather than traded away: 000 renders UNVERIFIABLE, which
+      # the caller keeps separate from DEAD and which still exits non-zero. Certifying
+      # "admitted" is weaker than certifying "200" — and it is the strongest claim that is
+      # true of this origin, which is the point.
+      case "$code" in
+        403) PAIR_VERDICT[$cache_key]="DEAD:${code}" ;;
+        000) PAIR_VERDICT[$cache_key]="UNVERIFIABLE:${code}" ;;
+        *)   PAIR_VERDICT[$cache_key]="LIVE" ;;
+      esac
+    else
+      # HTTP origin. Fail CLOSED on anything that is not an explicit 200. A timeout, a DNS
+      # failure or a 5xx means this script did not learn the token is good, and "did not
+      # learn" must never render as LIVE — that is the shape of every silent-green bug in
+      # this area.
+      case "$code" in
+        200) PAIR_VERDICT[$cache_key]="LIVE" ;;
+        *)   PAIR_VERDICT[$cache_key]="DEAD:${code}" ;;
+      esac
+    fi
   fi
   printf '%s' "${PAIR_VERDICT[$cache_key]}"
 }
@@ -307,9 +352,15 @@ for base in $(printf '%s\n' "${!ACCESS_BASESET[@]}" | sort); do
       DEAD_N=$((DEAD_N + 1)); DEAD_ROWS+=("${base}_ID/_SECRET (only one half present)|$cfg")
       continue
     fi
-    state=$(verify_access_pair "$host" "$tid" "$tsec")
+    state=$(verify_access_pair "$host" "$tid" "$tsec" "$(access_origin_kind_for "$base")")
     if [[ "$state" == LIVE ]]; then
       LIVE_N=$((LIVE_N + 1))
+    elif [[ "$state" == UNVERIFIABLE:* ]]; then
+      # Kept OUT of DEAD_ROWS deliberately. "curl got no answer" and "Cloudflare rejected
+      # this pair" are different facts with opposite remedies, and the DEAD heading tells
+      # the operator to overwrite the secret — which, on a probe that measured nothing,
+      # destroys a working credential to fix a problem that was never observed.
+      UNVERIFIABLE_ROWS+=("${base}_ID/_SECRET|probe inconclusive (HTTP ${state#UNVERIFIABLE:} from ${host} in ${cfg}) — no answer reached this script, so nothing is known about the credential. Do NOT rotate on the strength of this row; re-run once ${host} is reachable.")
     else
       DEAD_N=$((DEAD_N + 1)); DEAD_ROWS+=("${base}_ID/_SECRET (HTTP ${state#DEAD:} from ${host})|$cfg")
     fi

--- a/scripts/check-cloudflare-token-drift.test.sh
+++ b/scripts/check-cloudflare-token-drift.test.sh
@@ -386,6 +386,57 @@ else
   fail "unwritable --json-file path must exit 2, got rc=$RC"
 fi
 
+# ---------------------------------------------------------------------------
+# T15-T17 — the ssh:// ORIGIN arm.
+#
+# `access_hostname_for()` maps CI_SSH_ACCESS_TOKEN to ssh.<base>, whose Cloudflare Tunnel
+# ingress is `ssh://<web-1-private-ip>:22` (apps/web-platform/infra/tunnel.tf). That origin
+# does not speak HTTP: a request that Access ADMITS is handed to sshd, which answers with
+# an SSH version banner, so cloudflared returns 5xx. HTTP 200 is therefore UNREACHABLE for
+# a perfectly healthy pair, and the 200-only rule graded this token family DEAD forever —
+# a permanent false positive that fired a twice-daily "[TOKEN DRIFT] rotation did not
+# propagate" email and told the operator to rotate a credential the script never measured.
+#
+# The discrimination that IS sound for a non-HTTP origin: Access runs at the EDGE, before
+# the origin is ever reached, so a 403 on this host can only come from Access (an ssh
+# origin cannot emit an HTTP status at all). 403 => rejected. Any definite non-403 HTTP
+# status => Access admitted, which is the only thing this probe can and should certify.
+#
+# The fail-closed principle is preserved, not traded away: a 000 (timeout / DNS / TLS
+# failure) still means the script did not LEARN anything, and must render UNVERIFIABLE —
+# never LIVE.
+# ---------------------------------------------------------------------------
+CI_SSH_FIXTURE="prd|CI_SSH_ACCESS_TOKEN_ID|${FIX_ID}
+prd|CI_SSH_ACCESS_TOKEN_SECRET|${FIX_SECRET}"
+
+echo "T15: 502 from an ssh:// origin -> LIVE (Access admitted; 200 is unreachable there)"
+run_sut t15 502 "$CI_SSH_FIXTURE"
+if [[ "$RC" == "0" ]] && grep -qE 'live entries: 1' "$OUT" && grep -qE 'dead entries: 0' "$OUT"; then
+  pass "a healthy ssh-origin pair grades LIVE on 502"
+else
+  fail "502 from an ssh:// origin must grade LIVE — 200 cannot occur there, so the 200-only rule reports a healthy token DEAD forever (rc=$RC)"
+fi
+
+echo "T16: 403 from an ssh:// origin -> DEAD (only Access can emit 403 on that host)"
+run_sut t16 403 "$CI_SSH_FIXTURE"
+if [[ "$RC" == "1" ]] && grep -qE 'dead entries: 1' "$OUT"; then
+  pass "403 still grades DEAD — the rejection signal is preserved"
+else
+  fail "403 on an ssh:// origin must remain DEAD; widening the arm must not blind it to a real rejection (rc=$RC)"
+fi
+
+echo "T17: 000 from an ssh:// origin -> UNVERIFIABLE, never LIVE (fail-closed preserved)"
+run_sut t17 000 "$CI_SSH_FIXTURE"
+_t17=1
+grep -qE 'live entries: 0' "$OUT" || _t17=0
+grep -qE 'unverifiable: 1' "$OUT" || _t17=0
+[[ "$RC" == "1" ]] || _t17=0
+if [[ "$_t17" == "1" ]]; then
+  pass "a timeout renders UNVERIFIABLE and exits non-zero, not LIVE"
+else
+  fail "000 must render UNVERIFIABLE — 'did not learn' must never read as LIVE, and must not read as DEAD either (rc=$RC)"
+fi
+
 echo ""
 echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
 # ANTI-VACUITY FLOOR. Without it, deleting every assertion call yields

--- a/scripts/check-cloudflare-token-drift.test.sh
+++ b/scripts/check-cloudflare-token-drift.test.sh
@@ -437,6 +437,30 @@ else
   fail "000 must render UNVERIFIABLE — 'did not learn' must never read as LIVE, and must not read as DEAD either (rc=$RC)"
 fi
 
+# T18-T19 — the FALSE-LIVE guard. LIVE must be a POSITIVE admission proof (5xx from the
+# tunnel layer behind Access), never "did not look like a rejection".
+#
+# 403 is not Access's only rejection shape. Give this app an identity policy and an
+# unauthenticated request answers 302 to the IdP login page; challenges (429) and 401s are
+# rejections too. Under an absence-based rule every one of those grades LIVE — a DEAD
+# credential certified healthy, which is worse than the DEAD-forever bug being fixed here,
+# because it fails silently instead of loudly. These two cases pin the direction.
+echo "T18: a 302 Access login redirect must NOT grade LIVE (false-LIVE guard)"
+run_sut t18 302 "$CI_SSH_FIXTURE"
+if [[ "$RC" != "0" ]] && ! grep -qE 'live entries: 1' "$OUT"; then
+  pass "302 does not certify the pair — unrecognised answers render UNVERIFIABLE"
+else
+  fail "302 (an Access login redirect) graded LIVE — LIVE must be positive 5xx admission proof, not absence-of-403 (rc=$RC)"
+fi
+
+echo "T19: 530 (tunnel-layer error, behind Access) grades LIVE"
+run_sut t19 530 "$CI_SSH_FIXTURE"
+if [[ "$RC" == "0" ]] && grep -qE 'live entries: 1' "$OUT"; then
+  pass "530 proves the request got past Access to the tunnel layer"
+else
+  fail "530 must grade LIVE — it is an origin/tunnel error, reachable only after Access admitted (rc=$RC)"
+fi
+
 echo ""
 echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
 # ANTI-VACUITY FLOOR. Without it, deleting every assertion call yields


### PR DESCRIPTION
## What was wrong

`scripts/check-cloudflare-token-drift.sh` graded every Cloudflare Access service token LIVE **only on HTTP 200**.

That rule fits `registry.<base>` — its tunnel ingress is `tcp://10.0.1.30:5000` fronting zot, which speaks HTTP over the raw TCP forward.

It cannot fit `ssh.<base>`. That ingress is `ssh://<web-1-ip>:22` (`apps/web-platform/infra/tunnel.tf`), and sshd answers an SSH version banner, not HTTP. A request Access **admits** is handed to sshd, and cloudflared returns 5xx.

So **200 is unreachable for a perfectly healthy credential**, and `CI_SSH_ACCESS_TOKEN_*` graded DEAD on every run regardless of its real state — a permanent false positive driving a twice-daily *"[TOKEN DRIFT] rotation did not propagate"* email whose prescribed remediation is to overwrite a healthy secret.

## How it was found

While diagnosing the genuinely-dead CI-SSH token, the detector's `31 live, 1 dead` output was being cited as evidence. It isn't evidence — that row is structurally guaranteed for this token family whatever the credential's state. The real discriminator was an independent `curl` returning 403 with real header values.

## The fix

`access_origin_kind_for()` declares what each mapped origin speaks. A non-HTTP origin is graded on **Access admission** — the strongest claim that is true of it:

| code | verdict | why |
|---|---|---|
| `403` | DEAD | only Access can emit it; an ssh origin produces no HTTP status at all |
| `5xx` | LIVE | Access admitted; cloudflared then failed to speak HTTP to sshd — healthy |
| `000` | UNVERIFIABLE | no definite answer (timeout/DNS/TLS) — learned nothing |

Fail-closed is **preserved, not traded away**: `000` renders UNVERIFIABLE and still exits non-zero. It is deliberately kept out of `DEAD_ROWS`, because "measured nothing" and "Cloudflare rejected this" have opposite remedies — and the DEAD heading tells the operator to overwrite the secret.

The HTTP arm is byte-identical.

## Verification

- 3 new cases, written **RED first** (T15/T17 failed as predicted; T16 passed, proving the rejection signal already worked and must not regress).
- **Mutation-tested both directions**: reverting the opaque arm reds T15/T17; grading 403 as LIVE reds T16.
- Suite: 19/19.
- **Real production run**: still reports the CI-SSH token DEAD — it genuinely is (403). This does not turn a real failure green; it makes a *repaired* token reportable, which it previously could not be.
- `shellcheck` clean (the one SC2016 info is pre-existing on `main`).

## Scope

Deliberately standalone. The CI-SSH token is still dead and its `-replace` repair path is separate work on `feat-one-shot-ci-ssh-token-replace`; this PR only stops the detector from lying about it.