### PR TITLE
fix(ci): the release-failure email step has never sent — R_DEPLOY unbound killed it

### DIFF
--- a/.github/workflows/web-platform-release.yml
+++ b/.github/workflows/web-platform-release.yml
@@ -1286,6 +1286,12 @@ jobs:
           FAILED: ${{ steps.outcome.outputs.failed }}
           FAILED_HTML: ${{ steps.outcome.outputs.failed_html }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # #7136 — DECLARED HERE, NOT INHERITED. Step-level `env:` does not cross step
+          # boundaries: this was declared only on the `outcome` step above, so under
+          # `set -u` the expansion below killed this step BEFORE the curl, on every
+          # failed release since #7097 introduced the branch. Nobody was ever told.
+          # scripts/lint-workflow-step-env-refs.py now fails CI on this shape.
+          R_DEPLOY: ${{ needs.deploy.result }}
         run: |
           set -uo pipefail
           # Always exits 0 and reports delivery through `delivered`; the
@@ -1312,18 +1318,27 @@ jobs:
           # teaches them to stop reading the next one — and alert fatigue is the failure mode that
           # let this incident run 26 hours. Getting this wrong would recreate the very thing the
           # job exists to prevent.
-          if [[ "${R_DEPLOY}" == "success" ]]; then
+          # `${R_DEPLOY:-}` — GUARDED, matching every sibling expansion in this step. An
+          # unset value must take the `else` ("production was NOT updated") branch: that
+          # over-warns, where the other direction would tell the operator their code is
+          # live when it is not. A rename that breaks this must degrade toward the alarm.
+          if [[ "${R_DEPLOY:-}" == "success" ]]; then
             SUBJ_TAIL="production WAS updated, but a post-release check failed"
             BODY="<p><strong>The new version DID reach production — but a check that runs afterwards failed, so we cannot confirm the site is fully healthy.</strong></p>"
+            BODY="${BODY}<p>Released version: <code>${VER_LABEL}</code> (tag: <code>${TAG_LABEL}</code>).</p>"
             BODY="${BODY}<p><strong>What this means for you:</strong> the code you merged is live. Something about verifying it afterwards did not pass, which may mean a real problem with the running site or may mean the check itself is faulty. Worth looking at soon; it is not the same as a release being stuck.</p>"
           else
             SUBJ_TAIL="production was NOT updated"
             BODY="<p><strong>The Soleur web platform did not finish releasing. Production is still running the OLDER build — the changes that were just merged are not live.</strong></p>"
-          BODY="${BODY}<p>Attempted version: <code>${VER_LABEL}</code> (tag: <code>${TAG_LABEL}</code>). Production is serving whatever was deployed before this run, which is now behind that tag.</p>"
-          BODY="${BODY}<p><strong>What stopped:</strong></p><ul>${FAILED_HTML}</ul>"
-          BODY="${BODY}<p><a href=\"${RUN_URL}\">Open the failed run</a> — the red entry named above is the one to look at.</p>"
+            BODY="${BODY}<p>Attempted version: <code>${VER_LABEL}</code> (tag: <code>${TAG_LABEL}</code>). Production is serving whatever was deployed before this run, which is now behind that tag.</p>"
             BODY="${BODY}<p><strong>What this means for you:</strong> until this is fixed, every further change you merge will also stay unreleased — the site keeps serving old code and looks healthy while doing it. This is not something that clears on its own.</p>"
           fi
+          # SHARED TAIL, both branches (#7136). These were indented inside the `else` above,
+          # so the success branch carried NO run link and NO failed-job list — while the
+          # closing paragraph tells the operator to "send the run link above" to their
+          # engineer. That branch had never executed, because the step always died first.
+          BODY="${BODY}<p><strong>What stopped:</strong></p><ul>${FAILED_HTML}</ul>"
+          BODY="${BODY}<p><a href=\"${RUN_URL}\">Open the failed run</a> — the red entry named above is the one to look at.</p>"
           BODY="${BODY}<p><strong>What to do:</strong> you do not need to fix this yourself. Send the run link above to your engineer, or paste it into Claude Code and ask it to fix the failing release. Treat it as urgent: nothing reaches production until it is resolved.</p>"
           PAYLOAD=$(jq -n \
             --arg from "Soleur Ops <noreply@soleur.ai>" \
@@ -1351,8 +1366,16 @@ jobs:
       # #7095 is about. Mirror it to Sentry (a DIFFERENT vendor, read from a
       # GitHub-side secret so it does not share Resend's failure) and fail this
       # job so the non-delivery is at least visible in the run.
+      #
+      # `!cancelled()` is load-bearing (#7136). Without it this step inherits the implicit
+      # `success()` guard, so when the email step FAILS outright — which is exactly what
+      # `R_DEPLOY: unbound variable` did on every failed release since #7097 — this step is
+      # SKIPPED rather than run. Verified on run 30703438860: email=failure, mirror=skipped.
+      # The compensating channel was disarmed by the same crash it exists to compensate for,
+      # so a step that "cannot end in silence" ended in silence. A guard that only fires when
+      # its subject succeeded cannot be a fallback for that subject failing.
       - name: Mirror non-delivery to Sentry and fail loudly
-        if: steps.outcome.outputs.failed != '' && steps.email.outputs.delivered != '1'
+        if: ${{ !cancelled() && steps.outcome.outputs.failed != '' && steps.email.outputs.delivered != '1' }}
         env:
           NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
           FAILED: ${{ steps.outcome.outputs.failed }}

--- a/knowledge-base/project/learnings/workflow-patterns/2026-08-01-alert-step-and-its-fallback-died-together-guard-fallbacks-with-not-cancelled.md
+++ b/knowledge-base/project/learnings/workflow-patterns/2026-08-01-alert-step-and-its-fallback-died-together-guard-fallbacks-with-not-cancelled.md
@@ -1,0 +1,95 @@
+---
+title: An alert step and its own fallback died together — guard fallbacks with `!cancelled()`
+date: 2026-08-01
+category: engineering
+tags: [github-actions, observability, alerting, fail-closed, shellcheck]
+issue: '#7136'
+type: learning
+---
+
+# An alert step and its own fallback died together
+
+`release-outcome`'s "Email the operator (release did NOT reach production)" step read
+`${R_DEPLOY}`, declared in the `env:` of a **different** step. Step-level `env:` does not
+cross step boundaries, so under `set -u` bash killed the step *before* the `curl` that sends
+the mail. Every failed release since PR #7097 introduced the branch went unannounced —
+the path had never once delivered.
+
+## 1. A fallback guarded by the default `success()` is not a fallback
+
+The design was explicitly two-channel: an email step that always exits 0 and reports through
+`delivered`, plus a "Mirror non-delivery to Sentry and fail loudly" step, so that "a missing
+API key and a dead Resend take the SAME path — neither can end in silence."
+
+It ended in silence. The mirror step had no `if: always()` / `!cancelled()`, so it inherited
+the implicit `success()` guard. When the email step *failed* — rather than exiting 0 with
+`delivered=0` — the mirror was **skipped**. Run 30703438860: email=`failure`,
+mirror=`skipped`.
+
+**The rule:** a compensating step whose condition can only be evaluated when its subject
+*succeeded* cannot compensate for that subject *failing*. Any step that exists to catch
+another step's failure needs `!cancelled()` (or `always()`), and the fallback's own
+crash-path must be considered, not just the value it reads. Reasoning about the *output* of
+the step you are compensating for (`delivered != '1'`) silently assumes it ran to completion.
+
+## 2. shellcheck structurally cannot catch a cross-step `env:` reference
+
+actionlint already pipes every `run:` body through shellcheck, and SC2154 ("referenced but
+not assigned") is exactly the right rule — it does not fire here **by design**: SC2154
+exempts `ALL_CAPS` names as presumed-environment, and shellcheck has no view of the
+workflow's `env:` blocks at all. Measured on the pre-fix body: zero findings.
+
+So "we already run a shell linter" is not coverage for this class. The check has to be
+workflow-aware: `scripts/lint-workflow-step-env-refs.py` resolves each reference against the
+step's / job's / workflow's `env:`, in-body assignments, and earlier `$GITHUB_ENV` exports.
+
+## 3. Guard defaults are the tell — and the direction of the default matters
+
+Every other expansion in the step was defensively guarded (`${VERSION:-unknown}`,
+`${TAG:-no tag was created}`, `${RESEND_API_KEY:-}`). The one bare `${R_DEPLOY}` was the one
+that chose which of two message bodies to send. **A lone unguarded expansion among guarded
+siblings is a defect signature**, and it is mechanically detectable: the linter treats
+"guarded anywhere in this step" as the author having considered unset, which is also what
+kept its false-positive count at zero.
+
+Which branch an unset value falls into is a safety decision, not a style one. `${R_DEPLOY:-}`
+now takes the "production was NOT updated" branch: over-warn rather than falsely reassure.
+
+## 4. A branch that has never executed is not a branch that works
+
+The `deploy == success` branch had never run, because the step always died first. It was
+missing the run link and the failed-job list — while the shared closing paragraph told the
+operator to *"send the run link above to your engineer."* Fixing the crash is what makes such
+a branch reachable for the first time; **audit the newly-reachable path in the same change**,
+because nothing has ever exercised it.
+
+## 5. Verify an alert by executing it, not by reading it
+
+The acceptance criterion asked for verification "against a forced-failure run, not only by
+reading the YAML". Better than a one-off dispatch: the test extracts the step's `run` body
+from the shipped workflow and executes it under `bash` with stubbed `curl`/`jq`, for
+`deploy=failure`, `deploy=success`, and `R_DEPLOY` absent — on every CI run.
+
+It carries a **mutation proof**: the same harness against the pre-fix body must die with
+`unbound variable` having captured no payload. Without that case, the harness could pass
+vacuously while never exercising the branch at all.
+
+## 6. Measure a new linter's exemptions; never assume them
+
+The check went 1046 → 69 → 23 → 7 → 1 findings as each exemption was added and *measured*
+against the 70 workflow files on `main`. The last six were literal `$VAR` text inside single
+quotes or written `\$VAR` — never expanded by bash. Landing at exactly one finding (the bug)
+is what let it ship fail-closed with **no allowlist and no highwater baseline**.
+
+Related: a first-revision regex for `mapfile`'s option grammar
+(`(?:-\w+\s+\S*\s*)*`) was flagged by CodeQL as `py/redos` — `\S*` can consume the next
+`-flag`, so each option parses two ways. For a scanner where over-counting assignments only
+*suppresses* findings, a broad linear scan beats a precise ambiguous one.
+
+## 7. A clean sweep of nothing reads as success
+
+Twice while developing this, a stale CWD made the glob match zero files and print
+`TOTAL: 0` — indistinguishable from a clean run. The shipped linter exits non-zero when it
+scans zero files, matching `scripts/lint-workflows.sh`. This is the same shape as
+`hr-empty-telemetry-is-not-evidence-of-absence`: nothing found because nothing was looked at
+is not the same as nothing found because nothing is there, and the first one reads as safety.

--- a/knowledge-base/project/plans/2026-08-01-release-outcome-email-step-env-refs-plan.md
+++ b/knowledge-base/project/plans/2026-08-01-release-outcome-email-step-env-refs-plan.md
@@ -1,0 +1,224 @@
+---
+lane: single-domain
+requires_cpo_signoff: true
+brand_survival_threshold: single-user incident
+closes: 7136
+---
+
+# Plan: the release-failure email step dies on an unbound `R_DEPLOY` before it can send
+
+## Overview
+
+`.github/workflows/web-platform-release.yml`, job `release-outcome`, step **"Email the
+operator (release did NOT reach production)"** reads `${R_DEPLOY}` at line 1315. `R_DEPLOY`
+is declared in the `env:` of a **different** step (`Classify the run outcome`, line 1240).
+Step-level `env:` does not cross step boundaries, so the variable is unset here; the body
+runs under `set -uo pipefail`, and bash terminates the shell on an unset expansion.
+
+The step dies **before** the `curl` to Resend. No email is sent. Confirmed from the run log,
+not inferred from the YAML:
+
+```
+release-outcome  Email the operator (release did NOT reach production)
+  /home/runner/work/_temp/dbd591da-…sh: line 26: R_DEPLOY: unbound variable
+  ##[error]Process completed with exit code 1.
+```
+
+The bare `${R_DEPLOY}` was introduced by commit `3faa95fa8` (PR #7097). It has never
+successfully evaluated — **this alert path has never once delivered.**
+
+### The failure is silent by construction
+
+The downstream **"Mirror non-delivery to Sentry and fail loudly"** step is gated on
+`steps.email.outputs.delivered != '1'`. The email step died before writing *any* output, so
+`delivered` is empty — the condition is true, yet the run log shows that step **`skipped`**.
+Verified on run 30703438860:
+
+| step | conclusion |
+|---|---|
+| Classify the run outcome | success |
+| Email the operator (release did NOT reach production) | **failure** |
+| Mirror non-delivery to Sentry and fail loudly | **skipped** |
+
+A step whose predecessor *failed* does not run without `if: always()` / `failure()`. So the
+compensating path — the one designed to guarantee "neither can end in silence" — was itself
+disarmed by the same crash. Both alert channels are dead simultaneously.
+
+### Blast radius
+
+Every `Web Platform Release` run on `main` has failed `deploy` (`reason=image_pull_failed`)
+since ~2026-07-30. On the three most recent, `release-outcome` also failed:
+
+| Run | Date | `deploy` | `release-outcome` |
+|---|---|---|---|
+| 30703438860 | 2026-08-01 14:16 | failure | failure |
+| 30688451384 | 2026-08-01 06:48 | failure | failure |
+| 30650563981 | 2026-07-31 17:17 | failure | failure |
+
+## Research Reconciliation — Spec vs. Codebase
+
+| Issue claim | Reality | Plan response |
+|---|---|---|
+| `R_DEPLOY` unbound kills the step | Confirmed verbatim in the run log | Fix as described |
+| Step runs under `bash -e` with nounset | It is `set -uo pipefail` — **no** `-e`. Irrelevant to the outcome: `set -u` alone terminates a non-interactive shell on unset expansion | No change to the fix |
+| Sentry mirror "does not compensate" because it reads `delivered=0` | Stronger than stated: the mirror step is **`skipped`**, not mis-fed — it lacks `if: always()` | Add `!cancelled()` to the mirror's `if:` so a future crash in the email step still mirrors |
+| shellcheck/actionlint should catch this | It cannot. shellcheck's SC2154 deliberately exempts `ALL_CAPS` names as presumed-environment, and it has no view of the workflow's `env:` blocks. Measured: `shellcheck -s bash` on the extracted step body reports **zero** findings | Build a workflow-aware linter; do not tune actionlint |
+| "at least the last three failed releases" went unnotified | Confirmed, and the step has in fact **never** delivered: the bare `${R_DEPLOY}` arrived with the branch itself in commit `3faa95fa8` (PR #7097) | Framing in the PR body corrected from "regressed" to "never worked" |
+
+## Second defect in the same step (found while reading the branch)
+
+The `else` (deploy-did-not-succeed) branch and the shared tail are mis-scoped. These three
+lines sit **inside** the `else` block:
+
+```
+BODY="${BODY}<p>Attempted version: …"
+BODY="${BODY}<p><strong>What stopped:</strong></p><ul>${FAILED_HTML}</ul>"
+BODY="${BODY}<p><a href=\"${RUN_URL}\">Open the failed run</a> …"
+```
+
+So in the `R_DEPLOY == success` branch the email contains **no run link and no list of what
+failed** — while the unconditional tail tells the operator *"Send the run link above to your
+engineer."* That branch has never executed in production (the step always died first), so the
+defect is unobserved rather than absent. In scope: it is the same step, the same never-run
+branch, and shipping the `R_DEPLOY` fix is exactly what makes this branch reachable for the
+first time.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** production silently stops taking new builds
+while every surface reports healthy. The operator merges work for days believing it is live.
+This already happened — the outage began ~2026-07-30 and no notification was ever sent.
+
+**If this leaks, the user's workflow is exposed via:** no new exposure vector; the email body
+carries version/tag/job-name metadata already public in the repo's Actions log. The change
+adds no new recipient and no new secret read.
+
+**Brand-survival threshold:** single-user incident. There is exactly one operator on this
+alert path; one undelivered email is a total loss of the signal, not a degraded one.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: release-outcome emits `SOLEUR_RELEASE_ALERT` to the step summary and stdout on every
+        run where any upstream job failed, carrying delivered=0|1 and the chosen branch
+  cadence: every Web Platform Release run that has a failed/cancelled upstream job
+  alert_target: ops@jikigai.com via Resend; Sentry `op:release-alert-undelivered` on non-delivery
+  configured_in: .github/workflows/web-platform-release.yml (job release-outcome)
+error_reporting:
+  destination: Sentry (store endpoint, DSN from GitHub secret — a different vendor than Resend)
+  fail_loud: yes — the mirror step exits 1, turning the run red on non-delivery
+failure_modes:
+  - mode: a variable the step reads is not declared in its own env: (this bug)
+    detection: scripts/lint-workflow-step-env-refs.py, run in CI on every PR
+    alert_route: CI job fails on the PR that introduces it — before it can reach main
+  - mode: email step crashes for any other reason before writing outputs
+    detection: mirror step gains `!cancelled()`, so it runs even when the email step failed
+    alert_route: Sentry op:release-alert-undelivered + red run
+  - mode: Resend rejects or is unreachable
+    detection: HTTP code captured; delivered=0 with reason=resend_http_<code>
+    alert_route: Sentry op:release-alert-undelivered + red run
+logs:
+  where: GitHub Actions run log + job summary for the run
+  retention: GitHub default (90 days)
+discoverability_test:
+  command: bash scripts/lint-workflow-step-env-refs.test.sh
+  expected_output: "All tests passed" — includes a live execution of the shipped step body
+                   under both R_DEPLOY branches, asserting no unbound-variable death
+```
+
+No `ssh` anywhere in the verification path.
+
+## Implementation Phases
+
+### Phase 1 — Fix the workflow
+
+1. Add `R_DEPLOY: ${{ needs.deploy.result }}` to the email step's **own** `env:` block.
+2. Change the reference to `${R_DEPLOY:-}` so it matches every sibling expansion
+   (`${VERSION:-unknown}`, `${TAG:-no tag was created}`, `${RESEND_API_KEY:-}`,
+   `${REASON:-unknown}`). An unset value then takes the **"production was NOT updated"**
+   branch — the safe direction: it over-warns rather than falsely reassuring.
+3. Audit every other variable the step reads against its declared `env:` (mechanised by
+   Phase 2's linter, which is the durable form of this audit).
+4. Hoist the run link and the "What stopped" list out of the `else` branch so both branches
+   carry the link the unconditional tail refers to.
+5. Add `!cancelled()` to the mirror step's `if:` so it survives an email-step crash.
+
+### Phase 2 — The linter (`scripts/lint-workflow-step-env-refs.py`)
+
+Fail-closed check: for every `run:` step in `.github/workflows/*.yml`, every **`ALL_CAPS`
+shell variable reference that is never guarded anywhere in that step** must be declared in
+the step / job / workflow `env:`, assigned within the same step, exported to `$GITHUB_ENV`
+by an earlier step of the same job, or runner-provided.
+
+Discriminators required to reach zero false positives (each measured against the 70 workflow
+files on `main`, not assumed):
+
+| Rule | Without it |
+|---|---|
+| Strip `${{ … }}` before shell parsing | GitHub expressions parse as shell vars |
+| Strip single-quoted regions and `\$` escapes via a quote-state lexer | 6 false positives — literal `$VAR` text in error strings, SQL, and markdown |
+| A name guarded **anywhere** in the step is exempt | 16 false positives — the `[[ -n "${X:-}" ]] \|\| exit 1` then bare `${X}` idiom |
+| Carry `$GITHUB_ENV` writes forward within a job | 41 false positives — the standard cross-step export |
+| Restrict to `ALL_CAPS` | ~977 false positives — jq `--arg` names and lowercase locals (shellcheck's SC2154 domain) |
+
+Measured result on `main`: **exactly one finding — the `R_DEPLOY` bug.** No allowlist, no
+highwater baseline; the gate is fail-closed from the first commit.
+
+The linter must **fail loudly when it scans zero files** rather than reporting a clean sweep
+of nothing — the silent-empty shape `scripts/lint-workflows.sh` already guards against, and
+which bit twice while developing this plan (a stale CWD produced `TOTAL: 0`, indistinguishable
+from success).
+
+### Phase 3 — Tests and registration
+
+`scripts/lint-workflow-step-env-refs.test.sh`, registered in `scripts/test-all.sh` (required
+— `scripts/lint-orphan-test-suites.sh` fails any unregistered `scripts/*.test.sh`) and wired
+into the CI lint job.
+
+Two test classes:
+
+1. **Linter unit tests** over synthetic fixtures: catches the bug shape; exempts each of the
+   five discriminators above; fails closed on zero files scanned.
+2. **Execution test against the shipped YAML** — extract the real email step's `run` body from
+   `web-platform-release.yml`, execute it under `bash` with exactly its declared `env:`, with
+   `curl`/`jq` stubbed, for `deploy=failure` and `deploy=success`. Assert: no unbound-variable
+   death, and the correct subject/branch for each. This is the acceptance criterion's
+   "verified against a forced-failure run" — it runs the shipped text under the failure
+   condition on every CI run, which a one-off dispatch would not.
+
+## Acceptance Criteria
+
+- [ ] The email step declares every variable it reads in its own `env:`.
+- [ ] `${R_DEPLOY:-}` is guarded like its siblings; an unset value takes the "not updated" branch.
+- [ ] A test asserts the step's referenced variables are a subset of its declared `env:` keys,
+      and fails on the pre-fix YAML.
+- [ ] Verified by executing the shipped step body under both branches, not only by reading YAML.
+- [ ] The linter reports zero findings across `.github/workflows/*.yml` after the fix.
+- [ ] The linter exits non-zero when it scans zero files.
+- [ ] The mirror-to-Sentry step runs even when the email step fails outright.
+- [ ] Both email branches contain the run link the message tells the operator to send.
+
+## Test Scenarios
+
+1. `python3 scripts/lint-workflow-step-env-refs.py` → exit 0, "0 findings", on the fixed tree.
+2. Same linter against the pre-fix step (fixture) → exit 1, naming `R_DEPLOY` and the step.
+3. Shipped-body execution, `R_DEPLOY=failure` → subject contains "production was NOT updated";
+   body contains the run URL and the failed-jobs list.
+4. Shipped-body execution, `R_DEPLOY=success` → subject contains "production WAS updated";
+   body contains the run URL.
+5. Shipped-body execution, `R_DEPLOY` **absent from the environment entirely** → does not die;
+   takes the "NOT updated" branch.
+6. Linter run against an empty directory → exit non-zero.
+
+## Risks
+
+- **Linter false positives on future workflows.** Mitigated by the five measured
+  discriminators and by an exemption that is already idiomatic in this repo (`${X:-}`
+  anywhere in the step). A genuinely new pattern fails the PR that introduces it, which is
+  the intended direction of the gate.
+- **Quote-state lexer mis-tracking inside an unquoted heredoc** could under-report
+  (false negative). Accepted: the gate is additive over today's zero coverage, and
+  under-reporting cannot break a passing build.
+- **Scope.** The email-body hoist is a content change to a never-executed branch. It ships
+  with the fix that first makes that branch reachable; it is not deferred to a second PR.

--- a/knowledge-base/project/specs/feat-one-shot-7136-release-outcome-email-unbound/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-7136-release-outcome-email-unbound/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — #7136 release-outcome email step dies on unbound `R_DEPLOY`
+
+Plan: `knowledge-base/project/plans/2026-08-01-release-outcome-email-step-env-refs-plan.md`
+
+## Phase 1 — Workflow fix
+- [ ] T1.1 Add `R_DEPLOY: ${{ needs.deploy.result }}` to the email step's own `env:`
+- [ ] T1.2 Guard the reference as `${R_DEPLOY:-}` (unset → "NOT updated" branch)
+- [ ] T1.3 Hoist run link + "What stopped" list so both branches carry them
+- [ ] T1.4 Add `!cancelled()` to the Sentry mirror step's `if:` so it survives an email-step crash
+
+## Phase 2 — Linter
+- [ ] T2.1 `scripts/lint-workflow-step-env-refs.py` with the five measured discriminators
+- [ ] T2.2 Fail loudly on zero files scanned (no silent clean sweep)
+- [ ] T2.3 Verify: exactly 0 findings on the fixed tree, 1 finding pre-fix
+
+## Phase 3 — Tests + registration
+- [ ] T3.1 `scripts/lint-workflow-step-env-refs.test.sh` — fixture unit tests
+- [ ] T3.2 Execution test: run the shipped step body under both `R_DEPLOY` branches + unset
+- [ ] T3.3 Register in `scripts/test-all.sh` (else `lint-orphan-test-suites.sh` fails)
+- [ ] T3.4 Wire the linter into the CI lint job

--- a/scripts/lint-workflow-step-env-refs.py
+++ b/scripts/lint-workflow-step-env-refs.py
@@ -71,7 +71,14 @@ ASSIGNMENT = re.compile(r"(?<![\w$.-])([A-Za-z_][A-Za-z0-9_]*)\s*(?:\+?=|\[)")
 FOR_LOOP_VAR = re.compile(r"\bfor\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\b")
 READ_VARS = re.compile(r"\bread\s+(?:-\w+\s+)*([A-Za-z_][A-Za-z0-9_ ]*)")
 PRINTF_VAR = re.compile(r"\bprintf\s+-v\s+([A-Za-z_][A-Za-z0-9_]*)")
-MAPFILE_VAR = re.compile(r"\b(?:mapfile|readarray)\s+(?:-\w+\s+\S*\s*)*([A-Za-z_][A-Za-z0-9_]*)")
+# `mapfile -t -d '' ARR < …`: take the whole line and harvest every identifier on it, rather
+# than modelling the option grammar. A pattern like `(?:-\w+\s+\S*\s*)*` for the flags is
+# exponentially backtrackable (CodeQL py/redos, flagged on this file's first revision) —
+# `\S*` can consume the next `-flag`, so each option is parseable two ways. Since counting a
+# non-assignment as assigned only SUPPRESSES a finding, the over-broad linear scan is both
+# safer and simpler than a precise ambiguous one.
+MAPFILE_LINE = re.compile(r"\b(?:mapfile|readarray)\b([^\n]*)")
+IDENTIFIER = re.compile(r"(?<![\w$-])([A-Za-z_][A-Za-z0-9_]*)")
 
 ENV_STYLE_NAME = re.compile(r"[A-Z][A-Z0-9_]*")
 # `${X:-}`, `${X-}`, `${X:+}`, `${X:=}`, `${X:?}` all mean "the author considered unset".
@@ -136,10 +143,12 @@ def env_keys(*scopes) -> set[str]:
 
 def assigned_names(body: str) -> set[str]:
     names: set[str] = set()
-    for rx in (ASSIGNMENT, FOR_LOOP_VAR, PRINTF_VAR, MAPFILE_VAR):
+    for rx in (ASSIGNMENT, FOR_LOOP_VAR, PRINTF_VAR):
         names |= set(rx.findall(body))
     for group in READ_VARS.findall(body):
         names |= set(group.split())
+    for tail in MAPFILE_LINE.findall(body):
+        names |= set(IDENTIFIER.findall(tail))
     return names
 
 

--- a/scripts/lint-workflow-step-env-refs.py
+++ b/scripts/lint-workflow-step-env-refs.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Fail when a workflow `run:` step reads a variable nothing in scope ever sets (#7136).
+
+WHY THIS EXISTS. `.github/workflows/web-platform-release.yml`'s "Email the operator
+(release did NOT reach production)" step read `${R_DEPLOY}`, but `R_DEPLOY` was declared
+in the `env:` of a DIFFERENT step. Step-level `env:` does not cross step boundaries, so
+under `set -u` bash killed the step at that line -- BEFORE the curl that sends the mail.
+Every failed release since #7097 went unannounced, and the downstream "mirror to Sentry"
+step was `skipped` (it inherits `success()`), so both alert channels died together.
+
+This class is invisible until the failure path runs, which is exactly when it must work.
+That is what makes it worth a dedicated gate rather than a code-review habit.
+
+WHY NOT SHELLCHECK. actionlint already pipes every `run:` body through shellcheck, and
+shellcheck has SC2154 ("referenced but not assigned") -- it does not fire here, by design:
+SC2154 deliberately exempts ALL_CAPS names as presumed-environment, and shellcheck cannot
+see the workflow's `env:` blocks at all. Measured on the pre-fix step body: zero findings.
+The workflow-awareness is the whole point; there is no actionlint setting that buys it.
+
+THE RULE. Within one `run:` step, an ALL_CAPS shell variable reference is a finding when
+ALL of these hold:
+  * it is never guarded (`${X:-}` / `${X-}` / `${X:+}` / `${X:?}`) ANYWHERE in that step;
+  * it is not declared in the step's, job's, or workflow's `env:`;
+  * it is not assigned anywhere in that step's own body;
+  * it was not exported to `$GITHUB_ENV` by an EARLIER step of the same job;
+  * it is not runner-provided (GITHUB_*, RUNNER_*, HOME, ...).
+
+Each exemption is measured, not assumed -- counts are against the 20 workflows on main at
+the time of writing, and each one is the difference between a usable gate and noise:
+
+  restrict to ALL_CAPS ............ ~977 findings without it (jq --arg names, lowercase
+                                     locals -- shellcheck's SC2154 domain, not ours)
+  $GITHUB_ENV carry-forward .......   41 findings without it (the standard cross-step export)
+  "guarded anywhere" exemption ....   16 findings without it (`[[ -n "${X:-}" ]] || exit 1`
+                                     followed by a bare `${X}` is correct, deliberate code)
+  quote/escape lexer ..............    6 findings without it (literal `$VAR` text inside
+                                     single quotes or written `\\$VAR` -- never expanded)
+
+With all four, the sweep over main returns EXACTLY ONE finding: the R_DEPLOY bug. So this
+ships fail-closed with no allowlist and no highwater baseline -- if it ever prints anything
+again, that is a new defect, not accumulated debt.
+
+DIRECTION OF ERROR. The lexer can mis-track quote state inside an unquoted heredoc and
+under-report. That is the acceptable direction: a false negative leaves today's (zero)
+coverage unchanged, while a false positive would block an unrelated PR and get the gate
+disabled. Findings are precise or absent, never approximate.
+
+Usage:  python3 scripts/lint-workflow-step-env-refs.py [<path>...]   # default: .github/workflows/*.yml
+Exit:   0 = clean, 1 = findings or nothing scanned.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+import sys
+
+import yaml
+
+# GitHub expression -- must go before any shell parsing, since `${{` starts with `${`.
+GH_EXPR = re.compile(r"\$\{\{.*?\}\}", re.DOTALL)
+# A QUOTED heredoc body ( <<'EOF' / <<"EOF" ) is literal: bash expands nothing inside it.
+QUOTED_HEREDOC = re.compile(r"<<-?\s*(['\"])(\w+)\1(.*?)^\s*\2\s*$", re.DOTALL | re.MULTILINE)
+
+BRACED_REF = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)([^}]*)\}")
+BARE_REF = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)")
+# Any `NAME=` / `NAME+=` / `NAME[` at a position where it can be an assignment. Deliberately
+# over-approximating: counting a non-assignment as an assignment only SUPPRESSES a finding,
+# and this gate prefers silence to noise (see DIRECTION OF ERROR above).
+ASSIGNMENT = re.compile(r"(?<![\w$.-])([A-Za-z_][A-Za-z0-9_]*)\s*(?:\+?=|\[)")
+FOR_LOOP_VAR = re.compile(r"\bfor\s+([A-Za-z_][A-Za-z0-9_]*)\s+in\b")
+READ_VARS = re.compile(r"\bread\s+(?:-\w+\s+)*([A-Za-z_][A-Za-z0-9_ ]*)")
+PRINTF_VAR = re.compile(r"\bprintf\s+-v\s+([A-Za-z_][A-Za-z0-9_]*)")
+MAPFILE_VAR = re.compile(r"\b(?:mapfile|readarray)\s+(?:-\w+\s+\S*\s*)*([A-Za-z_][A-Za-z0-9_]*)")
+
+ENV_STYLE_NAME = re.compile(r"[A-Z][A-Z0-9_]*")
+# `${X:-}`, `${X-}`, `${X:+}`, `${X:=}`, `${X:?}` all mean "the author considered unset".
+GUARD_PREFIXES = (":-", ":=", ":+", ":?", "-", "+", "?")
+
+# Provided by the runner or the shell itself; never declared in `env:`.
+RUNNER_PROVIDED = re.compile(
+    r"^(GITHUB_|RUNNER_|ACTIONS_|INPUT_|BASH_|CI$|HOME$|PATH$|PWD$|OLDPWD$|USER$|SHELL$|"
+    r"HOSTNAME$|TMPDIR$|LANG$|LC_|TERM$|IFS$|RANDOM$|LINENO$|PPID$|UID$|EUID$|OSTYPE$|"
+    r"HOSTTYPE$|SECONDS$|FUNCNAME$|PIPESTATUS$|REPLY$|OPTARG$|OPTIND$|_$|EDITOR$|TZ$)"
+)
+
+SHELLS_WE_PARSE = (None, "bash", "sh")
+
+
+def strip_unexpanded(body: str) -> str:
+    """Drop the text bash would never expand: single-quoted regions and backslash escapes.
+
+    Without this, a literal `\\$HCLOUD_TOKEN` inside an error message, a `$BS_TABLE` inside a
+    single-quoted SQL string, and a `$CF_ACCOUNT_ID` inside a single-quoted printf format all
+    read as live references. Tracking double-quote state matters too: an apostrophe inside
+    "don't" must not open a single-quoted region.
+    """
+    out: list[str] = []
+    i, n = 0, len(body)
+    in_single = in_double = False
+    while i < n:
+        ch = body[i]
+        if in_single:
+            if ch == "'":
+                in_single = False
+            i += 1
+            continue
+        if ch == "\\":  # escaped char is literal; drop the pair
+            out.append(" ")
+            i += 2
+            continue
+        if ch == "'" and not in_double:
+            in_single = True
+            i += 1
+            continue
+        if ch == '"':
+            in_double = not in_double
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def strip_comments(body: str) -> str:
+    return "\n".join(ln for ln in body.split("\n") if not ln.lstrip().startswith("#"))
+
+
+def env_keys(*scopes) -> set[str]:
+    names: set[str] = set()
+    for scope in scopes:
+        if isinstance(scope, dict):
+            names |= {str(k) for k in scope}
+    return names
+
+
+def assigned_names(body: str) -> set[str]:
+    names: set[str] = set()
+    for rx in (ASSIGNMENT, FOR_LOOP_VAR, PRINTF_VAR, MAPFILE_VAR):
+        names |= set(rx.findall(body))
+    for group in READ_VARS.findall(body):
+        names |= set(group.split())
+    return names
+
+
+def references(body: str) -> dict[str, bool]:
+    """name -> guarded-anywhere-in-this-step."""
+    refs: dict[str, bool] = {}
+    for name, suffix in BRACED_REF.findall(body):
+        guarded = suffix.startswith(GUARD_PREFIXES)
+        refs[name] = refs.get(name, False) or guarded
+    for name in BARE_REF.findall(body):
+        refs.setdefault(name, False)  # never upgrades a guard already recorded
+    return refs
+
+
+def scan_workflow(path: str) -> list[tuple[str, str, str, str]]:
+    with open(path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    if not isinstance(doc, dict):
+        return []
+
+    workflow_env = doc.get("env")
+    findings: list[tuple[str, str, str, str]] = []
+
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        job_env = job.get("env")
+        # Names an EARLIER step in this job exported via `$GITHUB_ENV`. Same-step writes do
+        # not count: GITHUB_ENV takes effect in the NEXT step, not the one doing the writing.
+        carried: set[str] = set()
+
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict) or "run" not in step:
+                continue
+            if step.get("shell") not in SHELLS_WE_PARSE:
+                continue
+
+            body = step["run"]
+            code = strip_unexpanded(strip_comments(QUOTED_HEREDOC.sub(" ", GH_EXPR.sub(" ", body))))
+            declared = env_keys(workflow_env, job_env, step.get("env")) | carried
+            local = assigned_names(code)
+
+            for name, guarded in sorted(references(code).items()):
+                if not ENV_STYLE_NAME.fullmatch(name):
+                    continue
+                if guarded or name in declared or name in local or RUNNER_PROVIDED.match(name):
+                    continue
+                findings.append((path, job_id, str(step.get("name", "<unnamed step>")), name))
+
+            if "GITHUB_ENV" in body:
+                carried |= assigned_names(GH_EXPR.sub(" ", body))
+
+    return findings
+
+
+def main(argv: list[str]) -> int:
+    targets = argv[1:] or sorted(glob.glob(".github/workflows/*.yml"))
+    if not targets:
+        # A clean sweep of nothing is indistinguishable from success, and reads as safety.
+        # Same failure shape scripts/lint-workflows.sh guards against.
+        print(
+            "lint-workflow-step-env-refs: no workflow files found from "
+            f"{__import__('os').getcwd()} — refusing to report a clean sweep of nothing.",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings: list[tuple[str, str, str, str]] = []
+    for path in targets:
+        try:
+            findings += scan_workflow(path)
+        except (OSError, yaml.YAMLError) as exc:
+            # Fail closed: an unparseable workflow is not a passing workflow.
+            print(f"lint-workflow-step-env-refs: cannot parse {path}: {exc}", file=sys.stderr)
+            return 1
+
+    if not findings:
+        print(f"lint-workflow-step-env-refs: 0 findings across {len(targets)} workflow file(s).")
+        return 0
+
+    print(
+        f"lint-workflow-step-env-refs: {len(findings)} finding(s) — a step reads a variable "
+        "that nothing in scope sets.\n",
+        file=sys.stderr,
+    )
+    for path, job_id, step_name, name in findings:
+        print(f"  {path}: job '{job_id}', step '{step_name}': ${name}", file=sys.stderr)
+    print(
+        "\nUnder `set -u` this kills the step at that line. Declare the variable in THIS "
+        "step's own `env:` (step-level `env:` does not cross step boundaries), or guard the "
+        "expansion as ${NAME:-} if being unset is legitimate.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/lint-workflow-step-env-refs.test.sh
+++ b/scripts/lint-workflow-step-env-refs.test.sh
@@ -332,6 +332,24 @@ else
   fail "B1 shipped step declares R_DEPLOY in its own env:" "not found in step env keys"
 fi
 
+# B1b -- the mirror step must NOT inherit the implicit success() guard. Without
+# `!cancelled()` it is SKIPPED whenever the email step FAILS -- verified on run 30703438860
+# (email=failure, mirror=skipped), which is how both alert channels died together. A static
+# assertion because a GitHub `if:` expression cannot be evaluated locally.
+MIRROR_IF="$(python3 - "$RELEASE_WF" <<'PY'
+import sys, yaml
+doc = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+steps = doc["jobs"]["release-outcome"]["steps"]
+step = next(s for s in steps if str(s.get("name", "")).startswith("Mirror non-delivery"))
+print(step.get("if", ""))
+PY
+)"
+if [[ "$MIRROR_IF" == *'!cancelled()'* ]]; then
+  pass "B1b Sentry mirror survives an email-step crash (!cancelled)"
+else
+  fail "B1b Sentry mirror survives an email-step crash (!cancelled)" "if: $MIRROR_IF"
+fi
+
 # Stubs. curl records the JSON payload it was handed and reports HTTP 200.
 mkdir -p "$TMP/bin"
 cat > "$TMP/bin/curl" <<'STUB'

--- a/scripts/lint-workflow-step-env-refs.test.sh
+++ b/scripts/lint-workflow-step-env-refs.test.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Tests for scripts/lint-workflow-step-env-refs.py, plus a live execution harness for the
+# step the guard was written for (#7136).
+#
+# TWO CLASSES, BOTH LOAD-BEARING:
+#
+#   PART A -- the linter over synthetic workflow fixtures. Asserts the bug shape is caught
+#   and that each measured exemption (guarded-anywhere, $GITHUB_ENV carry-forward, in-body
+#   assignment, single-quoted/escaped literals, lowercase, runner-provided) still holds.
+#   Assert on EXIT CODES, not on message text.
+#
+#   PART B -- EXECUTION of the real step body extracted from the shipped
+#   .github/workflows/web-platform-release.yml, under bash, with curl/jq stubbed. This is
+#   the acceptance criterion "verified against a forced-failure run, not only by reading the
+#   YAML": it runs the shipped text under the failure condition on every CI run, which a
+#   one-off workflow dispatch would not. Part B includes a MUTATION PROOF -- the same harness
+#   run against the pre-fix body (reconstructed by deleting R_DEPLOY from the step's env)
+#   MUST die with "unbound variable". Without that case, Part B could pass vacuously against
+#   a harness that never actually exercised the branch.
+#
+# Exit contract of the SUT: 0 clean, 1 findings / nothing scanned / unparseable input.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUT="$SCRIPT_DIR/lint-workflow-step-env-refs.py"
+RELEASE_WF="$REPO_ROOT/.github/workflows/web-platform-release.yml"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() {
+  echo "FAIL: $1"
+  [[ -n "${2:-}" ]] && echo "  detail: $2"
+  FAIL=$((FAIL + 1))
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---------------------------------------------------------------------------
+# PART A -- linter behaviour over fixtures
+# ---------------------------------------------------------------------------
+
+CASE_N=0
+# mkwf <<'YAML' ... YAML  -> echoes the path of a throwaway workflow file
+mkwf() {
+  CASE_N=$((CASE_N + 1))
+  local f="$TMP/wf_${CASE_N}.yml"
+  cat > "$f"
+  printf '%s' "$f"
+}
+
+# expect_exit <name> <expected> <file...>
+expect_exit() {
+  local name="$1" expected="$2"
+  shift 2
+  local out rc
+  out="$(python3 "$SUT" "$@" 2>&1)"
+  rc=$?
+  if [[ "$rc" -eq "$expected" ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected exit $expected, got $rc — output: $out"
+  fi
+}
+
+echo "== Part A: linter fixtures =="
+
+# A1 -- the #7136 shape: uppercase, unguarded, declared only on ANOTHER step.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: classify
+        env:
+          R_DEPLOY: ${{ needs.deploy.result }}
+        run: echo "classified"
+      - name: email
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -uo pipefail
+          if [[ "${R_DEPLOY}" == "success" ]]; then echo hi; fi
+YAML
+)"
+expect_exit "A1 catches the cross-step env bug shape" 1 "$f"
+
+# A2 -- same body, variable declared in THIS step's env (the fix).
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: email
+        env:
+          R_DEPLOY: ${{ needs.deploy.result }}
+        run: |
+          if [[ "${R_DEPLOY}" == "success" ]]; then echo hi; fi
+YAML
+)"
+expect_exit "A2 clean when declared in the step's own env" 0 "$f"
+
+# A3 -- guarded anywhere in the step exempts every reference to that name. This is the
+# `[[ -n "${X:-}" ]] || exit 1` then bare `${X}` idiom; 16 real occurrences on main.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: bridge
+        run: |
+          [[ -n "${WEB_HOST_SSH:-}" ]] || { echo "no bridge"; exit 1; }
+          ${WEB_HOST_SSH} host "uptime"
+YAML
+)"
+expect_exit "A3 guarded-anywhere exempts later bare refs" 0 "$f"
+
+# A4 -- $GITHUB_ENV export from an EARLIER step in the same job.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup
+        run: |
+          REMOTE_DIR=/var/tmp/x
+          echo "REMOTE_DIR=$REMOTE_DIR" >> "$GITHUB_ENV"
+      - name: use
+        run: rm -rf "$REMOTE_DIR"
+YAML
+)"
+expect_exit "A4 honours \$GITHUB_ENV carry-forward" 0 "$f"
+
+# A5 -- a $GITHUB_ENV write does NOT exempt the SAME step: GITHUB_ENV lands in the NEXT step.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: only
+        run: |
+          echo "LATER_VAR=1" >> "$GITHUB_ENV"
+          echo "reading ${OTHER_VAR} now"
+YAML
+)"
+expect_exit "A5 same-step \$GITHUB_ENV write does not exempt that step" 1 "$f"
+
+# A6 -- assigned in the body.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: local
+        run: |
+          BODY="<p>x</p>"
+          BODY="${BODY}<p>y</p>"
+          echo "$BODY"
+YAML
+)"
+expect_exit "A6 in-body assignment is not a finding" 0 "$f"
+
+# A7 -- literal `$VAR` text: single-quoted region and backslash-escaped. Never expanded.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: literals
+        run: |
+          echo "run: curl -H \"Authorization: Bearer \$HCLOUD_TOKEN\" https://api"
+          printf '%s\n' 'SELECT * FROM remote($BS_TABLE)'
+YAML
+)"
+expect_exit "A7 single-quoted and escaped literals are not references" 0 "$f"
+
+# A8 -- lowercase locals are shellcheck's SC2154 domain, not this gate's.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: jqargs
+        run: |
+          jq -n --arg from "a" '{from: $from, other: $missing}'
+YAML
+)"
+expect_exit "A8 ignores lowercase names" 0 "$f"
+
+# A9 -- runner-provided variables need no declaration.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: runner
+        run: echo "$GITHUB_SHA $RUNNER_TEMP $HOME" >> "$GITHUB_OUTPUT"
+YAML
+)"
+expect_exit "A9 runner-provided variables are exempt" 0 "$f"
+
+# A10 -- workflow-level and job-level env both count.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+env:
+  WF_LEVEL: a
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    env:
+      JOB_LEVEL: b
+    steps:
+      - name: scopes
+        run: echo "${WF_LEVEL} ${JOB_LEVEL}"
+YAML
+)"
+expect_exit "A10 workflow-level and job-level env count as declared" 0 "$f"
+
+# A11 -- unparseable YAML fails closed rather than reporting clean.
+printf 'name: t\non: push\njobs:\n  j:\n   steps: [ unclosed\n' > "$TMP/bad.yml"
+expect_exit "A11 unparseable workflow fails closed" 1 "$TMP/bad.yml"
+
+# A12 -- a clean sweep of NOTHING must not read as success.
+mkdir -p "$TMP/empty"
+out="$(cd "$TMP/empty" && python3 "$SUT" 2>&1)"; rc=$?
+if [[ "$rc" -eq 1 ]]; then
+  pass "A12 zero files scanned exits non-zero"
+else
+  fail "A12 zero files scanned exits non-zero" "expected exit 1, got $rc — $out"
+fi
+
+# A13 -- the real tree is clean. This is the gate's steady state: no allowlist, no baseline.
+expect_exit "A13 repository workflows are clean" 0
+
+# ---------------------------------------------------------------------------
+# PART B -- execute the SHIPPED step body
+# ---------------------------------------------------------------------------
+
+echo
+echo "== Part B: execution of the shipped release-outcome email step =="
+
+# extract_step <mode>  -- writes the step's run body to $TMP/step_<mode>.sh and its declared
+# env keys to $TMP/env_<mode>.txt. mode=fixed uses the shipped env; mode=prefix reconstructs
+# the pre-#7136 state by dropping R_DEPLOY from the step's env (the mutation proof).
+extract_step() {
+  local mode="$1"
+  python3 - "$RELEASE_WF" "$mode" "$TMP" <<'PY'
+import sys, yaml
+wf, mode, tmp = sys.argv[1], sys.argv[2], sys.argv[3]
+doc = yaml.safe_load(open(wf, encoding="utf-8"))
+steps = doc["jobs"]["release-outcome"]["steps"]
+step = next(s for s in steps if s.get("id") == "email")
+keys = [k for k in (step.get("env") or {}) if not (mode == "prefix" and k == "R_DEPLOY")]
+open(f"{tmp}/step_{mode}.sh", "w", encoding="utf-8").write(step["run"])
+open(f"{tmp}/env_{mode}.txt", "w", encoding="utf-8").write("\n".join(keys))
+PY
+}
+
+if ! extract_step fixed || ! extract_step prefix; then
+  fail "B0 extract the email step from the shipped workflow" "python/yaml extraction failed"
+else
+  pass "B0 extract the email step from the shipped workflow"
+fi
+
+# The subset assertion the acceptance criteria name, stated directly against the shipped file.
+if grep -qx 'R_DEPLOY' "$TMP/env_fixed.txt"; then
+  pass "B1 shipped step declares R_DEPLOY in its own env:"
+else
+  fail "B1 shipped step declares R_DEPLOY in its own env:" "not found in step env keys"
+fi
+
+# Stubs. curl records the JSON payload it was handed and reports HTTP 200.
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+payload=""
+prev=""
+for a in "$@"; do
+  [[ "$prev" == "-d" ]] && payload="$a"
+  prev="$a"
+done
+printf '%s' "$payload" > "$PAYLOAD_CAPTURE"
+printf '200'
+STUB
+chmod +x "$TMP/bin/curl"
+
+# run_step <name> <mode> <expect_rc> <r_deploy_mode> -- r_deploy_mode: value | unset
+run_step() {
+  local name="$1" mode="$2" expect_rc="$3" rdep="$4"
+  local capture="$TMP/payload_${mode}_${rdep}.json"
+  local rc out
+  : > "$capture"
+  local -a envargs=(
+    "PATH=$TMP/bin:$PATH"
+    "PAYLOAD_CAPTURE=$capture"
+    "RESEND_API_KEY=test-key"
+    "VERSION=0.247.3"
+    "TAG=v0.247.3"
+    "FAILED=deploy=failure"
+    "FAILED_HTML=<li>Rolling the new version out</li>"
+    "RUN_URL=https://github.com/jikig-ai/soleur/actions/runs/30703438860"
+    "GITHUB_OUTPUT=$TMP/gh_output_${mode}_${rdep}"
+    "RUNNER_TEMP=$TMP"
+  )
+  [[ "$rdep" != "unset" ]] && envargs+=("R_DEPLOY=$rdep")
+  : > "$TMP/gh_output_${mode}_${rdep}"
+  out="$(env -i "${envargs[@]}" bash "$TMP/step_${mode}.sh" 2>&1)"
+  rc=$?
+  LAST_OUT="$out"
+  LAST_PAYLOAD="$capture"
+  if [[ "$rc" -eq "$expect_rc" ]]; then
+    pass "$name"
+  else
+    fail "$name" "expected exit $expect_rc, got $rc — output: $out"
+  fi
+}
+
+payload_has() {
+  local capture="$1" needle="$2"
+  grep -qF -- "$needle" "$capture"
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  fail "B2..B6 execution cases" "jq is required by the step body but is not installed"
+else
+  RUN_URL_EXPECT="https://github.com/jikig-ai/soleur/actions/runs/30703438860"
+
+  # B2 -- the forced-failure case: this is the exact condition that has been firing in
+  # production since 2026-07-30 and delivering nothing.
+  run_step "B2 deploy=failure sends without dying" fixed 0 failure
+  if payload_has "$LAST_PAYLOAD" "production was NOT updated" \
+     && payload_has "$LAST_PAYLOAD" "$RUN_URL_EXPECT"; then
+    pass "B2a failure branch: correct subject + run link"
+  else
+    fail "B2a failure branch: correct subject + run link" "$(cat "$LAST_PAYLOAD")"
+  fi
+
+  # B3 -- the branch that had NEVER executed, because the step always died first.
+  run_step "B3 deploy=success sends without dying" fixed 0 success
+  if payload_has "$LAST_PAYLOAD" "production WAS updated"; then
+    pass "B3a success branch: correct subject"
+  else
+    fail "B3a success branch: correct subject" "$(cat "$LAST_PAYLOAD")"
+  fi
+  # The unconditional tail tells the operator to "send the run link above" — so the link
+  # has to be in BOTH branches. It was not, before #7136.
+  if payload_has "$LAST_PAYLOAD" "$RUN_URL_EXPECT"; then
+    pass "B3b success branch carries the run link its own text refers to"
+  else
+    fail "B3b success branch carries the run link its own text refers to" "$(cat "$LAST_PAYLOAD")"
+  fi
+
+  # B4 -- R_DEPLOY absent from the environment entirely must NOT kill the step, and must
+  # take the alarming branch (over-warn, never falsely reassure).
+  run_step "B4 R_DEPLOY unset survives" fixed 0 unset
+  if payload_has "$LAST_PAYLOAD" "production was NOT updated"; then
+    pass "B4a unset R_DEPLOY degrades to the 'NOT updated' branch"
+  else
+    fail "B4a unset R_DEPLOY degrades to the 'NOT updated' branch" "$(cat "$LAST_PAYLOAD")"
+  fi
+
+  # B5 -- MUTATION PROOF. Same harness, pre-fix env (R_DEPLOY removed) AND the guard
+  # removed from the expansion: must reproduce the production failure exactly.
+  sed 's/\${R_DEPLOY:-}/${R_DEPLOY}/' "$TMP/step_prefix.sh" > "$TMP/step_prefixbare.sh"
+  cp "$TMP/env_prefix.txt" "$TMP/env_prefixbare.txt"
+  run_step "B5 pre-fix body dies (mutation proof)" prefixbare 1 unset
+  if grep -q "unbound variable" <<< "$LAST_OUT"; then
+    pass "B5a pre-fix failure is the reported 'R_DEPLOY: unbound variable'"
+  else
+    fail "B5a pre-fix failure is the reported 'R_DEPLOY: unbound variable'" "$LAST_OUT"
+  fi
+  if [[ ! -s "$LAST_PAYLOAD" ]]; then
+    pass "B5b pre-fix body never reaches the send (no payload captured)"
+  else
+    fail "B5b pre-fix body never reaches the send (no payload captured)" "$(cat "$LAST_PAYLOAD")"
+  fi
+fi
+
+echo
+echo "Total: $((PASS + FAIL))  Pass: $PASS  Fail: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+echo "All tests passed"

--- a/scripts/lint-workflow-step-env-refs.test.sh
+++ b/scripts/lint-workflow-step-env-refs.test.sh
@@ -239,6 +239,46 @@ YAML
 )"
 expect_exit "A10 workflow-level and job-level env count as declared" 0 "$f"
 
+# A10b -- `mapfile`/`readarray` targets count as assigned. Regression guard for the ReDoS
+# rewrite: the option-grammar regex this replaced was exponentially backtrackable
+# (CodeQL py/redos), so the whole-line identifier harvest must still cover the array name.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mapfile
+        run: |
+          mapfile -t HOSTS < /tmp/hosts
+          readarray -t -d '' PATHS < /tmp/paths
+          echo "${HOSTS[0]} ${PATHS[0]}"
+YAML
+)"
+expect_exit "A10b mapfile/readarray targets count as assigned" 0 "$f"
+
+# A10c -- the pathological input for the replaced regex must return promptly, not hang.
+f="$(mkwf <<'YAML'
+name: t
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: redos-shape
+        run: |
+          mapfile -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 -0 X
+YAML
+)"
+START_S=$SECONDS
+expect_exit "A10c pathological mapfile line does not backtrack" 0 "$f"
+if [[ $((SECONDS - START_S)) -lt 10 ]]; then
+  pass "A10d pathological input completes in under 10s"
+else
+  fail "A10d pathological input completes in under 10s" "took $((SECONDS - START_S))s"
+fi
+
 # A11 -- unparseable YAML fails closed rather than reporting clean.
 printf 'name: t\non: push\njobs:\n  j:\n   steps: [ unclosed\n' > "$TMP/bad.yml"
 expect_exit "A11 unparseable workflow fails closed" 1 "$TMP/bad.yml"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -292,6 +292,11 @@ if want_scripts; then
   run_suite "scripts/lint-agents-compound-sync-unit" bash scripts/lint-agents-compound-sync.test.sh
   run_suite "scripts/lint-infra-no-human-steps" bash scripts/lint-infra-no-human-steps.test.sh
   run_suite "scripts/lint-credential-path-literals" bash scripts/lint-credential-path-literals.test.sh
+  # #7136: a `run:` step reading a variable declared only on ANOTHER step. Part B of this
+  # suite EXECUTES the shipped release-failure email body under both deploy branches — the
+  # alert path that had never once delivered, because `set -u` killed it before the curl.
+  run_suite "scripts/lint-workflow-step-env-refs" bash scripts/lint-workflow-step-env-refs.test.sh
+  run_suite "scripts/lint-workflow-step-env-refs-live" python3 scripts/lint-workflow-step-env-refs.py
   # ADR-140: Layer A encryption-posture detector (the mechanical resolver behind
   # the "encryption at rest + in transit" design-time gate). TS-1..8,15..17 +
   # the MB-1..MB-12 mutation battery (fixture-isolated, not suite-pass-count).


### PR DESCRIPTION
Closes #7136

## The bug

`.github/workflows/web-platform-release.yml`, job `release-outcome`, step **"Email the operator (release did NOT reach production)"** read `${R_DEPLOY}` — but `R_DEPLOY` was declared in the `env:` of a **different** step (`Classify the run outcome`). Step-level `env:` does not cross step boundaries, so under `set -uo pipefail` bash terminated the step at that line, **before** the `curl` to Resend.

Confirmed from the run log, not inferred from the YAML:

```
release-outcome  Email the operator (release did NOT reach production)
  /home/runner/work/_temp/dbd591da-…sh: line 26: R_DEPLOY: unbound variable
  ##[error]Process completed with exit code 1.
```

The bare expansion arrived **with the branch itself** (commit `3faa95fa8`, PR #7097), so this alert path has **never once delivered**. Production has taken no new build since ~2026-07-30 and nobody was told.

## The compensating channel was disarmed by the same crash

The issue notes the Sentry mirror "does not compensate". It is worse than that. **"Mirror non-delivery to Sentry and fail loudly"** inherits the implicit `success()` guard, so when the email step *failed* it was **skipped**, not mis-fed. Verified on run 30703438860:

| step | conclusion |
|---|---|
| Classify the run outcome | success |
| Email the operator (release did NOT reach production) | **failure** |
| Mirror non-delivery to Sentry and fail loudly | **skipped** |

A fallback that only runs when its subject succeeded cannot be a fallback for that subject failing. Both alert channels died together — which is how a step built so that "neither can end in silence" ended in silence.

## Fixes

- `R_DEPLOY: ${{ needs.deploy.result }}` declared in the email step's **own** `env:`.
- Reference guarded as `${R_DEPLOY:-}`, matching every sibling expansion. Unset now takes the **"production was NOT updated"** branch — the safe direction: over-warn rather than falsely reassure.
- `!cancelled()` added to the mirror step so it runs even when the email step fails outright.
- **Second defect, same step:** the run link and the "What stopped" list were indented *inside* the `else` branch, so the `success` branch carried neither — while the unconditional closing paragraph tells the operator to *"send the run link above to your engineer."* That branch had never executed, because the step always died first. Both now carry the tail.

## Prevention — `scripts/lint-workflow-step-env-refs.py`

A `run:` step may not read an `ALL_CAPS` variable that nothing in scope sets.

**shellcheck structurally cannot catch this.** actionlint already pipes every `run:` body through it, and SC2154 exists for exactly this — but it deliberately exempts `ALL_CAPS` names as presumed-environment, and it has no view of the workflow's `env:` blocks. Measured on the pre-fix body: **zero findings**. The workflow-awareness is the whole point; no actionlint setting buys it.

Four exemptions, each **measured** against the 70 workflow files on `main` rather than assumed:

| Exemption | Findings without it |
|---|---|
| Restrict to `ALL_CAPS` | ~977 (jq `--arg` names, lowercase locals — SC2154's domain) |
| `$GITHUB_ENV` carry-forward within a job | 41 |
| Guarded **anywhere** in the step (`[[ -n "${X:-}" ]] \|\| exit 1` then bare `${X}`) | 16 |
| Quote-state lexer (single-quoted regions, `\$` escapes) | 6 |

With all four, the sweep over `main` returns **exactly one finding — this bug**. So the gate ships fail-closed with **no allowlist and no highwater baseline**; if it ever prints again, that is a new defect, not accumulated debt. It also refuses to report a clean sweep of zero files — the silent-empty shape that bit twice while developing this.

## Tests

25 tests in `scripts/lint-workflow-step-env-refs.test.sh`, registered in `test-all.sh`'s `scripts` shard (a required check).

- **Part A** — fixtures for the bug shape and each exemption, plus fail-closed on unparseable YAML and on zero files scanned.
- **Part B** — **executes the shipped step body** extracted from the workflow, under `bash`, with `curl`/`jq` stubbed, for `deploy=failure`, `deploy=success`, and `R_DEPLOY` absent entirely. This is the acceptance criterion's "verified against a forced-failure run": it runs the shipped text under the failure condition on **every** CI run, which a one-off dispatch would not.
- **Mutation proof (B5)** — the same harness against the pre-fix body must die with `unbound variable` having captured no payload. Without it, Part B could pass vacuously against a harness that never exercised the branch.

Verified both directions: `python3 scripts/lint-workflow-step-env-refs.py` → 0 findings on this branch; against the pre-fix `web-platform-release.yml` from `main` → exit 1, naming `$R_DEPLOY` and the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)