### PR TITLE
fix(infra): the tier-2 digest oracle hashed nothing and called it ACTIVE

### DIFF
--- a/.github/workflows/apply-deploy-pipeline-fix.yml
+++ b/.github/workflows/apply-deploy-pipeline-fix.yml
@@ -438,9 +438,37 @@ jobs:
           # and an explicit ::warning:: naming exactly what is disabled, so a silently-weaker
           # gate is never mistaken for a passing one.
           set -uo pipefail
-          sha="$(doppler run --name-transformer tf-var -- \
-            terraform console -var="ssh_key_path=${CI_SSH_PUB}" <<<'base64encode(local.webhook_doppler_token_env)' 2>/dev/null \
-            | tr -d '"' | base64 -d 2>/dev/null | sha256sum | awk '{print $1}')" || true
+          # `nonsensitive()` is LOAD-BEARING, not a style choice. var.doppler_token is
+          # `sensitive = true`, and sensitivity propagates through the local and through
+          # base64encode(), so `terraform console` prints the literal string
+          # `(sensitive value)` — never the base64. Measured 2026-08-01 against prd.
+          #
+          # WHY THAT WAS INVISIBLE, and why the guard below is shaped the way it is:
+          # `(sensitive value)` fed to `base64 -d` fails, the failure was swallowed by
+          # `2>/dev/null`, the empty result reached `sha256sum`, and
+          # sha256("") = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+          # — a PERFECTLY WELL-FORMED 64-hex string. So the old `[[ =~ ^[0-9a-f]{64}$ ]]`
+          # shape check passed, the step announced "tier-2 byte compare ACTIVE", and it
+          # armed the gate with a digest that can never match ANY real file. The gate then
+          # reported content_mismatch and blamed the delivery. First real execution of this
+          # step was run 30708795115 (#7095); it failed a delivery that was byte-correct.
+          #
+          # A shape check cannot distinguish "hashed the payload" from "hashed nothing".
+          # So guard on CONTENT: require the decode to succeed AND to yield the template's
+          # own marker line. sha256sum is reached only through that gate.
+          b64=""; console_rc=0
+          b64="$(doppler run --name-transformer tf-var -- \
+            terraform console -var="ssh_key_path=${CI_SSH_PUB}" \
+            <<<'nonsensitive(base64encode(local.webhook_doppler_token_env))' 2>/dev/null)" || console_rc=$?
+          b64="${b64//\"/}"
+          sha=""
+          # The hash pipeline stays byte-identical to the original (`base64 -d | sha256sum`,
+          # no command substitution on the decoded bytes) so a trailing newline in the
+          # rendered file is preserved — $(...) would strip it and shift the digest.
+          if [[ "$console_rc" -eq 0 && -n "$b64" ]] \
+             && printf '%s' "$b64" | base64 -d 2>/dev/null | grep -q '^DOPPLER_TOKEN='; then
+            sha="$(printf '%s' "$b64" | base64 -d 2>/dev/null | sha256sum | awk '{print $1}')"
+          fi
           if [[ "$sha" =~ ^[0-9a-f]{64}$ ]]; then
             echo "INFRA_CONFIG_RENDERED_SHA__ETC_DEFAULT_SOLEUR_DOPPLER_TOKEN=${sha}" >> "$GITHUB_ENV"
             echo "rendered credential digest exported — tier-2 byte compare ACTIVE"


### PR DESCRIPTION
## Summary

`apply-deploy-pipeline-fix` run [30708795115](https://github.com/jikig-ai/soleur/actions/runs/30708795115) failed a delivery that was **byte-correct**. The delivery reported `exit_code=0, files_written=19/19, files_failed=0`, and the host's `/etc/default/soleur-doppler-token` digests to `41a7a0fb…` — confirmed byte-identical to the correctly-computed render. The gate rejected it anyway.

## Cause

`var.doppler_token` is `sensitive = true`. Sensitivity propagates through `local.webhook_doppler_token_env` and through `base64encode()`, so `terraform console` prints the literal string **`(sensitive value)`** rather than the base64. Measured against prd 2026-08-01.

## Why nothing caught it

```
"(sensitive value)"  →  base64 -d  (fails, silenced by 2>/dev/null)
                     →  ""         →  sha256sum
                     →  e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```

That is `sha256("")` — **a perfectly well-formed 64-hex string**. The old guard was `[[ "$sha" =~ ^[0-9a-f]{64}$ ]]`, i.e. a check on the digest's *shape*. It passed. The step then printed `rendered credential digest exported — tier-2 byte compare ACTIVE` and armed the gate with a digest that cannot match any real file.

The step's own comment promises it "DEGRADES LOUDLY, NEVER BLOCKS". In this failure mode it did neither — the `::warning::` branch was unreachable, and the poisoned digest made the fail-closed gate reject a healthy apply.

This step shipped in #7097; run 30708795115 was its **first real execution** (the previous successful apply, 2026-07-30, predates it). It has never worked.

## Fix

- `nonsensitive()` around the console expression, so the value is returned rather than redacted.
- **Guard on CONTENT, not shape:** require the decode to succeed *and* to yield the template's own `DOPPLER_TOKEN=` marker before `sha256sum` is reached. A shape check cannot distinguish "hashed the payload" from "hashed nothing".

The hash pipeline stays byte-identical (`base64 -d | sha256sum`, no command substitution on the decoded bytes) so a trailing newline in the rendered file is preserved — `$(...)` would strip it and shift the digest.

## Verification

Extracted the step from the parsed YAML and drove it with a stubbed `doppler`:

| Case | Result |
|---|---|
| console returns `(sensitive value)` — the exact production failure | warns, exports **nothing** |
| console exits non-zero, no output | warns, exports **nothing** |
| console returns valid base64 | exports the expected digest **byte-for-byte** |

Against prd: `nonsensitive()` yields `41a7a0fb…`, matching the host exactly — which is what establishes that run 30708795115's delivery was correct.

`yaml` parses; `actionlint` 0 findings.

## Not in this change, deliberately

The 3-case harness is **not** committed as a suite here. Its natural home (`.github/scripts/test/`) auto-globs into a **required** job, and adding a required-job dependency while production is undeployable is the wrong trade (#6454). Filed as a follow-up on #7103 with the recipe.

`Ref #7095` — production is still `v0.244.0`; this unblocks the Phase 2 re-run.

Generated with [Claude Code](https://claude.com/claude-code)
