### PR TITLE
fix(infra): the twice-daily drift scan reads ONE config and reports it as clean

### DIFF
--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -175,7 +175,7 @@ jobs:
           # inside a YAML block scalar puts its body at column 0, which ends the scalar and
           # makes the whole workflow unparseable. (Measured — the first version of this did
           # exactly that.) Parsing stays in python; the DECISION stays in bash, below.
-          # `causes` rides along because UNVERIFIABLE has four disjoint causes with four
+          # `causes` rides along because UNVERIFIABLE has TEN disjoint causes with
           # different remedies, and this step previously collapsed them into one email that
           # said "add a hostname mapping to access_hostname_for()". That is correct for
           # exactly one cause; for the others the mapping already exists, so the instruction
@@ -209,17 +209,29 @@ jobs:
           # heredoc mangled), an empty string would match no consumer condition and the run
           # would report nothing at all. Empty is unavailable.
           [[ -n "$verdict" ]] || verdict=unavailable
-          # Closed vocabulary (no-probe-configured | gate-absent | host-unreachable |
-          # probe-failed | refused-unstamped), comma-joined — no newlines, so it cannot
+          # Closed vocabulary (the ten causes the detector emits, plus `unknown` for a
+          # row with no cause field), comma-joined — no newlines, so it cannot
           # break the $GITHUB_OUTPUT key=value framing.
           [[ -n "${causes:-}" ]] || causes="-"
           [[ -n "${configs:-}" ]] || configs="-1"
           # A scan that saw fewer than 2 configs cannot answer the fan-out question at
           # all. Surfaced as its own output so every downstream consumer can qualify a
           # clean verdict rather than each re-deriving it.
-          coverage=full
-          [[ "$configs" =~ ^[0-9]+$ ]] && (( configs < 2 )) && coverage=single-config
-          [[ "$configs" == "-1" ]] && coverage=unknown
+          # DEFAULT IS `unknown`, and the ladder only ever moves OFF it on a parsed
+          # non-negative integer. The first version of this defaulted to the optimistic
+          # state and moved off it on two guarded assignments — which meant every
+          # unparseable value (`None` from a JSON null, `-2`, `abc`, or any field-shift
+          # out of `read -r`'s greedy last variable) asserted fleet-wide coverage, and
+          # the email then reassured the operator with the word itself. An unmeasured
+          # coverage must never be the confident one.
+          #
+          # `multi-config`, not `full`: this counts the configs the token could READ,
+          # which is not the number that EXISTS. A 2-of-14 scan is still a lower bound,
+          # so no state here claims completeness.
+          coverage=unknown
+          if [[ "$configs" =~ ^[0-9]+$ ]]; then
+            if (( configs < 2 )); then coverage=single-config; else coverage=multi-config; fi
+          fi
           {
             echo "rc=${rc}"
             echo "verdict=${verdict}"
@@ -228,8 +240,10 @@ jobs:
             echo "coverage=${coverage}"
           } >> "$GITHUB_OUTPUT"
           echo "token-drift verdict: ${verdict} (detector exit ${rc}, causes: ${causes}, configs: ${configs}, coverage: ${coverage})"
-          if [[ "$coverage" != "full" ]]; then
-            echo "::warning::Cloudflare token drift scanned ${configs} Doppler config(s) — this run CANNOT detect fan-out drift (a value stale in a config it never read). The verdict '${verdict}' is scoped to what was visible, not to the fleet. Widen the workflow's Doppler token scope to restore fleet-wide coverage."
+          if [[ "$coverage" == "single-config" ]]; then
+            echo "::warning::Cloudflare token drift scanned ${configs} Doppler config(s) — this run CANNOT detect fan-out drift (a value stale in a config it never read), which is the failure class this detector exists for. The verdict '${verdict}' is scoped to what was visible, not to the fleet. Remedy: the DOPPLER_TOKEN repo secret is a service token scoped to prd_terraform; a project-scoped token (or a second secret used only by this step) restores fleet-wide coverage."
+          elif [[ "$coverage" == "unknown" ]]; then
+            echo "::warning::Cloudflare token drift could not measure its own coverage (configs='${configs}') — the verdict file was unreadable or malformed. Treat the verdict '${verdict}' as unscoped."
           fi
           # Re-raise the detector's exit code AFTER the outputs are written. Capturing rc
           # with `|| rc=$?` makes this block succeed, which would have flipped this step's
@@ -254,7 +268,7 @@ jobs:
         uses: ./.github/actions/notify-ops-email
         with:
           subject: '[TOKEN DRIFT] A Cloudflare token rotation did not propagate to Doppler'
-          body: '<p><strong>At least one Cloudflare token value in Doppler is no longer accepted by Cloudflare.</strong></p><p>Terraform will NOT fix this on its own: the <code>doppler_secret</code> resources carry <code>lifecycle.ignore_changes = [value]</code>, so <code>terraform apply</code> reports "No changes" while the stale value keeps being served. Set the live value on the <code>prd</code> ROOT config — branch configs inherit it.</p><p>This matters for releases: the registry-push Access service token is what lets CI reach the zot registry, and zot is the only registry production can pull from. <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> to see which key in which config is stale.</p><p>Additional finding(s) from this same run that are NOT about a stale value: <code>${{ steps.token_drift.outputs.causes }}</code> (<code>-</code> means none). The verdict ladder reports one headline state; these are the others.</p><p><em>Scan coverage: <code>${{ steps.token_drift.outputs.coverage }}</code> (${{ steps.token_drift.outputs.configs }} Doppler config(s) read). A <code>single-config</code> scan cannot detect a value that is stale only in a config it never read — treat this as a lower bound, not a fleet-wide result.</em></p>'
+          body: '<p><strong>At least one Cloudflare token value in Doppler is no longer accepted by Cloudflare.</strong></p><p>Terraform will NOT fix this on its own: the <code>doppler_secret</code> resources carry <code>lifecycle.ignore_changes = [value]</code>, so <code>terraform apply</code> reports "No changes" while the stale value keeps being served. Set the live value on the <code>prd</code> ROOT config — branch configs inherit it.</p><p>This matters for releases: the registry-push Access service token is what lets CI reach the zot registry, and zot is the only registry production can pull from. <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> to see which key in which config is stale.</p><p>Additional finding(s) from this same run that are NOT about a stale value: <code>${{ steps.token_drift.outputs.causes }}</code> (<code>-</code> means none). The verdict ladder reports one headline state; these are the others.</p><p><em>Scan coverage: <code>${{ steps.token_drift.outputs.coverage }}</code> (${{ steps.token_drift.outputs.configs }} Doppler config(s) read). Coverage counts configs this token could READ, which is not the number that EXISTS — so even <code>multi-config</code> is a lower bound, and <code>single-config</code> cannot detect a value stale only in a config it never read.</em></p>'
           resend-api-key: ${{ secrets.RESEND_API_KEY }}
 
       # Fires on `causes`, NOT on `verdict`, and therefore independently of the first-match
@@ -289,6 +303,90 @@ jobs:
       # Deduped on the dedicated label so three fires produce one issue with three
       # comments, not three issues. `continue-on-error` matches every sibling emitter
       # in this job — a rate-limited filer must not shadow the email below it.
+      # ── COVERAGE HAS NO CHANNEL WITHOUT THIS ────────────────────────────
+      # A single-config scan reports `verdict: clean`, exits 0, and matches NO email
+      # arm — `Enforce token-drift result` is gated on outcome == 'failure'. So the
+      # only artifact is a ::warning:: on a GREEN cron run, which nobody opens. That
+      # is `hr-no-dashboard-eyeball-pull-data-yourself`, and it is the same "clean bill
+      # of health for a question never asked" shape the detector's own header condemns
+      # — reproduced by the change that added the coverage signal.
+      #
+      # CREATE-ONLY, not create-or-comment. Coverage is `single-config` on EVERY
+      # scheduled run until the token scope is widened, so the DEAD filer's
+      # comment-on-existing shape would post 730 comments a year. The
+      # `heartbeat-live-reconcile` job already chose create-only for exactly this
+      # standing-condition case. One issue, open until fixed, then gone.
+      #
+      # The job stays GREEN and the ::warning:: stays. A hard failure here would fire
+      # twice daily forever and teach the operator that a red scheduled-terraform-drift
+      # means nothing — which would poison the DEAD arm's red signal too (#7133 in
+      # reverse).
+      - name: Open an action-required issue (token drift — narrow scan coverage)
+        if: always() && steps.token_drift.outputs.coverage != 'multi-config'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          COVERAGE: ${{ steps.token_drift.outputs.coverage }}
+          CONFIGS: ${{ steps.token_drift.outputs.configs }}
+          VERDICT: ${{ steps.token_drift.outputs.verdict }}
+        run: |
+          set -uo pipefail
+          LABEL="token-drift-coverage"
+          TITLE="[TOKEN DRIFT] The fan-out detector is scanning one Doppler config"
+          RUN_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+
+          gh label create "$LABEL" \
+            --description "check-cloudflare-token-drift.sh could not scan the config fan-out" \
+            --color "FBCA04" 2>/dev/null || true
+
+          EXISTING=$(gh issue list --label "$LABEL" --state open -L 5 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          if [[ -n "$EXISTING" ]]; then
+            echo "coverage issue #${EXISTING} already open — create-only, not commenting."
+            exit 0
+          fi
+
+          BODY=$(mktemp)
+          {
+            echo "**The twice-daily Cloudflare token-drift scan read ${CONFIGS} Doppler config(s).**"
+            echo ""
+            echo "Coverage: \`${COVERAGE}\`  •  Verdict this run: \`${VERDICT}\`  •  Run: ${RUN_URL}"
+            echo ""
+            echo "### Why this matters"
+            echo ""
+            echo "This detector exists to catch **fan-out** drift. Its own header cites the cases"
+            echo "that motivated it: \`CF_API_TOKEN_DNS_EDIT\` stale in **5 of 7** configs after a"
+            echo "dashboard roll, \`CF_API_TOKEN_PURGE\` in **6 of 7**. A scan that reads one config"
+            echo "cannot observe that class at all — it reports \`clean\` while every unread config"
+            echo "could hold a stale value."
+            echo ""
+            echo "A \`clean\` verdict from this workflow is therefore scoped to what was visible,"
+            echo "not to the fleet. That also bounds the escalation added in #7133: an"
+            echo "action-required issue can only be filed for a credential the scan actually read."
+            echo ""
+            echo "### Remedy"
+            echo ""
+            echo "The \`DOPPLER_TOKEN\` repo secret is a **service token scoped to \`prd_terraform\`**,"
+            echo "so \`doppler configs -p soleur\` returns only that config. Restore fleet-wide"
+            echo "coverage with a project-scoped read token — either replacing \`DOPPLER_TOKEN\` or"
+            echo "as a second secret consumed only by the token-drift step."
+            echo ""
+            echo "This is a production credential change, which is why it is filed rather than"
+            echo "automated."
+            echo ""
+            echo "### Closing"
+            echo ""
+            echo "Close when a scheduled run reports \`coverage: multi-config\`. Filed create-only:"
+            echo "the condition holds on every run until fixed, so this issue is not re-commented."
+          } > "$BODY"
+
+          gh issue create --title "$TITLE" --body-file "$BODY" \
+            --label "$LABEL" --label action-required --label priority/p1-high \
+            --milestone "Post-MVP / Later" 2>&1 | tail -2 || true
+          rm -f "$BODY"
+
       - name: Open or update an action-required issue (token drift — DEAD credential)
         if: always() && steps.token_drift.outputs.verdict == 'dead'
         continue-on-error: true
@@ -347,7 +445,7 @@ jobs:
             echo "  Note this publishes to \`prd_terraform\` only. If the detector reports a stale"
             echo "  copy in any OTHER config, re-minting will not clear it — fix that copy directly."
             echo ""
-            echo "_Auto-filed by [scheduled-terraform-drift](${SERVER_URL}/${REPOSITORY}/actions/workflows/scheduled-terraform-drift.yml). Close it when the detector reports \`verdict: clean\`._"
+            echo "_Auto-filed by [scheduled-terraform-drift](${SERVER_URL}/${REPOSITORY}/actions/workflows/scheduled-terraform-drift.yml). Close it when the detector reports \`verdict: clean\` **at \`coverage: multi-config\`** — a \`clean\` from a single-config scan is scoped to the configs it read, not to the fleet._"
           } > "${RUNNER_TEMP}/token-drift-issue.md"
 
           EXISTING=$(gh issue list --label "$LABEL" --state open --limit 100 \
@@ -397,7 +495,7 @@ jobs:
         uses: ./.github/actions/notify-ops-email
         with:
           subject: '[TOKEN DRIFT] No conclusion could be drawn about at least one token'
-          body: '<p><strong>No token was found stale, but at least one enumerated token could not be verified at all</strong>, so this run cannot claim the fleet is clean — and it is NOT claiming anything is broken.</p><p><strong>Do not rotate anything on the strength of this email.</strong></p><p>Reported cause(s): <code>${{ steps.token_drift.outputs.causes }}</code>. What each one means:</p><ul><li><code>no-probe-configured</code> — the detector has no hostname mapping for that key. Fix the DETECTOR: add one to <code>access_hostname_for()</code> in <code>scripts/check-cloudflare-token-drift.sh</code>.</li><li><code>gate-absent</code> — an UNCREDENTIALED request to the host was not refused by Cloudflare Access. Nothing is gating that hostname. This is a GATE finding, not a credential finding: check the Access application and policy. Rotating the token changes nothing.</li><li><code>host-unreachable</code> / <code>probe-failed</code> — the probe got no answer (timeout, DNS, TLS). Nothing was measured. Re-run.</li><li><code>gate-indeterminate</code> — the host answered an anonymous request without an Access stamp and without succeeding (a 530 tunnel outage looks like this). Neither a gate nor its absence was established. Re-run.</li><li><code>control-blocked</code> — Cloudflare itself blocked or challenged the anonymous probe, so it never reached Access. Check the WAF / rate-limit / bot-fight rules for the host.</li><li><code>stamped-non-refusal</code> — the host returned an Access-stamped response that is not a refusal. Not evidence the credential was rejected; investigate the Access application.</li><li><code>unexpected-status</code> — no Access stamp and no success. LIVE requires positive proof of admission, so nothing was certified — and nothing is claimed stale either.</li><li><code>detector-env</code> — a LOCAL fault on the runner (could not allocate a temp file). No request was sent; nothing about the credential or the host is implied.</li><li><code>refused-unstamped</code> — something in FRONT of Access refused the probe (WAF rule, IP access rule, bot-fight). Check the rule set for the host, not the credential.</li></ul><p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> for the exact keys and the reason each was skipped.</p><p><em>Scan coverage: <code>${{ steps.token_drift.outputs.coverage }}</code> (${{ steps.token_drift.outputs.configs }} Doppler config(s) read). A <code>single-config</code> scan cannot detect a value that is stale only in a config it never read — treat this as a lower bound, not a fleet-wide result.</em></p>'
+          body: '<p><strong>No token was found stale, but at least one enumerated token could not be verified at all</strong>, so this run cannot claim the fleet is clean — and it is NOT claiming anything is broken.</p><p><strong>Do not rotate anything on the strength of this email.</strong></p><p>Reported cause(s): <code>${{ steps.token_drift.outputs.causes }}</code>. What each one means:</p><ul><li><code>no-probe-configured</code> — the detector has no hostname mapping for that key. Fix the DETECTOR: add one to <code>access_hostname_for()</code> in <code>scripts/check-cloudflare-token-drift.sh</code>.</li><li><code>gate-absent</code> — an UNCREDENTIALED request to the host was not refused by Cloudflare Access. Nothing is gating that hostname. This is a GATE finding, not a credential finding: check the Access application and policy. Rotating the token changes nothing.</li><li><code>host-unreachable</code> / <code>probe-failed</code> — the probe got no answer (timeout, DNS, TLS). Nothing was measured. Re-run.</li><li><code>unknown</code> — a row arrived with no <code>cause</code> field. That is a detector/consumer contract break, not a credential finding: report it rather than acting on it.</li><li><code>gate-indeterminate</code> — the host answered an anonymous request without an Access stamp and without succeeding (a 530 tunnel outage looks like this). Neither a gate nor its absence was established. Re-run.</li><li><code>control-blocked</code> — Cloudflare itself blocked or challenged the anonymous probe, so it never reached Access. Check the WAF / rate-limit / bot-fight rules for the host.</li><li><code>stamped-non-refusal</code> — the host returned an Access-stamped response that is not a refusal. Not evidence the credential was rejected; investigate the Access application.</li><li><code>unexpected-status</code> — no Access stamp and no success. LIVE requires positive proof of admission, so nothing was certified — and nothing is claimed stale either.</li><li><code>detector-env</code> — a LOCAL fault on the runner (could not allocate a temp file). No request was sent; nothing about the credential or the host is implied.</li><li><code>refused-unstamped</code> — something in FRONT of Access refused the probe (WAF rule, IP access rule, bot-fight). Check the rule set for the host, not the credential.</li></ul><p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> for the exact keys and the reason each was skipped.</p><p><em>Scan coverage: <code>${{ steps.token_drift.outputs.coverage }}</code> (${{ steps.token_drift.outputs.configs }} Doppler config(s) read). Coverage counts configs this token could READ, which is not the number that EXISTS — so even <code>multi-config</code> is a lower bound, and <code>single-config</code> cannot detect a value stale only in a config it never read.</em></p>'
           resend-api-key: ${{ secrets.RESEND_API_KEY }}
 
       - name: Email notification (token drift — detector could not run)

--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -182,7 +182,17 @@ jobs:
           # is unperformable and the state never clears. The detector now emits a closed
           # `cause` vocabulary per row precisely so this decision does not have to
           # pattern-match English prose.
-          read -r dead unver causes < <(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["dead"], d["unverifiable"], ",".join(sorted({r.get("cause","unknown") for r in d.get("unverifiable_keys",[])})) or "-")' "$RUNNER_TEMP/token-drift.json" 2>/dev/null || echo "-1 -1 -")
+          # `configs` rides along for the COVERAGE question, which is separate from the
+          # verdict question. This detector exists to catch fan-out drift — its own
+          # header cites "5 of 7 configs stale after a dashboard roll" — and the
+          # scheduled run's Doppler service token is scoped to ONE config, so a
+          # single-config scan reports `clean` while twelve unseen configs could each
+          # hold a stale value. That is the script's own condemned failure ("a clean
+          # bill of health for a question never asked") reproduced at the scheduling
+          # layer. Emitting the number is what lets `clean` be qualified instead of
+          # silently over-read; #7133's escalation channel is only as good as the
+          # coverage feeding it.
+          read -r dead unver causes configs < <(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["dead"], d["unverifiable"], ",".join(sorted({r.get("cause","unknown") for r in d.get("unverifiable_keys",[])})) or "-", d.get("configs", -1))' "$RUNNER_TEMP/token-drift.json" 2>/dev/null || echo "-1 -1 - -1")
           # Anything unreadable or unparseable is "unavailable", never "clean". A missing or
           # corrupt verdict file means the scan's result is UNKNOWN, and the one arm it must
           # never take is the one saying every token is live.
@@ -203,12 +213,24 @@ jobs:
           # probe-failed | refused-unstamped), comma-joined — no newlines, so it cannot
           # break the $GITHUB_OUTPUT key=value framing.
           [[ -n "${causes:-}" ]] || causes="-"
+          [[ -n "${configs:-}" ]] || configs="-1"
+          # A scan that saw fewer than 2 configs cannot answer the fan-out question at
+          # all. Surfaced as its own output so every downstream consumer can qualify a
+          # clean verdict rather than each re-deriving it.
+          coverage=full
+          [[ "$configs" =~ ^[0-9]+$ ]] && (( configs < 2 )) && coverage=single-config
+          [[ "$configs" == "-1" ]] && coverage=unknown
           {
             echo "rc=${rc}"
             echo "verdict=${verdict}"
             echo "causes=${causes}"
+            echo "configs=${configs}"
+            echo "coverage=${coverage}"
           } >> "$GITHUB_OUTPUT"
-          echo "token-drift verdict: ${verdict} (detector exit ${rc}, causes: ${causes})"
+          echo "token-drift verdict: ${verdict} (detector exit ${rc}, causes: ${causes}, configs: ${configs}, coverage: ${coverage})"
+          if [[ "$coverage" != "full" ]]; then
+            echo "::warning::Cloudflare token drift scanned ${configs} Doppler config(s) — this run CANNOT detect fan-out drift (a value stale in a config it never read). The verdict '${verdict}' is scoped to what was visible, not to the fleet. Widen the workflow's Doppler token scope to restore fleet-wide coverage."
+          fi
           # Re-raise the detector's exit code AFTER the outputs are written. Capturing rc
           # with `|| rc=$?` makes this block succeed, which would have flipped this step's
           # `outcome` to 'success' permanently and silently disarmed the enforce step at
@@ -232,7 +254,7 @@ jobs:
         uses: ./.github/actions/notify-ops-email
         with:
           subject: '[TOKEN DRIFT] A Cloudflare token rotation did not propagate to Doppler'
-          body: '<p><strong>At least one Cloudflare token value in Doppler is no longer accepted by Cloudflare.</strong></p><p>Terraform will NOT fix this on its own: the <code>doppler_secret</code> resources carry <code>lifecycle.ignore_changes = [value]</code>, so <code>terraform apply</code> reports "No changes" while the stale value keeps being served. Set the live value on the <code>prd</code> ROOT config — branch configs inherit it.</p><p>This matters for releases: the registry-push Access service token is what lets CI reach the zot registry, and zot is the only registry production can pull from. <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> to see which key in which config is stale.</p><p>Additional finding(s) from this same run that are NOT about a stale value: <code>${{ steps.token_drift.outputs.causes }}</code> (<code>-</code> means none). The verdict ladder reports one headline state; these are the others.</p>'
+          body: '<p><strong>At least one Cloudflare token value in Doppler is no longer accepted by Cloudflare.</strong></p><p>Terraform will NOT fix this on its own: the <code>doppler_secret</code> resources carry <code>lifecycle.ignore_changes = [value]</code>, so <code>terraform apply</code> reports "No changes" while the stale value keeps being served. Set the live value on the <code>prd</code> ROOT config — branch configs inherit it.</p><p>This matters for releases: the registry-push Access service token is what lets CI reach the zot registry, and zot is the only registry production can pull from. <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> to see which key in which config is stale.</p><p>Additional finding(s) from this same run that are NOT about a stale value: <code>${{ steps.token_drift.outputs.causes }}</code> (<code>-</code> means none). The verdict ladder reports one headline state; these are the others.</p><p><em>Scan coverage: <code>${{ steps.token_drift.outputs.coverage }}</code> (${{ steps.token_drift.outputs.configs }} Doppler config(s) read). A <code>single-config</code> scan cannot detect a value that is stale only in a config it never read — treat this as a lower bound, not a fleet-wide result.</em></p>'
           resend-api-key: ${{ secrets.RESEND_API_KEY }}
 
       # Fires on `causes`, NOT on `verdict`, and therefore independently of the first-match
@@ -375,7 +397,7 @@ jobs:
         uses: ./.github/actions/notify-ops-email
         with:
           subject: '[TOKEN DRIFT] No conclusion could be drawn about at least one token'
-          body: '<p><strong>No token was found stale, but at least one enumerated token could not be verified at all</strong>, so this run cannot claim the fleet is clean — and it is NOT claiming anything is broken.</p><p><strong>Do not rotate anything on the strength of this email.</strong></p><p>Reported cause(s): <code>${{ steps.token_drift.outputs.causes }}</code>. What each one means:</p><ul><li><code>no-probe-configured</code> — the detector has no hostname mapping for that key. Fix the DETECTOR: add one to <code>access_hostname_for()</code> in <code>scripts/check-cloudflare-token-drift.sh</code>.</li><li><code>gate-absent</code> — an UNCREDENTIALED request to the host was not refused by Cloudflare Access. Nothing is gating that hostname. This is a GATE finding, not a credential finding: check the Access application and policy. Rotating the token changes nothing.</li><li><code>host-unreachable</code> / <code>probe-failed</code> — the probe got no answer (timeout, DNS, TLS). Nothing was measured. Re-run.</li><li><code>refused-unstamped</code> — something in FRONT of Access refused the probe (WAF rule, IP access rule, bot-fight). Check the rule set for the host, not the credential.</li></ul><p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> for the exact keys and the reason each was skipped.</p>'
+          body: '<p><strong>No token was found stale, but at least one enumerated token could not be verified at all</strong>, so this run cannot claim the fleet is clean — and it is NOT claiming anything is broken.</p><p><strong>Do not rotate anything on the strength of this email.</strong></p><p>Reported cause(s): <code>${{ steps.token_drift.outputs.causes }}</code>. What each one means:</p><ul><li><code>no-probe-configured</code> — the detector has no hostname mapping for that key. Fix the DETECTOR: add one to <code>access_hostname_for()</code> in <code>scripts/check-cloudflare-token-drift.sh</code>.</li><li><code>gate-absent</code> — an UNCREDENTIALED request to the host was not refused by Cloudflare Access. Nothing is gating that hostname. This is a GATE finding, not a credential finding: check the Access application and policy. Rotating the token changes nothing.</li><li><code>host-unreachable</code> / <code>probe-failed</code> — the probe got no answer (timeout, DNS, TLS). Nothing was measured. Re-run.</li><li><code>gate-indeterminate</code> — the host answered an anonymous request without an Access stamp and without succeeding (a 530 tunnel outage looks like this). Neither a gate nor its absence was established. Re-run.</li><li><code>control-blocked</code> — Cloudflare itself blocked or challenged the anonymous probe, so it never reached Access. Check the WAF / rate-limit / bot-fight rules for the host.</li><li><code>stamped-non-refusal</code> — the host returned an Access-stamped response that is not a refusal. Not evidence the credential was rejected; investigate the Access application.</li><li><code>unexpected-status</code> — no Access stamp and no success. LIVE requires positive proof of admission, so nothing was certified — and nothing is claimed stale either.</li><li><code>detector-env</code> — a LOCAL fault on the runner (could not allocate a temp file). No request was sent; nothing about the credential or the host is implied.</li><li><code>refused-unstamped</code> — something in FRONT of Access refused the probe (WAF rule, IP access rule, bot-fight). Check the rule set for the host, not the credential.</li></ul><p><a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Open the run</a> for the exact keys and the reason each was skipped.</p><p><em>Scan coverage: <code>${{ steps.token_drift.outputs.coverage }}</code> (${{ steps.token_drift.outputs.configs }} Doppler config(s) read). A <code>single-config</code> scan cannot detect a value that is stale only in a config it never read — treat this as a lower bound, not a fleet-wide result.</em></p>'
           resend-api-key: ${{ secrets.RESEND_API_KEY }}
 
       - name: Email notification (token drift — detector could not run)

--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -225,12 +225,21 @@ jobs:
           # the email then reassured the operator with the word itself. An unmeasured
           # coverage must never be the confident one.
           #
-          # `multi-config`, not `full`: this counts the configs the token could READ,
-          # which is not the number that EXISTS. A 2-of-14 scan is still a lower bound,
-          # so no state here claims completeness.
+          # `multi-config`, not `full`: this counts the configs the scan ENUMERATED
+          # (`doppler configs`, i.e. what the token could list), which is not the number
+          # that EXISTS. A 2-of-14 scan is still a lower bound, so no state here claims
+          # completeness. Note it is also not a count of configs whose token VALUES were
+          # read: a config whose `secrets get` calls all fail is still enumerated.
+          #
+          # `10#` forces base 10. Without it a zero-padded value (`09`) is read as octal,
+          # `(( ))` errors, and — because an arithmetic error in an `if` condition is not
+          # fatal under `set -e` — control falls to the `else`, i.e. to the CONFIDENT
+          # state. Unreachable from today's producer (json.dumps of an int never pads),
+          # but this ladder's whole premise is that a future producer may write something
+          # we did not anticipate, and every other unparseable value already fails safe.
           coverage=unknown
           if [[ "$configs" =~ ^[0-9]+$ ]]; then
-            if (( configs < 2 )); then coverage=single-config; else coverage=multi-config; fi
+            if (( 10#$configs < 2 )); then coverage=single-config; else coverage=multi-config; fi
           fi
           {
             echo "rc=${rc}"
@@ -301,8 +310,17 @@ jobs:
       # production host, and it is the reason this workflow exists.
       #
       # Deduped on the dedicated label so three fires produce one issue with three
-      # comments, not three issues. `continue-on-error` matches every sibling emitter
-      # in this job — a rate-limited filer must not shadow the email below it.
+      # comments, not three issues. `continue-on-error` matches every sibling
+      # token-drift emitter in this job — a rate-limited filer must not shadow the
+      # email below it. (The two Terraform-plan-drift email steps further down carry
+      # no `continue-on-error`; the claim is scoped to the token-drift family.)
+      #
+      # NOTE: the block above describes the DEAD filer, which is the step named
+      # `Open or update an action-required issue (token drift — DEAD credential)`
+      # BELOW the coverage filer — not the coverage filer immediately following.
+      # The two make OPPOSITE dedup choices, and the reason is in each one's own
+      # comment: DEAD is acute and recurrence is signal, so it comments on the open
+      # issue; coverage is a standing condition, so it does not.
       # ── COVERAGE HAS NO CHANNEL WITHOUT THIS ────────────────────────────
       # A single-config scan reports `verdict: clean`, exits 0, and matches NO email
       # arm — `Enforce token-drift result` is gated on outcome == 'failure'. So the
@@ -313,17 +331,41 @@ jobs:
       #
       # CREATE-ONLY, not create-or-comment. Coverage is `single-config` on EVERY
       # scheduled run until the token scope is widened, so the DEAD filer's
-      # comment-on-existing shape would post 730 comments a year. The
-      # `heartbeat-live-reconcile` job already chose create-only for exactly this
-      # standing-condition case. One issue, open until fixed, then gone.
+      # comment-on-existing shape would post 730 comments a year.
+      #
+      # The precedent is the `heartbeat-live-reconcile` job's EMAIL step, which gates on
+      # `steps.reconcile_issue.outputs.created == 'true'` — commented there as
+      # "Creation-only for a mismatch (avoid twice-daily spam while a heartbeat awaits
+      # disposition)". Its ISSUE filer is create-OR-comment, so do not read it as the
+      # precedent for this step; an earlier version of this comment cited it that way and
+      # was wrong. What transfers is the reasoning, not the step: a condition that does
+      # not vary between runs earns one notification, not one per run.
+      #
+      # One issue, open until fixed — then closed by the close arm below, not by hand.
       #
       # The job stays GREEN and the ::warning:: stays. A hard failure here would fire
       # twice daily forever and teach the operator that a red scheduled-terraform-drift
       # means nothing — which would poison the DEAD arm's red signal too (#7133 in
       # reverse).
+      # POSITIVE POLARITY, and this is load-bearing rather than stylistic. `drift-check`
+      # is a 2-leg matrix and `token_drift` is gated `matrix.directory ==
+      # 'apps/web-platform/infra'`, so on the `infra/github` leg it is SKIPPED and every
+      # `steps.token_drift.outputs.*` is the empty string. The first version of this
+      # tested `!= 'multi-config'`, and `'' != 'multi-config'` is TRUE — so the filer
+      # fired from the leg that never ran the scan, filing an issue whose body read
+      # "read  Doppler config(s)" with a blank coverage and verdict. Create-only then
+      # locked that blank issue in and suppressed the real leg's correct one, and it
+      # kept re-firing after the token was widened, making the issue's own stated
+      # closing condition unsatisfiable. Every sibling arm in this job tests positively
+      # (`== 'dead'`, `== 'unverifiable'`, `contains(...)`), which is exactly why they
+      # are skip-safe. Match them: an empty output must match nothing.
       - name: Open an action-required issue (token drift — narrow scan coverage)
-        if: always() && steps.token_drift.outputs.coverage != 'multi-config'
+        if: >-
+          always()
+          && (steps.token_drift.outputs.coverage == 'single-config'
+              || steps.token_drift.outputs.coverage == 'unknown')
         continue-on-error: true
+        timeout-minutes: 2
         env:
           GH_TOKEN: ${{ github.token }}
           SERVER_URL: ${{ github.server_url }}
@@ -335,22 +377,62 @@ jobs:
         run: |
           set -uo pipefail
           LABEL="token-drift-coverage"
-          TITLE="[TOKEN DRIFT] The fan-out detector is scanning one Doppler config"
           RUN_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+
+          # `unknown` is NOT a narrow scan — it is an unreadable or malformed verdict
+          # file, i.e. a detector that could not run. Filing it under the single-config
+          # title told the operator the scan was narrow (body: "read -1 Doppler
+          # config(s)") and prescribed widening the Doppler token, which fixes nothing
+          # on that path. That is verbatim the defect this workflow's `causes` handling
+          # exists to remove — one remedy for disjoint causes, unperformable for all but
+          # one of them, so the state never clears. It also mattered more than usual
+          # here: dedup is label-scoped and create-only, so whichever state filed FIRST
+          # permanently suppressed the other.
+          #
+          # `unknown` keeps a channel rather than being dropped, because it is reachable
+          # with a CLEAN verdict (well-formed JSON that simply lacks `configs`), and no
+          # email arm fires on clean. The `verdict == 'unavailable'` email only covers
+          # the crash path.
+          if [[ "$COVERAGE" == "unknown" ]]; then
+            TITLE="[TOKEN DRIFT] The fan-out detector could not measure its own scan coverage"
+            LEAD="**The token-drift scan published an unreadable config count (\`${CONFIGS}\`).** Its verdict (\`${VERDICT}\`) is therefore unscoped — it is not a fleet-wide claim, and it is not evidence of a narrow scan either. This is a DETECTOR fault, not a token-scope fault: widening the Doppler token will not clear it."
+          else
+            TITLE="[TOKEN DRIFT] The fan-out detector is scanning one Doppler config"
+            LEAD="**The twice-daily Cloudflare token-drift scan read ${CONFIGS} Doppler config(s).**"
+          fi
 
           gh label create "$LABEL" \
             --description "check-cloudflare-token-drift.sh could not scan the config fan-out" \
             --color "FBCA04" 2>/dev/null || true
 
-          EXISTING=$(gh issue list --label "$LABEL" --state open -L 5 --json number --jq '.[0].number // empty' 2>/dev/null || true)
+          # Fail CLOSED on a failed query. `2>/dev/null || true` made an API error, a
+          # rate limit and "no issue open" the same empty string — and the create-only
+          # design reads empty as "file one", so every transient fault added a permanent
+          # duplicate. The condition is standing, so declining to act costs at most 12h.
+          LIST_RC=0
+          EXISTING=$(gh issue list --label "$LABEL" --state open -L 5 --json number --jq '.[0].number // empty') || LIST_RC=$?
+          if (( LIST_RC != 0 )); then
+            echo "::error::token_drift_coverage_list_failed — could not query open ${LABEL} issues (gh exit ${LIST_RC}); declining to create a possible duplicate. Narrow coverage reached no issue channel this run."
+            exit 0
+          fi
           if [[ -n "$EXISTING" ]]; then
+            # Re-assert the labels before short-circuiting. The DEAD filer does this for
+            # a reason that applies with more force to a create-only step: if triage
+            # strips `action-required`, `operator-digest` stops harvesting the issue, and
+            # because this path never creates again the channel is lost permanently.
+            gh issue edit "$EXISTING" --add-label action-required --add-label priority/p1-high >/dev/null 2>&1 || true
             echo "coverage issue #${EXISTING} already open — create-only, not commenting."
             exit 0
           fi
 
-          BODY=$(mktemp)
+          # RUNNER_TEMP, not mktemp: `set -u` does not catch a FAILED mktemp (the
+          # variable is set, just empty), so `> ""` is an ambiguous redirect and
+          # `--body-file ""` fails — silently, under continue-on-error. The DEAD filer
+          # already writes to RUNNER_TEMP; this removes both the failure mode and a
+          # gratuitous difference between two adjacent filers.
+          BODY="${RUNNER_TEMP}/token-drift-coverage-issue.md"
           {
-            echo "**The twice-daily Cloudflare token-drift scan read ${CONFIGS} Doppler config(s).**"
+            echo "$LEAD"
             echo ""
             echo "Coverage: \`${COVERAGE}\`  •  Verdict this run: \`${VERDICT}\`  •  Run: ${RUN_URL}"
             echo ""
@@ -368,24 +450,89 @@ jobs:
             echo ""
             echo "### Remedy"
             echo ""
-            echo "The \`DOPPLER_TOKEN\` repo secret is a **service token scoped to \`prd_terraform\`**,"
-            echo "so \`doppler configs -p soleur\` returns only that config. Restore fleet-wide"
-            echo "coverage with a project-scoped read token — either replacing \`DOPPLER_TOKEN\` or"
-            echo "as a second secret consumed only by the token-drift step."
-            echo ""
-            echo "This is a production credential change, which is why it is filed rather than"
-            echo "automated."
+            if [[ "$COVERAGE" == "unknown" ]]; then
+              echo "**Do not widen the Doppler token on the strength of this issue** — the scan did"
+              echo "not report a narrow config count, it reported an unreadable one. Fix the verdict"
+              echo "file first: check the \`Cloudflare token drift\` step in the linked run for a"
+              echo "non-zero detector exit, a missing \`doppler\`/\`python3\`, or a truncated write in"
+              echo "\`emit_json\` (\`scripts/check-cloudflare-token-drift.sh\`). Coverage cannot be"
+              echo "assessed until the detector publishes a parseable \`configs\` field again."
+            else
+              echo "The \`DOPPLER_TOKEN\` repo secret is a **service token scoped to \`prd_terraform\`**,"
+              echo "so \`doppler configs -p soleur\` returns only that config."
+              echo ""
+              echo "Note a Doppler service token is **config-scoped by construction** (see the"
+              echo "BLAST RADIUS note in \`apps/web-platform/infra/web-probe-read-token.tf\`), so"
+              echo "there is no single \"project-scoped read token\" to mint. The shapes that exist"
+              echo "are: a read token on the \`prd\` ROOT config (branch configs inherit from it), a"
+              echo "\`for_each\` read token per config, or reusing \`DOPPLER_TOKEN_TF\`. They differ in"
+              echo "prd read blast radius, which is why the CHOICE is an operator decision."
+              echo ""
+              echo "The MECHANISM is not manual: \`apps/web-platform/infra/kb-drift.tf\` already mints"
+              echo "a read-scoped \`doppler_service_token\` in-band via Terraform and publishes it"
+              echo "with \`github_actions_secret\` (\`autonomy-considered: provider-mint-applied\`,"
+              echo "closing the operator-mint requirement in #4150). Four sibling tokens follow the"
+              echo "same pattern. Once the shape is chosen, this is a Terraform change, not a"
+              echo "dashboard step."
+            fi
             echo ""
             echo "### Closing"
             echo ""
-            echo "Close when a scheduled run reports \`coverage: multi-config\`. Filed create-only:"
-            echo "the condition holds on every run until fixed, so this issue is not re-commented."
+            echo "Closed automatically when a scheduled run reports \`coverage: multi-config\` (see"
+            echo "the \`Close the coverage issue once the fan-out is restored\` step in the same"
+            echo "job). Filed create-only: the condition holds on every run until fixed, so this"
+            echo "issue is not re-commented. Closing it by hand while coverage is still narrow"
+            echo "re-files a fresh one within 12h — the dedup query matches OPEN issues only."
           } > "$BODY"
 
-          gh issue create --title "$TITLE" --body-file "$BODY" \
-            --label "$LABEL" --label action-required --label priority/p1-high \
-            --milestone "Post-MVP / Later" 2>&1 | tail -2 || true
+          # Never echo success unconditionally, and never let the create's status vanish.
+          # `… 2>&1 | tail -2 || true` lost gh's exit code behind the pipe (tail exits 0)
+          # and then discarded what was left — so a failed create produced a GREEN step
+          # on a GREEN cron run with no issue filed and no annotation. Coverage has no
+          # email arm, so that is total loss of the one channel this step exists to be
+          # (`hr-no-dashboard-eyeball-pull-data-yourself`). The realistic triggers are the
+          # ones the DEAD filer below already enumerates: a renamed or closed milestone,
+          # an API 5xx, a secondary rate limit, or the best-effort `gh label create`
+          # above having failed so `--label "$LABEL"` is rejected.
+          if gh issue create --title "$TITLE" --body-file "$BODY" \
+               --label "$LABEL" --label action-required --label priority/p1-high \
+               --milestone "Post-MVP / Later"; then
+            echo "Filed a new action-required issue for narrow scan coverage (${COVERAGE})."
+          else
+            echo "::error::token_drift_coverage_escalation_failed — gh issue create did not succeed. Narrow scan coverage (${COVERAGE}, ${CONFIGS} config(s)) reached NO channel this run: no issue exists, and a clean verdict matches no email arm."
+          fi
           rm -f "$BODY"
+
+      # The close arm. Without it `coverage: multi-config` is observable only by opening
+      # a GREEN cron run's step log — which is the same "nobody opens it" problem the
+      # file arm above exists to solve, just on the recovery side. It also made the
+      # issue's own stated closing condition an operator step with no artifact behind it.
+      - name: Close the coverage issue once the fan-out is restored
+        if: always() && steps.token_drift.outputs.coverage == 'multi-config'
+        continue-on-error: true
+        timeout-minutes: 2
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          CONFIGS: ${{ steps.token_drift.outputs.configs }}
+        run: |
+          set -uo pipefail
+          LABEL="token-drift-coverage"
+          RUN_URL="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+          LIST_RC=0
+          N=$(gh issue list --label "$LABEL" --state open -L 5 --json number --jq '.[0].number // empty') || LIST_RC=$?
+          if (( LIST_RC != 0 )); then
+            echo "::warning::could not query open ${LABEL} issues (gh exit ${LIST_RC}); leaving any open coverage issue alone."
+            exit 0
+          fi
+          [[ -n "$N" ]] || { echo "no open coverage issue to close."; exit 0; }
+          if gh issue close "$N" --comment "Coverage restored: run ${RUN_URL} reported \`coverage: multi-config\` (${CONFIGS} Doppler config(s) enumerated). Auto-closed. Note the count is a lower bound — it counts configs this token could enumerate, not the number that exist."; then
+            echo "Closed coverage issue #${N}."
+          else
+            echo "::error::token_drift_coverage_close_failed — coverage is multi-config but issue #${N} could not be closed; it will keep asserting a narrow scan."
+          fi
 
       - name: Open or update an action-required issue (token drift — DEAD credential)
         if: always() && steps.token_drift.outputs.verdict == 'dead'

--- a/knowledge-base/engineering/operations/runbooks/ci-ssh-token-replace.md
+++ b/knowledge-base/engineering/operations/runbooks/ci-ssh-token-replace.md
@@ -5,7 +5,7 @@ Re-mint the `ci_ssh` Cloudflare Access service token when Cloudflare has stopped
 - **Dispatch target:** `apply-web-platform-infra.yml`, `apply_target=ci-ssh-token-replace`
 - **Confirm token:** `REPLACE-CI-SSH-TOKEN`
 - **Irreversible:** yes — Cloudflare will not re-issue the old secret
-- **First real use:** 2026-08-01, run `30708675183` (#7095). Worked; `verdict: clean (1 verified)`.
+- **First real use:** 2026-08-01, run `30708675183` (#7095). Worked; `verdict: clean (1 verified)` — scoped to `prd_terraform`, which is the only config that run could read (see the halt-gate note below).
 - **ADR:** [ADR-154](../../architecture/decisions/ADR-154-repair-the-credential-channel-not-the-host.md)
 
 ## When to fire this
@@ -82,7 +82,9 @@ All three inputs are required. `reason` is the audit trail and is echoed to the 
 gh workflow run apply-web-platform-infra.yml -f apply_target=manual-rerun -f reason="re-sync ci_ssh after a failed publish"
 ```
 
-**At the halt gate with `ci_ssh_access_denied`** — the re-mint succeeded but Access still rejects the pair. This **falsifies the premise** that the credential was the fault. Stop and re-diagnose; do not re-mint again. Check whether a stale `CI_SSH_ACCESS_TOKEN_*` copy exists in a Doppler config other than `prd_terraform` — this arm publishes to `prd_terraform` only, so a sibling copy elsewhere would keep the fleet-wide verdict `dead` forever and no amount of re-minting clears it.
+**At the halt gate with `ci_ssh_access_denied`** — the re-mint succeeded but Access still rejects the pair. This **falsifies the premise** that the credential was the fault. Stop and re-diagnose; do not re-mint again. Check whether a stale `CI_SSH_ACCESS_TOKEN_*` copy exists in a Doppler config other than `prd_terraform` — this arm publishes to `prd_terraform` only, so a sibling copy elsewhere is never cleared by re-minting.
+
+> **Do not wait for a `dead` verdict to confirm that.** An earlier version of this step said a sibling copy "would keep the fleet-wide verdict `dead` forever", which is inverted: the scheduled scan's Doppler token is scoped to `prd_terraform`, so it never reads the other configs and a stale sibling is **invisible** to it — the verdict reads `clean`. Check the other configs directly with a workplace-scoped token (`doppler secrets get CI_SSH_ACCESS_TOKEN_ID -p soleur -c <cfg>`), and treat any scheduled `clean` here as scoped to `prd_terraform` unless the run also reports `coverage: multi-config`.
 
 **At the halt gate with `unverifiable` / `unavailable`** — nothing was measured. The re-mint is **not** known to have failed and the new credential is already published. Do not re-dispatch; re-run the detector.
 

--- a/plugins/soleur/test/token-drift-workflow-causes.test.sh
+++ b/plugins/soleur/test/token-drift-workflow-causes.test.sh
@@ -47,50 +47,60 @@ done
 echo "=== token-drift workflow consumer ==="
 
 # ---------------------------------------------------------------------------
-# Extract the REAL parser from the workflow. The line is the `python3 -c '...'`
-# inside the `read -r dead unver causes configs < <(...)` process substitution.
+# Run the WHOLE `token_drift` step body, not a grepped line.
+#
+# v1 extracted one `read -r …` line and a three-line awk window, and its prose spoke
+# about "the step". Review mutated the workflow and found 7 survivors living in the
+# lines BETWEEN those two fragments — including deleting the ::warning:: and both
+# email footers (the PR's entire user-visible deliverable) at a fully green suite,
+# and `if [[ "$rc" == "2" || "$dead" == "-1" ]]` -> `if [[ "$rc" == "2" ]]`, which
+# routes a corrupt verdict file to `clean` — the exact thing T4's pass-message claims
+# to prevent.
+#
+# So: pull the step's `run:` body out of the YAML, stub ONLY the detector invocation
+# (the external dependency), point $RUNNER_TEMP at a fixture dir and $GITHUB_OUTPUT at
+# a temp file, and execute it under `bash -eo pipefail` — the shell Actions actually
+# uses. Assertions then read the PUBLISHED outputs, which is what every downstream
+# consumer sees.
 # ---------------------------------------------------------------------------
-PARSER=$(grep -F 'read -r dead unver causes configs < <(python3 -c' "$WF" | head -1)
-if [[ -n "$PARSER" ]]; then
-  pass "the workflow's verdict-parser line was located for extraction"
+STEP_BODY=$(python3 - "$WF" <<'PYX'
+import sys, yaml
+d = yaml.safe_load(open(sys.argv[1]))
+for job in d["jobs"].values():
+    for st in job.get("steps", []):
+        if st.get("id") == "token_drift":
+            sys.stdout.write(st["run"]); raise SystemExit(0)
+raise SystemExit("no step with id: token_drift")
+PYX
+)
+if [[ -n "$STEP_BODY" ]]; then
+  pass "the token_drift step body was extracted from the workflow YAML"
 else
-  fail "could not find the 'read -r dead unver causes configs' parser in $WF — every assertion below would test a copy, not the workflow"
+  fail "could not extract the token_drift step — every assertion below would test nothing. Re-point the extractor rather than deleting this case."
 fi
 
-# Run the WHOLE extracted line — including its `|| echo` fallback — by pointing
-# $RUNNER_TEMP at a fixture dir. An earlier version extracted only the python
-# program and re-added the fallback here; a mutation deleting the workflow's
-# fallback then left this suite green, because the suite was testing its own copy.
-# That is the precise failure rule 1 in this header names, committed by this file.
-run_parser() {
-  local fixture_dir="$1"
-  local out
-  out=$(RUNNER_TEMP="$fixture_dir" bash -c "
-    $PARSER
-    printf '%s %s %s %s' \"\$dead\" \"\$unver\" \"\$causes\" \"\$configs\"
-  " 2>/dev/null)
-  printf '%s' "$out"
-}
-
-# Coverage derivation, extracted from the workflow so the same drift rule applies.
-COVERAGE_SNIPPET=$(grep -F 'coverage=single-config' "$WF" | head -1)
-if [[ -n "$COVERAGE_SNIPPET" ]]; then
-  pass "the coverage derivation is present in the workflow"
+# Stub the detector call, preserving the `|| rc=$?` shape the step depends on.
+DETECTOR_CALL='bash scripts/check-cloudflare-token-drift.sh --json-file "$RUNNER_TEMP/token-drift.json"'
+if [[ "$STEP_BODY" == *"$DETECTOR_CALL"* ]]; then
+  pass "the detector invocation was located for stubbing"
 else
-  fail "the workflow has no coverage derivation — a single-config scan would report 'clean' with nothing qualifying it"
+  fail "the detector invocation changed shape; the stub below would not apply and the step would shell out for real"
 fi
 
-# Extract the coverage derivation from the workflow (the three lines from
-# `coverage=full` through the `unknown` assignment) and evaluate THOSE, for the
-# same reason as run_parser: a local re-implementation cannot observe the
-# workflow's rule changing underneath it.
-COVERAGE_BLOCK=$(awk '/^[[:space:]]*coverage=full$/{f=1} f{print} /coverage=unknown$/{if(f) exit}' "$WF")
-derive_coverage() {
-  local configs="$1"
-  bash -c "configs='$configs'
-    $COVERAGE_BLOCK
-    printf '%s' \"\$coverage\"" 2>/dev/null
+# run_step <fixture-dir> <detector-rc> -> echoes "rc|<published key=value lines, ;-joined>"
+run_step() {
+  local dir="$1" det_rc="${2:-0}"
+  local out; out=$(mktemp)
+  local body="${STEP_BODY//$DETECTOR_CALL/bash -c \"exit $det_rc\"}"
+  local step_rc=0
+  STEP_STDOUT=$(mktemp)
+  RUNNER_TEMP="$dir" GITHUB_OUTPUT="$out" bash -eo pipefail -c "$body" >"$STEP_STDOUT" 2>&1 || step_rc=$?
+  printf '%s|%s' "$step_rc" "$(tr '\n' ';' < "$out")"
+  rm -f "$out"
 }
+
+# Read one published output value from a run_step result.
+out_val() { printf '%s' "$1" | sed 's/^[0-9]*|//' | tr ';' '\n' | sed -n "s/^$2=//p" | head -1; }
 
 # ---------------------------------------------------------------------------
 # T1-T5 — the parser's contract.
@@ -109,9 +119,10 @@ JSON
 # A two-element fixture happened to hash into sorted order, so dropping sorted()
 # from the workflow left the assertion green — the sort was asserted by luck.
 echo "T1: multiple causes are comma-joined and SORTED (stable for a downstream match)"
-got=$(run_parser "$TMP/two")
-if [[ "$got" == "0 3 detector-env,gate-absent,probe-failed 7" ]]; then
-  pass "three causes -> sorted 'detector-env,gate-absent,probe-failed'"
+r=$(run_step "$TMP/two" 1)
+got="$(out_val "$r" causes)"
+if [[ "$got" == "detector-env,gate-absent,probe-failed" ]]; then
+  pass "three causes -> sorted 'detector-env,gate-absent,probe-failed' (published output)"
 else
   fail "expected sorted 'detector-env,gate-absent,probe-failed', got '$got' — the workflow's email interpolates this string verbatim, and an unsorted set order makes it unstable run-to-run"
 fi
@@ -121,9 +132,10 @@ cat > "$TMP/clean/token-drift.json" <<'JSON'
 {"live":9,"dead":0,"unverifiable":0,"probes":9,"configs":13,"stale":[],"unverifiable_keys":[]}
 JSON
 echo "T2: zero unverifiable rows yield the '-' sentinel, never an empty field"
-got=$(run_parser "$TMP/clean")
-if [[ "$got" == "0 0 - 13" ]]; then
-  pass "empty vocabulary renders '-' so \`read\` still fills all four variables"
+r=$(run_step "$TMP/clean" 0)
+got="$(out_val "$r" causes) $(out_val "$r" configs) $(out_val "$r" verdict)"
+if [[ "$got" == "- 13 clean" ]]; then
+  pass "empty vocabulary publishes causes='-', configs=13, verdict=clean"
 else
   fail "expected '0 0 - 13', got '$got' — an empty third field shifts \`configs\` into \`causes\` and the coverage derivation then reads a cause string as a number"
 fi
@@ -134,8 +146,9 @@ cat > "$TMP/nocause/token-drift.json" <<'JSON'
  "stale":[],"unverifiable_keys":[{"key":"K","reason":"no cause key at all"}]}
 JSON
 echo "T3: a row with no 'cause' key degrades to 'unknown', not to a crash"
-got=$(run_parser "$TMP/nocause")
-if [[ "$got" == "0 1 unknown 2" ]]; then
+r=$(run_step "$TMP/nocause" 1)
+got="$(out_val "$r" causes) $(out_val "$r" configs)"
+if [[ "$got" == "unknown 2" ]]; then
   pass "a malformed row is absorbed as 'unknown'"
 else
   fail "expected '0 1 unknown 2', got '$got' — a KeyError here takes the whole step's fallback path and reports the fleet unavailable"
@@ -144,18 +157,20 @@ fi
 mkdir -p "$TMP/corrupt"
 printf '{ this is not json' > "$TMP/corrupt/token-drift.json"
 echo "T4: corrupt JSON takes the fallback and is NEVER read as clean"
-got=$(run_parser "$TMP/corrupt")
-if [[ "$got" == "-1 -1 - -1" ]]; then
-  pass "corrupt verdict file -> '-1 -1 - -1' (the workflow maps dead=-1 to 'unavailable')"
+r=$(run_step "$TMP/corrupt" 1)
+got="$(out_val "$r" verdict)"
+if [[ "$got" == "unavailable" ]]; then
+  pass "corrupt verdict file publishes verdict=unavailable — never 'clean'"
 else
   fail "expected the '-1 -1 - -1' fallback, got '$got' — anything else risks an unreadable scan being read as a healthy fleet"
 fi
 
 mkdir -p "$TMP/missing"
 echo "T5: a MISSING verdict file takes the same fallback"
-got=$(run_parser "$TMP/missing")
-if [[ "$got" == "-1 -1 - -1" ]]; then
-  pass "missing verdict file -> fallback"
+r=$(run_step "$TMP/missing" 1)
+got="$(out_val "$r" verdict)"
+if [[ "$got" == "unavailable" ]]; then
+  pass "missing verdict file publishes verdict=unavailable"
 else
   fail "expected the fallback for a missing file, got '$got'"
 fi
@@ -165,28 +180,52 @@ fi
 # from the verdict question: the detector's own header cites "5 of 7 configs
 # stale", and the scheduled run's Doppler token is scoped to ONE config.
 # ---------------------------------------------------------------------------
+mkdir -p "$TMP/one" "$TMP/two_cfg"
+printf '{"live":1,"dead":0,"unverifiable":0,"probes":1,"configs":1,"stale":[],"unverifiable_keys":[]}' > "$TMP/one/token-drift.json"
+printf '{"live":2,"dead":0,"unverifiable":0,"probes":2,"configs":2,"stale":[],"unverifiable_keys":[]}' > "$TMP/two_cfg/token-drift.json"
 echo "T6: a 1-config scan derives coverage=single-config"
-c=$(derive_coverage 1)
+c=$(out_val "$(run_step "$TMP/one" 0)" coverage)
 if [[ "$c" == "single-config" ]]; then
   pass "configs=1 -> single-config"
 else
   fail "configs=1 must derive single-config, got '$c' — a scan that read one config cannot detect a value stale only in a config it never read, and 'clean' would be over-read as fleet-wide"
 fi
 
-echo "T7: a multi-config scan derives coverage=full"
-c=$(derive_coverage 13)
-if [[ "$c" == "full" ]]; then
-  pass "configs=13 -> full"
+echo "T7: a 2-config scan is enough to leave the single-config state"
+c=$(out_val "$(run_step "$TMP/two_cfg" 0)" coverage)
+if [[ "$c" == "multi-config" ]]; then
+  pass "configs=2 -> multi-config"
 else
-  fail "configs=13 must derive full, got '$c'"
+  fail "configs=2 must derive multi-config, got '$c'"
 fi
 
-echo "T8: an absent configs field derives coverage=unknown, not full"
-c=$(derive_coverage -1)
-if [[ "$c" == "unknown" ]]; then
-  pass "configs=-1 -> unknown (an unmeasured coverage is not a good one)"
+echo "T8: every UNPARSEABLE configs value derives unknown, never the confident state"
+# -1 is the documented fallback sentinel; the rest are the fail-open family found in
+# review. The first version of the derivation defaulted to the confident state and
+# moved off it on two guarded assignments, so `None` (a JSON null reaching
+# d.get("configs", -1)), a negative, a word, or any field-shift out of `read -r`'s
+# greedy last variable ALL asserted fleet-wide coverage. Pinning only -1 could not
+# see that: it was the one input that already worked.
+_t8=1
+for bad in -1 -2 None abc null; do
+  mkdir -p "$TMP/bad"
+  printf '{"live":0,"dead":0,"unverifiable":0,"probes":0,"configs":%s,"stale":[],"unverifiable_keys":[]}' \
+    "$([[ "$bad" =~ ^(-?[0-9]+|null)$ ]] && printf '%s' "$bad" || printf '"%s"' "$bad")" > "$TMP/bad/token-drift.json"
+  c=$(out_val "$(run_step "$TMP/bad" 0)" coverage)
+  [[ "$c" == "unknown" ]] || { _t8=0; echo "    configs='$bad' derived '$c'"; }
+done
+if [[ "$_t8" == "1" ]]; then
+  pass "-1, -2, None, abc, empty and a field-shift all derive unknown"
 else
-  fail "configs=-1 must derive unknown, got '$c' — defaulting an unmeasured coverage to 'full' is the silent direction"
+  fail "an unparseable configs value derived something other than 'unknown' — the confident state must never be the default for a number we could not read, because the email then reassures the operator with that word"
+fi
+
+echo "T8b: a parseable multi-config count derives multi-config, not 'full'"
+c=$(out_val "$(run_step "$TMP/clean" 0)" coverage)
+if [[ "$c" == "multi-config" ]]; then
+  pass "13 -> multi-config (counts configs READ, which is not the number that EXISTS)"
+else
+  fail "expected multi-config, got '$c' — naming this state 'full' claims a completeness the count has no denominator for: the config list is itself scope-filtered by the same token"
 fi
 
 # ---------------------------------------------------------------------------
@@ -197,10 +236,14 @@ mapfile -t CAUSES < <(grep -oE 'UNVERIFIABLE:[a-z-]+' "$DETECTOR" | sed 's/^UNVE
 # The unmapped-base row is pushed with a literal `|no-probe-configured|` field
 # rather than through a PAIR_VERDICT string, so the grep above cannot see it.
 grep -q '|no-probe-configured|' "$DETECTOR" && CAUSES+=("no-probe-configured")
+# `unknown` originates in the WORKFLOW's parser (r.get("cause","unknown")), not in the
+# detector — so a detector-only derivation is blind to it, which is exactly where T3's
+# fixture lives. T3 pins it as contract; the email must therefore explain it.
+grep -qF 'r.get("cause","unknown")' "$WF" && CAUSES+=("unknown")
 mapfile -t CAUSES < <(printf '%s\n' "${CAUSES[@]}" | sort -u)
 
 echo "T9: the cause vocabulary is non-empty (guards a silently-broken extraction)"
-if (( ${#CAUSES[@]} >= 4 )); then
+if (( ${#CAUSES[@]} >= 5 )); then
   pass "derived ${#CAUSES[@]} causes from the detector: ${CAUSES[*]}"
 else
   fail "derived only ${#CAUSES[@]} causes — the extraction regex has drifted from the detector, and every parity assertion below would pass vacuously over an empty set"
@@ -226,7 +269,7 @@ while IFS= read -r tok; do
   for c in "${CAUSES[@]}"; do [[ "$tok" == "$c" ]] && { found=1; break; }; done
   (( found == 0 )) && stale_entries+=("$tok")
 done < <(printf '%s' "$UNVER_BODY" | grep -oE '<code>[a-z-]+</code>' | sed 's/<\/\?code>//g' | sort -u \
-         | grep -E '^(no-probe-configured|gate-absent|gate-indeterminate|control-blocked|host-unreachable|probe-failed|refused-unstamped|stamped-non-refusal|unexpected-status|detector-env)$')
+         | grep -E "^($(IFS='|'; printf '%s' "${CAUSES[*]}")|unknown)$")
 if (( ${#stale_entries[@]} == 0 )); then
   pass "no orphaned cause entries in the email"
 else
@@ -246,13 +289,78 @@ else
   fail "the gate-absent arm does not key on outputs.causes — with a first-match ladder, a dead row anywhere in the same run silently drops the 'nothing is gating this host' finding"
 fi
 
+echo "T13: narrow coverage has a delivery channel that survives a GREEN clean run"
+ARM=$(grep -F "steps.token_drift.outputs.coverage != 'multi-config'" "$WF" | head -1)
+if [[ -n "$ARM" ]]; then
+  pass "an arm fires on coverage alone, independent of verdict/outcome"
+else
+  fail "nothing fires on coverage alone. A single-config scan yields verdict=clean, rc=0, outcome=success — so NO email arm matches and the enforce step is skipped, leaving a ::warning:: on a green cron run as the only artifact. Nobody opens a green cron run (hr-no-dashboard-eyeball-pull-data-yourself)"
+fi
+
+echo "T14: that arm is CREATE-ONLY (the condition holds on every run until fixed)"
+if grep -q 'create-only, not commenting' "$WF" && grep -qF 'gh issue list --label "$LABEL" --state open' "$WF"; then
+  pass "an existing open coverage issue short-circuits instead of re-commenting"
+else
+  fail "the coverage arm must not comment on an existing issue: coverage is single-config on EVERY scheduled run until the token scope is widened, so create-or-comment posts ~730 comments a year and trains the operator to filter the label"
+fi
+
+echo "T15: a single-config scan EMITS the ::warning:: annotation"
+run_step "$TMP/one" 0 >/dev/null
+if grep -q '::warning::.*Doppler config' "$STEP_STDOUT"; then
+  pass "the annotation is emitted, not merely derivable"
+else
+  fail "no ::warning:: on a single-config scan — deriving coverage correctly and showing it to nobody is the whole defect this PR exists to fix; the derivation was previously pinned while its only in-run surface was not"
+fi
+
+echo "T16: a multi-config scan does NOT emit the warning (no hedge when there is nothing to hedge)"
+run_step "$TMP/clean" 0 >/dev/null
+if ! grep -q '::warning::.*Doppler config' "$STEP_STDOUT"; then
+  pass "a full-fan-out scan is quiet"
+else
+  fail "the warning fired on a multi-config scan — an unconditional hedge is the defect the enforce step's own comment records removing ('a hedge that fires when there is nothing to hedge makes a true alarm look uncertain')"
+fi
+
+echo "T17: a 0-config scan is not the confident state"
+mkdir -p "$TMP/zero"
+printf '{"live":0,"dead":0,"unverifiable":0,"probes":0,"configs":0,"stale":[],"unverifiable_keys":[]}' > "$TMP/zero/token-drift.json"
+c=$(out_val "$(run_step "$TMP/zero" 0)" coverage)
+if [[ "$c" == "single-config" ]]; then
+  pass "configs=0 -> single-config (nothing read is not fleet-wide)"
+else
+  fail "configs=0 derived '$c' — a threshold of '== 1' rather than '< 2' lets a scan that read NOTHING report the confident state, which is the silent direction"
+fi
+
+echo "T18: unverifiable rows publish verdict=unverifiable (the ladder branch actually fires)"
+v=$(out_val "$(run_step "$TMP/two" 1)" verdict)
+if [[ "$v" == "unverifiable" ]]; then
+  pass "unver>0 with dead=0 publishes verdict=unverifiable"
+else
+  fail "expected verdict=unverifiable, got '$v' — widening the ladder's unver threshold silently disables the UNVERIFIABLE email arm entirely"
+fi
+
+echo "T19: both verdict-bearing email bodies carry the coverage caveat"
+_t19=1
+# Anchor on text that lives in the BODY. 'No conclusion could be drawn' is the
+# UNVERIFIABLE step's SUBJECT, so anchoring there matched a line with no body: and
+# reported a caveat missing from a body that has one — the assertion was wrong, not
+# the workflow. Verified by auditing every body: line before changing anything.
+for phrase in 'no longer accepted by Cloudflare' 'No token was found stale'; do
+  line=$(grep -F "$phrase" "$WF" | grep -F 'body:' | head -1)
+  printf '%s' "$line" | grep -q 'Scan coverage:' || { _t19=0; echo "    missing caveat in the body containing: $phrase"; }
+done
+if [[ "$_t19" == "1" ]]; then
+  pass "the DEAD and UNVERIFIABLE bodies both render coverage"
+else
+  fail "a verdict-bearing email lost its coverage caveat — the reader is told a finding without being told how much of the fleet was actually looked at"
+fi
+
 echo ""
 echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
 # ANTI-VACUITY FLOOR. Deleting every assertion call yields "0/0 passed" and exit 0,
 # which test-all.sh (reading only the exit code) cannot distinguish from success.
 # A FLOOR, not equality: adding a case must not require editing this line.
-if [[ "$((PASS + FAIL))" -lt 13 ]]; then
-  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 13." >&2
+if [[ "$((PASS + FAIL))" -lt 20 ]]; then
+  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 20." >&2
   exit 1
 fi
 if [[ "$FAIL" -gt 0 ]]; then exit 1; fi

--- a/plugins/soleur/test/token-drift-workflow-causes.test.sh
+++ b/plugins/soleur/test/token-drift-workflow-causes.test.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# Tests the CONSUMER half of the Cloudflare token-drift detector: the
+# `scheduled-terraform-drift.yml` step that parses the detector's --json-file and
+# derives `verdict` / `causes` / `configs` / `coverage`, plus the email bodies that
+# render them.
+#
+# WHY THIS EXISTS. PR #7134 moved UNVERIFIABLE from one bucket with one static
+# remedy to a closed CAUSE vocabulary the workflow branches on, and shipped with the
+# emitting side pinned and the consuming side pinned by nothing — stated as a known
+# gap in that PR's body rather than papered over. The gap matters because the
+# failure it enables is silent: a cause the detector emits but the email never
+# renders sends the operator a remedy for a different problem, which is the exact
+# defect #7134 existed to remove.
+#
+# TWO RULES THIS SUITE FOLLOWS, both learned the hard way in #7134:
+#
+#   1. The parser under test is EXTRACTED FROM THE WORKFLOW, never re-implemented.
+#      A hand-copied `python3 -c` would pin the copy, and the workflow could drift
+#      away from it while this suite stayed green.
+#   2. The expected cause vocabulary is DERIVED FROM THE DETECTOR SOURCE, never
+#      restated here. A restated list is a second unsynchronized pin: the detector
+#      grows a cause, the list does not, and the parity assertion passes over a
+#      cause no email can explain. Deriving it means adding a cause to the detector
+#      REDS this suite until the email learns to render it.
+#
+# Run: bash plugins/soleur/test/token-drift-workflow-causes.test.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WF="$REPO_ROOT/.github/workflows/scheduled-terraform-drift.yml"
+DETECTOR="$REPO_ROOT/scripts/check-cloudflare-token-drift.sh"
+
+export TMPDIR="${TMPDIR:-/var/tmp}"
+PASS=0
+FAIL=0
+pass() { echo "  pass: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP=$(mktemp -d) || { echo "FATAL: sandbox"; exit 2; }
+trap 'rm -rf "$TMP"' EXIT
+
+for f in "$WF" "$DETECTOR"; do
+  [[ -f "$f" ]] || { echo "FATAL: missing $f"; exit 2; }
+done
+
+echo "=== token-drift workflow consumer ==="
+
+# ---------------------------------------------------------------------------
+# Extract the REAL parser from the workflow. The line is the `python3 -c '...'`
+# inside the `read -r dead unver causes configs < <(...)` process substitution.
+# ---------------------------------------------------------------------------
+PARSER=$(grep -F 'read -r dead unver causes configs < <(python3 -c' "$WF" | head -1)
+if [[ -n "$PARSER" ]]; then
+  pass "the workflow's verdict-parser line was located for extraction"
+else
+  fail "could not find the 'read -r dead unver causes configs' parser in $WF — every assertion below would test a copy, not the workflow"
+fi
+
+# Run the WHOLE extracted line — including its `|| echo` fallback — by pointing
+# $RUNNER_TEMP at a fixture dir. An earlier version extracted only the python
+# program and re-added the fallback here; a mutation deleting the workflow's
+# fallback then left this suite green, because the suite was testing its own copy.
+# That is the precise failure rule 1 in this header names, committed by this file.
+run_parser() {
+  local fixture_dir="$1"
+  local out
+  out=$(RUNNER_TEMP="$fixture_dir" bash -c "
+    $PARSER
+    printf '%s %s %s %s' \"\$dead\" \"\$unver\" \"\$causes\" \"\$configs\"
+  " 2>/dev/null)
+  printf '%s' "$out"
+}
+
+# Coverage derivation, extracted from the workflow so the same drift rule applies.
+COVERAGE_SNIPPET=$(grep -F 'coverage=single-config' "$WF" | head -1)
+if [[ -n "$COVERAGE_SNIPPET" ]]; then
+  pass "the coverage derivation is present in the workflow"
+else
+  fail "the workflow has no coverage derivation — a single-config scan would report 'clean' with nothing qualifying it"
+fi
+
+# Extract the coverage derivation from the workflow (the three lines from
+# `coverage=full` through the `unknown` assignment) and evaluate THOSE, for the
+# same reason as run_parser: a local re-implementation cannot observe the
+# workflow's rule changing underneath it.
+COVERAGE_BLOCK=$(awk '/^[[:space:]]*coverage=full$/{f=1} f{print} /coverage=unknown$/{if(f) exit}' "$WF")
+derive_coverage() {
+  local configs="$1"
+  bash -c "configs='$configs'
+    $COVERAGE_BLOCK
+    printf '%s' \"\$coverage\"" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# T1-T5 — the parser's contract.
+# ---------------------------------------------------------------------------
+mkdir -p "$TMP/two"
+cat > "$TMP/two/token-drift.json" <<'JSON'
+{"live":3,"dead":0,"unverifiable":3,"probes":4,"configs":7,
+ "stale":[],
+ "unverifiable_keys":[
+   {"key":"A_ID/_SECRET","cause":"probe-failed","reason":"x"},
+   {"key":"B_ID/_SECRET","cause":"gate-absent","reason":"y"},
+   {"key":"C_ID/_SECRET","cause":"detector-env","reason":"z"}]}
+JSON
+# These three are chosen so SET iteration order differs from SORTED order
+# (set -> "gate-absent,probe-failed,detector-env"; sorted -> "detector-env,...").
+# A two-element fixture happened to hash into sorted order, so dropping sorted()
+# from the workflow left the assertion green — the sort was asserted by luck.
+echo "T1: multiple causes are comma-joined and SORTED (stable for a downstream match)"
+got=$(run_parser "$TMP/two")
+if [[ "$got" == "0 3 detector-env,gate-absent,probe-failed 7" ]]; then
+  pass "three causes -> sorted 'detector-env,gate-absent,probe-failed'"
+else
+  fail "expected sorted 'detector-env,gate-absent,probe-failed', got '$got' — the workflow's email interpolates this string verbatim, and an unsorted set order makes it unstable run-to-run"
+fi
+
+mkdir -p "$TMP/clean"
+cat > "$TMP/clean/token-drift.json" <<'JSON'
+{"live":9,"dead":0,"unverifiable":0,"probes":9,"configs":13,"stale":[],"unverifiable_keys":[]}
+JSON
+echo "T2: zero unverifiable rows yield the '-' sentinel, never an empty field"
+got=$(run_parser "$TMP/clean")
+if [[ "$got" == "0 0 - 13" ]]; then
+  pass "empty vocabulary renders '-' so \`read\` still fills all four variables"
+else
+  fail "expected '0 0 - 13', got '$got' — an empty third field shifts \`configs\` into \`causes\` and the coverage derivation then reads a cause string as a number"
+fi
+
+mkdir -p "$TMP/nocause"
+cat > "$TMP/nocause/token-drift.json" <<'JSON'
+{"live":0,"dead":0,"unverifiable":1,"probes":1,"configs":2,
+ "stale":[],"unverifiable_keys":[{"key":"K","reason":"no cause key at all"}]}
+JSON
+echo "T3: a row with no 'cause' key degrades to 'unknown', not to a crash"
+got=$(run_parser "$TMP/nocause")
+if [[ "$got" == "0 1 unknown 2" ]]; then
+  pass "a malformed row is absorbed as 'unknown'"
+else
+  fail "expected '0 1 unknown 2', got '$got' — a KeyError here takes the whole step's fallback path and reports the fleet unavailable"
+fi
+
+mkdir -p "$TMP/corrupt"
+printf '{ this is not json' > "$TMP/corrupt/token-drift.json"
+echo "T4: corrupt JSON takes the fallback and is NEVER read as clean"
+got=$(run_parser "$TMP/corrupt")
+if [[ "$got" == "-1 -1 - -1" ]]; then
+  pass "corrupt verdict file -> '-1 -1 - -1' (the workflow maps dead=-1 to 'unavailable')"
+else
+  fail "expected the '-1 -1 - -1' fallback, got '$got' — anything else risks an unreadable scan being read as a healthy fleet"
+fi
+
+mkdir -p "$TMP/missing"
+echo "T5: a MISSING verdict file takes the same fallback"
+got=$(run_parser "$TMP/missing")
+if [[ "$got" == "-1 -1 - -1" ]]; then
+  pass "missing verdict file -> fallback"
+else
+  fail "expected the fallback for a missing file, got '$got'"
+fi
+
+# ---------------------------------------------------------------------------
+# T6-T8 — coverage derivation. This is the fan-out question, which is separate
+# from the verdict question: the detector's own header cites "5 of 7 configs
+# stale", and the scheduled run's Doppler token is scoped to ONE config.
+# ---------------------------------------------------------------------------
+echo "T6: a 1-config scan derives coverage=single-config"
+c=$(derive_coverage 1)
+if [[ "$c" == "single-config" ]]; then
+  pass "configs=1 -> single-config"
+else
+  fail "configs=1 must derive single-config, got '$c' — a scan that read one config cannot detect a value stale only in a config it never read, and 'clean' would be over-read as fleet-wide"
+fi
+
+echo "T7: a multi-config scan derives coverage=full"
+c=$(derive_coverage 13)
+if [[ "$c" == "full" ]]; then
+  pass "configs=13 -> full"
+else
+  fail "configs=13 must derive full, got '$c'"
+fi
+
+echo "T8: an absent configs field derives coverage=unknown, not full"
+c=$(derive_coverage -1)
+if [[ "$c" == "unknown" ]]; then
+  pass "configs=-1 -> unknown (an unmeasured coverage is not a good one)"
+else
+  fail "configs=-1 must derive unknown, got '$c' — defaulting an unmeasured coverage to 'full' is the silent direction"
+fi
+
+# ---------------------------------------------------------------------------
+# T9-T11 — VOCABULARY PARITY. The cause set is derived from the detector source,
+# so a new cause reds this suite until the workflow email learns to render it.
+# ---------------------------------------------------------------------------
+mapfile -t CAUSES < <(grep -oE 'UNVERIFIABLE:[a-z-]+' "$DETECTOR" | sed 's/^UNVERIFIABLE://' | sort -u)
+# The unmapped-base row is pushed with a literal `|no-probe-configured|` field
+# rather than through a PAIR_VERDICT string, so the grep above cannot see it.
+grep -q '|no-probe-configured|' "$DETECTOR" && CAUSES+=("no-probe-configured")
+mapfile -t CAUSES < <(printf '%s\n' "${CAUSES[@]}" | sort -u)
+
+echo "T9: the cause vocabulary is non-empty (guards a silently-broken extraction)"
+if (( ${#CAUSES[@]} >= 4 )); then
+  pass "derived ${#CAUSES[@]} causes from the detector: ${CAUSES[*]}"
+else
+  fail "derived only ${#CAUSES[@]} causes — the extraction regex has drifted from the detector, and every parity assertion below would pass vacuously over an empty set"
+fi
+
+# The UNVERIFIABLE email body is the operator's per-cause remedy surface.
+UNVER_BODY=$(grep -F 'No conclusion could be drawn about at least one token' -A 2 "$WF" | head -4)
+echo "T10: every cause the detector can emit is explained in the UNVERIFIABLE email"
+missing=()
+for c in "${CAUSES[@]}"; do
+  printf '%s' "$UNVER_BODY" | grep -qF "<code>${c}</code>" || missing+=("$c")
+done
+if (( ${#missing[@]} == 0 )); then
+  pass "all ${#CAUSES[@]} causes have a <li><code>cause</code> entry"
+else
+  fail "causes with no entry in the operator email: ${missing[*]} — the detector can emit these and the email cannot explain them, so the operator receives a remedy for a different problem (the exact defect #7134 removed one layer down)"
+fi
+
+echo "T11: the email does not explain a cause the detector cannot emit"
+stale_entries=()
+while IFS= read -r tok; do
+  found=0
+  for c in "${CAUSES[@]}"; do [[ "$tok" == "$c" ]] && { found=1; break; }; done
+  (( found == 0 )) && stale_entries+=("$tok")
+done < <(printf '%s' "$UNVER_BODY" | grep -oE '<code>[a-z-]+</code>' | sed 's/<\/\?code>//g' | sort -u \
+         | grep -E '^(no-probe-configured|gate-absent|gate-indeterminate|control-blocked|host-unreachable|probe-failed|refused-unstamped|stamped-non-refusal|unexpected-status|detector-env)$')
+if (( ${#stale_entries[@]} == 0 )); then
+  pass "no orphaned cause entries in the email"
+else
+  fail "email explains causes the detector no longer emits: ${stale_entries[*]} — dead remedies train the operator to skim"
+fi
+
+# ---------------------------------------------------------------------------
+# T12 — the gate-absent arm must fire on CAUSES, not on VERDICT. The ladder is
+# first-match (dead > unverifiable > clean), so a security finding gated on the
+# verdict is dropped whenever any dead row co-occurs.
+# ---------------------------------------------------------------------------
+echo "T12: the gate-absent email arm keys on outputs.causes, independent of the verdict ladder"
+GATE_ARM=$(grep -F "contains(steps.token_drift.outputs.causes, 'gate-absent')" "$WF" | head -1)
+if [[ -n "$GATE_ARM" ]]; then
+  pass "gate-absent fires on causes, so a co-occurring dead row cannot pre-empt it"
+else
+  fail "the gate-absent arm does not key on outputs.causes — with a first-match ladder, a dead row anywhere in the same run silently drops the 'nothing is gating this host' finding"
+fi
+
+echo ""
+echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
+# ANTI-VACUITY FLOOR. Deleting every assertion call yields "0/0 passed" and exit 0,
+# which test-all.sh (reading only the exit code) cannot distinguish from success.
+# A FLOOR, not equality: adding a case must not require editing this line.
+if [[ "$((PASS + FAIL))" -lt 13 ]]; then
+  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 13." >&2
+  exit 1
+fi
+if [[ "$FAIL" -gt 0 ]]; then exit 1; fi

--- a/plugins/soleur/test/token-drift-workflow-causes.test.sh
+++ b/plugins/soleur/test/token-drift-workflow-causes.test.sh
@@ -93,7 +93,9 @@ run_step() {
   local out; out=$(mktemp)
   local body="${STEP_BODY//$DETECTOR_CALL/bash -c \"exit $det_rc\"}"
   local step_rc=0
-  STEP_STDOUT=$(mktemp)
+  # Under $TMP so the EXIT trap reclaims it. `mktemp` put one file per call in TMPDIR
+  # (exported to /var/tmp above) and never removed it — ~20 leaked strays per run.
+  STEP_STDOUT="$TMP/step-stdout.$$"
   RUNNER_TEMP="$dir" GITHUB_OUTPUT="$out" bash -eo pipefail -c "$body" >"$STEP_STDOUT" 2>&1 || step_rc=$?
   printf '%s|%s' "$step_rc" "$(tr '\n' ';' < "$out")"
   rm -f "$out"
@@ -101,6 +103,37 @@ run_step() {
 
 # Read one published output value from a run_step result.
 out_val() { printf '%s' "$1" | sed 's/^[0-9]*|//' | tr ';' '\n' | sed -n "s/^$2=//p" | head -1; }
+
+# step_field <step-name-prefix> <if|run> -> that step's parsed field, or exit 1.
+#
+# WHY THIS EXISTS. T12/T13/T14 originally grepped the WHOLE workflow for a literal, which
+# pins spelling, not behavior — and this PR simultaneously added a comment block quoting
+# those same literals, so a comment satisfies the assertion. All three were measured
+# green under mutations that reproduced the exact defect each one names:
+#   T13  `always()` -> `failure()` on the coverage arm   (step skipped on every clean run)
+#   T13  `if:` replaced, literal preserved in a comment  (cq-assert-anchor-not-bare-token)
+#   T14  `exit 0` deleted under the short-circuit        (~730 duplicate issues a year)
+#   T12  gate-absent re-gated onto the verdict ladder    (security finding pre-empted)
+# Extracting the step by NAME and asserting inside ITS OWN parsed field is the shape the
+# sibling detector suite's W10 adopted for the same reason. A comment cannot survive
+# yaml.safe_load, and a missing step is a hard failure rather than a silent zero-match.
+step_field() {
+  python3 - "$WF" "$1" "$2" <<'PYF'
+import sys, yaml
+wf, want, field = sys.argv[1], sys.argv[2], sys.argv[3]
+for job in yaml.safe_load(open(wf))["jobs"].values():
+    for st in job.get("steps", []) or []:
+        if str(st.get("name", "")).startswith(want):
+            v = st.get(field)
+            if v is None:
+                raise SystemExit(f"step '{want}' has no '{field}:'")
+            sys.stdout.write(str(v))
+            raise SystemExit(0)
+raise SystemExit(f"no step named '{want}'")
+PYF
+}
+
+COVERAGE_STEP="Open an action-required issue (token drift — narrow scan coverage)"
 
 # ---------------------------------------------------------------------------
 # T1-T5 — the parser's contract.
@@ -232,18 +265,50 @@ fi
 # T9-T11 — VOCABULARY PARITY. The cause set is derived from the detector source,
 # so a new cause reds this suite until the workflow email learns to render it.
 # ---------------------------------------------------------------------------
-mapfile -t CAUSES < <(grep -oE 'UNVERIFIABLE:[a-z-]+' "$DETECTOR" | sed 's/^UNVERIFIABLE://' | sort -u)
-# The unmapped-base row is pushed with a literal `|no-probe-configured|` field
-# rather than through a PAIR_VERDICT string, so the grep above cannot see it.
-grep -q '|no-probe-configured|' "$DETECTOR" && CAUSES+=("no-probe-configured")
+# DERIVE FROM THE EMITTED LITERAL, not from the internal state string. `UNVERIFIABLE:
+# <cause>` is the PAIR_VERDICT map VALUE; what actually reaches the JSON the workflow
+# parses is the second field of an `UNVERIFIABLE_ROWS+=(...)` push, produced by a `case`
+# that translates the first into the second. Deriving from PAIR_VERDICT pinned the wrong
+# side: renaming ONE row literal (`|probe-failed|` -> `|probe-timeout|`) while leaving
+# its PAIR_VERDICT string intact left this suite fully green while the detector emitted
+# a cause the email had no <li> for — the exact defect this file exists to catch.
+# Verified by mutation.
+mapfile -t CAUSES < <(grep -oE 'UNVERIFIABLE_ROWS\+=\("\$\{base\}_ID/_SECRET\|[a-z-]+\|' "$DETECTOR" \
+                      | grep -oE '\|[a-z-]+\|' | tr -d '|' | sort -u)
+# The two vocabularies must agree. They are separate literals in separate lines of the
+# detector, so either can drift alone: a PAIR_VERDICT state with no `case` arm emits
+# nothing (dead code), and an emitted cause with no PAIR_VERDICT state means the `case`
+# invented one. Cardinality is the cheap cross-check — a member either extraction cannot
+# see is otherwise silently exempt from every parity assertion below, and that exemption
+# is invisible on a green run.
+mapfile -t _PAIR_CAUSES < <(grep -oE 'UNVERIFIABLE:[a-z-]+' "$DETECTOR" | sed 's/^UNVERIFIABLE://' | sort -u)
+# The unmapped-base row is pushed with a literal `|no-probe-configured|` field and has no
+# PAIR_VERDICT state at all, so it is expected in CAUSES and not in _PAIR_CAUSES.
+echo "T9a: the emitted cause vocabulary and the internal PAIR_VERDICT vocabulary agree"
+_only_pair=()
+for c in "${_PAIR_CAUSES[@]}"; do
+  printf '%s\n' "${CAUSES[@]}" | grep -qx "$c" || _only_pair+=("$c")
+done
+if (( ${#_only_pair[@]} == 0 )); then
+  pass "every PAIR_VERDICT state has a matching emitted row literal (${#_PAIR_CAUSES[@]} states, ${#CAUSES[@]} emitted)"
+else
+  fail "PAIR_VERDICT states with no matching emitted row literal: ${_only_pair[*]} — the case translating state to row has drifted, so the detector either emits a cause name nothing derived or drops one entirely"
+fi
 # `unknown` originates in the WORKFLOW's parser (r.get("cause","unknown")), not in the
 # detector — so a detector-only derivation is blind to it, which is exactly where T3's
 # fixture lives. T3 pins it as contract; the email must therefore explain it.
 grep -qF 'r.get("cause","unknown")' "$WF" && CAUSES+=("unknown")
 mapfile -t CAUSES < <(printf '%s\n' "${CAUSES[@]}" | sort -u)
 
-echo "T9: the cause vocabulary is non-empty (guards a silently-broken extraction)"
-if (( ${#CAUSES[@]} >= 5 )); then
+# FLOOR AT THE CURRENT COUNT, not far below it. This was `>= 5` against 11 derived —
+# six free slots, and a floor that slack cannot distinguish "the extraction broke" from
+# "it worked". Measured: refactoring four detector cause literals behind a variable
+# (invisible to the extraction) AND deleting their four email remedies left this suite
+# 22/22 green, with T10 then checking 7 of 11 causes and the parity claim silently
+# covering less. A DROP below this number means the extraction drifted; raise it when
+# the detector legitimately grows a cause.
+echo "T9: the cause vocabulary is complete (guards a silently-broken extraction)"
+if (( ${#CAUSES[@]} >= 11 )); then
   pass "derived ${#CAUSES[@]} causes from the detector: ${CAUSES[*]}"
 else
   fail "derived only ${#CAUSES[@]} causes — the extraction regex has drifted from the detector, and every parity assertion below would pass vacuously over an empty set"
@@ -268,8 +333,19 @@ while IFS= read -r tok; do
   found=0
   for c in "${CAUSES[@]}"; do [[ "$tok" == "$c" ]] && { found=1; break; }; done
   (( found == 0 )) && stale_entries+=("$tok")
-done < <(printf '%s' "$UNVER_BODY" | grep -oE '<code>[a-z-]+</code>' | sed 's/<\/\?code>//g' | sort -u \
-         | grep -E "^($(IFS='|'; printf '%s' "${CAUSES[*]}")|unknown)$")
+# NO membership filter on the input. The first version piped through
+# `grep -E "^(${CAUSES[*]}|unknown)$"` — which keeps ONLY tokens already in CAUSES — and
+# then asked whether each survivor was in CAUSES. `found` was always 1 and this assertion
+# could not fail in either direction. Measured: injecting <code>bogus-orphan</code> into
+# the email body left the suite 22/22 green.
+#
+# Anchored on `<li><code>` rather than a bare `<code>`, because the same body legitimately
+# uses <code> for non-cause spans (access_hostname_for(), the script path, multi-config)
+# and those are not orphaned remedies. Cause entries are always at list-item position,
+# optionally as a `<code>a</code> / <code>b</code>` pair sharing one remedy.
+done < <(printf '%s' "$UNVER_BODY" \
+         | grep -oE '<li><code>[a-z-]+</code>( / <code>[a-z-]+</code>)?' \
+         | grep -oE '<code>[a-z-]+</code>' | sed 's/<\/\?code>//g' | sort -u)
 if (( ${#stale_entries[@]} == 0 )); then
   pass "no orphaned cause entries in the email"
 else
@@ -282,26 +358,77 @@ fi
 # verdict is dropped whenever any dead row co-occurs.
 # ---------------------------------------------------------------------------
 echo "T12: the gate-absent email arm keys on outputs.causes, independent of the verdict ladder"
-GATE_ARM=$(grep -F "contains(steps.token_drift.outputs.causes, 'gate-absent')" "$WF" | head -1)
-if [[ -n "$GATE_ARM" ]]; then
+GATE_IF=$(step_field "Email notification (token drift — ACCESS GATE MISSING)" if) || GATE_IF=""
+if grep -qF "contains(steps.token_drift.outputs.causes, 'gate-absent')" <<<"$GATE_IF" \
+   && ! grep -qE "outputs\.verdict *==" <<<"$GATE_IF"; then
   pass "gate-absent fires on causes, so a co-occurring dead row cannot pre-empt it"
 else
-  fail "the gate-absent arm does not key on outputs.causes — with a first-match ladder, a dead row anywhere in the same run silently drops the 'nothing is gating this host' finding"
+  fail "the gate-absent arm does not key on outputs.causes (its if: is '${GATE_IF}') — with a first-match ladder, a dead row anywhere in the same run silently drops the 'nothing is gating this host' finding"
 fi
 
 echo "T13: narrow coverage has a delivery channel that survives a GREEN clean run"
-ARM=$(grep -F "steps.token_drift.outputs.coverage != 'multi-config'" "$WF" | head -1)
-if [[ -n "$ARM" ]]; then
-  pass "an arm fires on coverage alone, independent of verdict/outcome"
+COV_IF=$(step_field "$COVERAGE_STEP" if) || COV_IF=""
+# Three properties, all load-bearing, asserted on the step's OWN parsed `if:`:
+#   always()          — a clean single-config run exits 0, so failure()/success()-implicit
+#                       would skip the step on exactly the runs it exists for
+#   single-config     — the state this channel's title, body and remedy describe
+#   NO bare `!=`      — `token_drift` is matrix-gated, so on the other leg every output is
+#                       '' and `'' != 'multi-config'` is TRUE; the step then fires from a
+#                       leg that never scanned, with a blank body, and create-only locks
+#                       it in. Positive polarity is what makes it skip-safe.
+if grep -qF 'always()' <<<"$COV_IF" \
+   && grep -qF "steps.token_drift.outputs.coverage == 'single-config'" <<<"$COV_IF" \
+   && ! grep -qF 'coverage !=' <<<"$COV_IF"; then
+  pass "an arm fires on coverage alone, positively, independent of verdict/outcome"
 else
-  fail "nothing fires on coverage alone. A single-config scan yields verdict=clean, rc=0, outcome=success — so NO email arm matches and the enforce step is skipped, leaving a ::warning:: on a green cron run as the only artifact. Nobody opens a green cron run (hr-no-dashboard-eyeball-pull-data-yourself)"
+  fail "the coverage arm's if: is '${COV_IF}' — it must be always() AND test coverage POSITIVELY. A single-config scan yields verdict=clean, rc=0, outcome=success, so no email arm matches and enforce is skipped; and a negative test also matches the empty output published by the matrix leg where the detector never ran"
+fi
+
+echo "T13b: the coverage arm also covers 'unknown', which no email arm reaches"
+if grep -qF "steps.token_drift.outputs.coverage == 'unknown'" <<<"$COV_IF"; then
+  pass "an unmeasurable coverage still reaches the issue channel"
+else
+  fail "coverage=unknown has no channel. It is reachable with a CLEAN verdict (well-formed JSON that simply lacks 'configs'), and no email arm fires on clean — the verdict=='unavailable' email only covers the crash path"
 fi
 
 echo "T14: that arm is CREATE-ONLY (the condition holds on every run until fixed)"
-if grep -q 'create-only, not commenting' "$WF" && grep -qF 'gh issue list --label "$LABEL" --state open' "$WF"; then
+COV_RUN=$(step_field "$COVERAGE_STEP" run) || COV_RUN=""
+# Assert the CONTROL FLOW, not the log sentence. `create-only, not commenting` is an echo
+# string: keeping it and deleting the `exit 0` beneath it left the suite green while the
+# step filed a fresh duplicate every run. And the dedup query literal is no longer unique
+# to this step — the DEAD filer contains it too (count went 1 -> 2 on this branch), so a
+# file-wide grep for it says nothing about this step at all.
+if grep -qF 'gh issue list --label "$LABEL" --state open' <<<"$COV_RUN" \
+   && grep -qE '^ *exit 0$' <<<"$COV_RUN" \
+   && ! grep -qF 'gh issue comment' <<<"$COV_RUN"; then
   pass "an existing open coverage issue short-circuits instead of re-commenting"
 else
-  fail "the coverage arm must not comment on an existing issue: coverage is single-config on EVERY scheduled run until the token scope is widened, so create-or-comment posts ~730 comments a year and trains the operator to filter the label"
+  fail "the coverage arm must query open issues, exit 0 on a hit, and never comment: coverage is single-config on EVERY scheduled run until the token scope is widened, so create-or-comment posts ~730 comments a year and trains the operator to filter the label"
+fi
+
+echo "T14b: a failed create is reported, not swallowed"
+if grep -qF '::error::token_drift_coverage_escalation_failed' <<<"$COV_RUN" \
+   && ! grep -qE 'gh issue create.*\| *tail' <<<"$COV_RUN"; then
+  pass "gh issue create's status is branched on and a failure annotates"
+else
+  fail "a failed 'gh issue create' leaves a GREEN step on a GREEN cron run with no issue and no annotation. Coverage has no email arm, so that is total loss of the only channel this step exists to be (hr-no-dashboard-eyeball-pull-data-yourself)"
+fi
+
+echo "T14c: a failed dedup QUERY fails closed, rather than filing a duplicate"
+if grep -qF 'token_drift_coverage_list_failed' <<<"$COV_RUN"; then
+  pass "an errored 'gh issue list' declines to create instead of reading empty as 'none open'"
+else
+  fail "the dedup query's failure is indistinguishable from 'no issue open', and create-only reads empty as 'file one' — so every transient API fault adds a permanent duplicate"
+fi
+
+echo "T14d: the issue is closed automatically when coverage recovers"
+CLOSE_IF=$(step_field "Close the coverage issue once the fan-out is restored" if) || CLOSE_IF=""
+CLOSE_RUN=$(step_field "Close the coverage issue once the fan-out is restored" run) || CLOSE_RUN=""
+if grep -qF "steps.token_drift.outputs.coverage == 'multi-config'" <<<"$CLOSE_IF" \
+   && grep -qF 'gh issue close' <<<"$CLOSE_RUN"; then
+  pass "coverage recovery closes the standing issue without an operator step"
+else
+  fail "nothing closes the coverage issue. Its stated closing condition is 'a scheduled run reports coverage: multi-config' — a fact observable only by opening a GREEN cron run's step log, which is the same problem the file arm exists to solve"
 fi
 
 echo "T15: a single-config scan EMITS the ::warning:: annotation"
@@ -320,14 +447,33 @@ else
   fail "the warning fired on a multi-config scan — an unconditional hedge is the defect the enforce step's own comment records removing ('a hedge that fires when there is nothing to hedge makes a true alarm look uncertain')"
 fi
 
-echo "T17: a 0-config scan is not the confident state"
+echo "T16b: an UNMEASURABLE coverage emits its own, differently-worded annotation"
+# The `unknown` branch of the ::warning:: was unpinned while its sibling was pinned —
+# measured: deleting the branch entirely, and widening the single-config branch's test to
+# `!= "multi-config"` (which makes an unreadable verdict file announce "scanned -1 Doppler
+# config(s)"), both left the suite green. That is T15's own defect one branch over.
+run_step "$TMP/corrupt" 0 >/dev/null
+if grep -q '::warning::.*could not measure its own coverage' "$STEP_STDOUT" \
+   && ! grep -q '::warning::.*scanned -1 Doppler' "$STEP_STDOUT"; then
+  pass "an unreadable verdict file says so, rather than reporting a narrow scan"
+else
+  fail "coverage=unknown did not emit its own annotation — a detector that could not run is being described to the operator as a narrow scan, whose remedy (widen the Doppler token) is unperformable on that path, so the state never clears"
+fi
+
+echo "T17: the coverage threshold is '< 2', not '== 1'"
 mkdir -p "$TMP/zero"
 printf '{"live":0,"dead":0,"unverifiable":0,"probes":0,"configs":0,"stale":[],"unverifiable_keys":[]}' > "$TMP/zero/token-drift.json"
 c=$(out_val "$(run_step "$TMP/zero" 0)" coverage)
+# NOTE ON REACHABILITY: configs=0 cannot arrive from today's detector — it exits 2 at
+# `if [[ ${#CONFIGS[@]} -eq 0 ]]` roughly 460 lines before emit_json, so a real 0-config
+# run publishes no verdict file at all and lands on the `-1` fallback, i.e. `unknown`
+# (T5 covers that path). This case pins the THRESHOLD SHAPE as defence-in-depth against a
+# future path that reaches emit_json with an empty CONFIGS; it is not evidence about a
+# reachable production state, and the pass message said otherwise.
 if [[ "$c" == "single-config" ]]; then
-  pass "configs=0 -> single-config (nothing read is not fleet-wide)"
+  pass "configs=0 -> single-config (pins '< 2'; not a reachable state today, see note)"
 else
-  fail "configs=0 derived '$c' — a threshold of '== 1' rather than '< 2' lets a scan that read NOTHING report the confident state, which is the silent direction"
+  fail "configs=0 derived '$c' — a threshold of '== 1' rather than '< 2' would let a future path that reaches emit_json with no configs report the confident state, which is the silent direction"
 fi
 
 echo "T18: unverifiable rows publish verdict=unverifiable (the ladder branch actually fires)"
@@ -348,6 +494,17 @@ for phrase in 'no longer accepted by Cloudflare' 'No token was found stale'; do
   line=$(grep -F "$phrase" "$WF" | grep -F 'body:' | head -1)
   printf '%s' "$line" | grep -q 'Scan coverage:' || { _t19=0; echo "    missing caveat in the body containing: $phrase"; }
 done
+# The caveat is the same sentence, in the same medium, for the same reader, in two email
+# bodies — and nothing pinned the copies to each other. A presence-only check stays green
+# while one is reworded and the other is not, leaving the DEAD and UNVERIFIABLE emails
+# disagreeing about what coverage means, in the one sentence whose entire job is to stop
+# `clean` being over-read. Same two-copies-one-pin shape as the #7134 defect this suite
+# exists for, so: assert the copies are byte-identical.
+mapfile -t _CAVEATS < <(grep -oP '<em>Scan coverage:.*?</em>' "$WF" | sort -u)
+if (( ${#_CAVEATS[@]} != 1 )); then
+  _t19=0
+  echo "    the coverage caveat has ${#_CAVEATS[@]} distinct wordings across the email bodies; expected exactly 1"
+fi
 if [[ "$_t19" == "1" ]]; then
   pass "the DEAD and UNVERIFIABLE bodies both render coverage"
 else
@@ -359,8 +516,14 @@ echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
 # ANTI-VACUITY FLOOR. Deleting every assertion call yields "0/0 passed" and exit 0,
 # which test-all.sh (reading only the exit code) cannot distinguish from success.
 # A FLOOR, not equality: adding a case must not require editing this line.
-if [[ "$((PASS + FAIL))" -lt 20 ]]; then
-  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 20." >&2
+#
+# SET AT THE CURRENT COUNT, not below it. At 20 against 22 running there were two free
+# slots — measured: deleting the T15 AND T16 blocks, i.e. the PR's only in-run
+# deliverable, reported "20/20 passed" and exit 0. A floor with slack licenses the
+# deletion of exactly the assertions under review. Raise it when adding a case; that edit
+# is the point, because it is what makes a REMOVAL visible in the diff.
+if [[ "$((PASS + FAIL))" -lt 28 ]]; then
+  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 28." >&2
   exit 1
 fi
 if [[ "$FAIL" -gt 0 ]]; then exit 1; fi

--- a/scripts/check-cloudflare-token-drift.sh
+++ b/scripts/check-cloudflare-token-drift.sh
@@ -562,10 +562,10 @@ emit_json() {
   # `split("|", 1)` — maxsplit 1, so a diagnostic containing a pipe cannot shift fields.
   # Unverifiable rows get their own key rather than riding in "stale" with the diagnostic
   # sentence mis-rendered into the "config" field.
-  python3 - "$LIVE_N" "$DEAD_N" "$UNVERIFIABLE_N" "$PROBES_MADE" "${DEAD_ROWS[@]:-}" "--" "${UNVERIFIABLE_ROWS[@]:-}" <<'PY'
+  python3 - "$LIVE_N" "$DEAD_N" "$UNVERIFIABLE_N" "$PROBES_MADE" "${#CONFIGS[@]}" "${DEAD_ROWS[@]:-}" "--" "${UNVERIFIABLE_ROWS[@]:-}" <<'PY'
 import json, sys
-live, dead, unver, probes = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
-rest = sys.argv[5:]
+live, dead, unver, probes, configs = (int(sys.argv[i]) for i in range(1, 6))
+rest = sys.argv[6:]
 sep = rest.index("--")
 def rows(xs, second):
     out = []
@@ -588,7 +588,12 @@ def unver_rows(xs):
         out.append({"key": k, "cause": cause, "reason": reason})
     return out
 print(json.dumps({
-    "live": live, "dead": dead, "unverifiable": unver, "probes": probes,
+    # `configs` is emitted so a CONSUMER can tell a fleet-wide clean from a
+    # single-config clean. The detector exists to catch fan-out drift ("5 of 7
+    # configs stale after a dashboard roll"); a scan that saw ONE config cannot
+    # answer that question, and without this field the caller's `clean` verdict
+    # is indistinguishable from one earned across the whole fleet.
+    "live": live, "dead": dead, "unverifiable": unver, "probes": probes, "configs": configs,
     "stale": rows(rest[:sep], "config"),
     "unverifiable_keys": unver_rows(rest[sep + 1:]),
 }, indent=2))

--- a/scripts/check-cloudflare-token-drift.sh
+++ b/scripts/check-cloudflare-token-drift.sh
@@ -171,7 +171,16 @@ done
 #
 # It matters most at the two call sites wired in the same PR as this guard: the release
 # preflight prints "verified live" on exit 0, and the twice-daily scheduled arm is the only
-# continuous fleet-wide coverage there is.
+# CONTINUOUS coverage there is.
+#
+# Not "fleet-wide", though the line said so until #7152 measured it. The scheduled arm's
+# `DOPPLER_TOKEN` is a service token scoped to `prd_terraform`, so `doppler configs`
+# returns ONE config and the twice-daily run inspects 1 of 13 — the same "clean bill of
+# health for a question never asked" shape as the paragraph above, one layer up at the
+# scheduling layer. The run now publishes `configs`/`coverage` so the gap is loud, and
+# files an action-required issue while it persists; widening the token scope is an
+# operator decision and is tracked there. Until it lands, read a scheduled `clean` as
+# "clean in prd_terraform", never as a fleet claim.
 if (( ${#KEYSET[@]} + ${#ACCESS_BASESET[@]} == 0 )); then
   {
     echo "ERROR: enumerated 0 token-shaped keys across ${#CONFIGS[@]} config(s)${ONLY_MATCH:+ under --only '$ONLY_MATCH'}."

--- a/scripts/check-cloudflare-token-drift.test.sh
+++ b/scripts/check-cloudflare-token-drift.test.sh
@@ -1007,7 +1007,14 @@ echo "W10: the DEAD verdict's escalation is bound to the DEAD verdict"
 # escalation step's `if:` to verdict == 'unverifiable' left the previous form green, which
 # restores the literal 2026-07-29 failure (dead credential → email only → nobody acts).
 # Extract the step that files the issue and require ITS OWN guard to name 'dead'.
-W10_STEP_START=$(awk '/^      - name: /{n=NR} /--label action-required/{print n; exit}' "$DRIFT_WF")
+# Target the DEAD filer BY NAME, not by "first step containing --label
+# action-required". The first-match form was correct while that was the only
+# action-required filer in the job; the coverage filer added alongside the
+# `coverage` output is a second one, and it sorts ABOVE the DEAD step — so
+# first-match silently retargeted this assertion onto the wrong step and reported
+# the DEAD guard missing when it was intact. Naming the step keeps the assertion
+# pinned to the thing it is about, however many filers the job grows.
+W10_STEP_START=$(awk '/^      - name: Open or update an action-required issue \(token drift — DEAD credential\)/{print NR; exit}' "$DRIFT_WF")
 W10_GUARD=$(awk -v s="${W10_STEP_START:-0}" 'NR>s && NR<=s+3 && /^        if: /{print; exit}' "$DRIFT_WF")
 if [[ -n "$W10_STEP_START" ]] && grep -qE "verdict == 'dead'" <<<"$W10_GUARD" && grep -qE '^\s+--label priority/p0-critical' "$DRIFT_WF"; then
   pass "the action-required filer is guarded on verdict == 'dead' and carries a priority label"

--- a/scripts/check-cloudflare-token-drift.test.sh
+++ b/scripts/check-cloudflare-token-drift.test.sh
@@ -515,6 +515,38 @@ fi
 # Fail-closed on an unwritable path. A missing verdict file makes the caller take its
 # could-not-determine arm, so a silent write failure would report a wrong cause rather
 # than no cause — the defect class this script exists to prevent.
+                                                                                     # T14c
+# THE PRODUCER SIDE OF `configs`. The consumer suite
+# (plugins/soleur/test/token-drift-workflow-causes.test.sh) pins the workflow's parsing of
+# this field against hand-written JSON fixtures, which cannot observe what the DETECTOR
+# actually writes. Measured: replacing `"${#CONFIGS[@]}"` in emit_json with the literal
+# `"1"` — every scan forever reporting single-config, filing the coverage issue and
+# hedging every email — left BOTH suites fully green, as did deleting the `"configs":`
+# key outright. The field this PR exists to add was pinned by nothing.
+#
+# TWO fixture sizes, because a one-size fixture cannot distinguish a real count from a
+# hardcoded one: with a single 1-config case, the literal `"1"` mutation passes.
+echo "T14c: --json-file reports the NUMBER OF CONFIGS ENUMERATED, not a constant"
+T14C_OK=1
+for _n_cfg in 1 3; do
+  case "$_n_cfg" in
+    1) _cfg_body='prd' ;;
+    3) _cfg_body=$'prd\nprd_terraform\ndev' ;;
+  esac
+  JF3="$TMP/t14c-${_n_cfg}.json"
+  MOCK_CRED_STAMPED=1 run_sut "t14c${_n_cfg}" 403 "$ACCESS_FIXTURE" "$_cfg_body" "--json-file $JF3"
+  _got=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("configs","<absent>"))' "$JF3" 2>/dev/null || echo '<unparseable>')
+  if [[ "$_got" != "$_n_cfg" ]]; then
+    T14C_OK=0
+    echo "    ${_n_cfg} config(s) enumerated but the verdict reported configs=${_got}"
+  fi
+done
+if [[ "$T14C_OK" == "1" ]]; then
+  pass "configs tracks the enumerated config count across fixture sizes (1 and 3)"
+else
+  fail "the verdict's 'configs' field does not track the configs actually enumerated. Every consumer's coverage signal is derived from this number, so a constant here makes the whole fan-out-coverage ladder report a fiction — in the confident direction if the constant is >= 2"
+fi
+
 echo "T14b: --json-file on an unwritable path exits 2 rather than continuing silently"
 run_sut t14b 200 "$ACCESS_FIXTURE" prd "--json-file $TMP/no-such-dir/x.json"
 if [[ "$RC" == "2" ]]; then
@@ -1016,7 +1048,15 @@ echo "W10: the DEAD verdict's escalation is bound to the DEAD verdict"
 # pinned to the thing it is about, however many filers the job grows.
 W10_STEP_START=$(awk '/^      - name: Open or update an action-required issue \(token drift — DEAD credential\)/{print NR; exit}' "$DRIFT_WF")
 W10_GUARD=$(awk -v s="${W10_STEP_START:-0}" 'NR>s && NR<=s+3 && /^        if: /{print; exit}' "$DRIFT_WF")
-if [[ -n "$W10_STEP_START" ]] && grep -qE "verdict == 'dead'" <<<"$W10_GUARD" && grep -qE '^\s+--label priority/p0-critical' "$DRIFT_WF"; then
+# The priority-label conjunct needs the SAME step scoping as the guard above, and for the
+# same reason — the retarget fixed one half and left this one file-wide. The coverage
+# filer emits its own `--label priority/...` line, so a file-wide grep for a priority
+# label is satisfiable by the WRONG step: measured, moving `p0-critical` off the DEAD
+# filer and onto the coverage filer left this assertion PASS while the DEAD credential
+# issue lost the label operator-digest sorts on. Bound to the DEAD step's own body, which
+# runs to the next top-level `- name:`.
+W10_BODY=$(awk -v s="${W10_STEP_START:-0}" 'NR>s { if (/^      - name: /) exit; print }' "$DRIFT_WF")
+if [[ -n "$W10_STEP_START" ]] && grep -qE "verdict == 'dead'" <<<"$W10_GUARD" && grep -qE '^\s+--label priority/p0-critical' <<<"$W10_BODY"; then
   pass "the action-required filer is guarded on verdict == 'dead' and carries a priority label"
 else
   fail "the step filing the action-required issue must itself be guarded on verdict == 'dead' (found guard: '${W10_GUARD:-none}') and must carry --label priority/p0-critical (operator-digest sorts on priority and caps the list, so an unprioritised issue is filed and still unseen)"
@@ -1036,8 +1076,13 @@ echo "=== Results: $PASS/$((PASS + FAIL)) passed, $FAIL failed ==="
 # the real count cannot distinguish "the feature's tests were removed" from "they passed".
 # Still a floor, not equality, so adding a case does not require editing it — but it is now
 # close enough to the count that deleting a feature's cases trips it.
-if [[ "$((PASS + FAIL))" -lt 50 ]]; then
-  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 50. The suite did not execute what it claims to." >&2
+# Raised 50 -> 53 with T14c. The remaining 2-assertion slack was deliberate but is not
+# defensible: a floor below the count licenses deleting exactly the cases under review
+# (measured in the sibling consumer suite — 20 against 22 let the two tests carrying that
+# PR's only in-run deliverable be deleted at "20/20 passed", exit 0). Still a floor, so
+# ADDING a case needs no edit here; only a removal trips it, which is the point.
+if [[ "$((PASS + FAIL))" -lt 53 ]]; then
+  echo "FATAL: only $((PASS + FAIL)) assertions ran; expected >= 53. The suite did not execute what it claims to." >&2
   exit 1
 fi
 if [[ "$FAIL" -gt 0 ]]; then exit 1; fi


### PR DESCRIPTION
## Two gaps, found by asking what the scheduled run *does*, not what the detector *can* do

### 1. The fan-out detector cannot see the fan-out

The detector exists for one job. Its own header:

> `CF_API_TOKEN_DNS_EDIT` — **5 of 7 configs stale** after a dashboard roll
> `CF_API_TOKEN_PURGE` — **6 of 7 configs stale** after a dashboard roll

Measured on the 18:00Z scheduled run vs. a manual fleet-wide run:

| | configs scanned | Access families | verdict |
|---|---|---|---|
| scheduled job | **1** | 2 | `clean` |
| manual (full auth) | **13** | 3 | — |

The workflow's Doppler service token is scoped to `prd_terraform`, so the twice-daily job that exists to detect fan-out drift **inspects a single config and reports `clean`** while twelve unread configs could each hold a stale value. That is the script's own condemned failure — *"a clean bill of health for a question never asked"* — reproduced one layer up, at the scheduling layer. It also matters more after #7133, whose new `action-required` escalation channel is only as good as the coverage feeding it.

**This PR makes the gap loud; it does not close it.** The detector now emits `configs` in `--json`; the workflow derives a `coverage` output (`multi-config` / `single-config` / `unknown`), emits a `::warning::` whenever coverage is not `multi-config`, and both verdict-bearing emails carry a caveat so `clean` reads as *"clean in what was visible"*. An unmeasured coverage derives `unknown`, never `multi-config`. There is deliberately **no `full` state**: the count has no denominator, because the config list is itself scope-filtered by the same token, so `multi-config` is a lower bound and never a completeness claim.

The actual remedy is **tracked in #7159 and left to the operator**, not done unilaterally. Two corrections landed there during review: a Doppler service token is *config-scoped by construction*, so there is no single "project-scoped read token" to mint (the real choice is a `prd`-root token vs. `for_each` per-config vs. reusing `DOPPLER_TOKEN_TF`, which differ in prd read blast radius); and the **mechanism** is not manual — `kb-drift.tf` already mints one in-band via Terraform. Only the *choice* needs an operator.

### 2. The consumer had no tests, and was already broken

#7134 shipped a closed UNVERIFIABLE cause vocabulary with the emitting side pinned and the consuming side pinned by nothing (stated as a known gap in that PR body). The new suite **caught a real defect on its first run**:

Of the **10** causes the detector can emit, the operator email explained **5**. The five added in #7134's second commit — `control-blocked`, `detector-env`, `gate-indeterminate`, `stamped-non-refusal`, `unexpected-status` — reached the script's report footer and never reached the email. Those runs would have sent the operator a remedy for a *different problem*: the exact defect #7134 removed one layer down. All 10 now render — plus the parser's own `unknown` sentinel for a row arriving with no `cause` field, which T3 pins as contract. That is 11 `<code>` entries across 10 `<li>` (`host-unreachable` / `probe-failed` share one remedy).

## Test design

Both rules below were learned in #7134 — and both were violated by this file's own first draft, then caught by mutation:

- **The parser is EXTRACTED from the workflow, not re-implemented.** v1 extracted only the python program and re-added the `|| echo` fallback locally, so deleting the workflow's fallback left the suite green. It now evaluates the whole line with `$RUNNER_TEMP` pointed at a fixture dir. Same fix for the coverage derivation.
- **The cause vocabulary is DERIVED from the detector source.** Adding a cause REDS this suite until the email learns to render it. A restated list would be a second unsynchronized pin — precisely the failure this suite exists to catch.
- **T1's fixture uses three causes whose SET order differs from SORTED order.** The original two-element fixture happened to hash into sorted order, so dropping `sorted()` from the workflow left the assertion green. The sort was asserted by luck.

## Verification

- detector **53/53**, new consumer suite **28/28**, terraform-drift step-order guard **7/7**
- **9-mutation battery** on a sandbox copy, green baseline required, each mutation asserted to have *landed*: first pass **6/9** — the three survivors were the two re-implementation vacuities above plus the lucky-sort fixture. After fixing them: **9/9 caught, 0 survivors**
- `shellcheck` clean at warning severity and above (5 × SC2016 *info* remain, on single-quoted literals deliberately matched against the workflow verbatim); `actionlint` finding count unchanged (13 → 13)
- **Live-fire:** the real detector emits `configs: 13` and the real workflow parser reads it (`dead=0 unver=0 causes=- configs=13`)

## Review (10 agents)

Four merge-blockers, all pr-introduced, all fixed inline. Every fix mutation-proven: **16/16 caught, 0 survivors**, green control required before each row, each mutation asserted to have landed.

- **The coverage filer fired from the matrix leg that never scanned.** `token_drift` is gated to `apps/web-platform/infra`; on the `infra/github` leg every output is `''`, and the arm tested `!= 'multi-config'` — so `'' != 'multi-config'` fired it with a blank body, raced the real leg, and create-only locked the blank issue in. It also kept firing *after* the remedy lands, making the issue's own closing condition unsatisfiable. Now positive, matching all five siblings.
- **T11 could not fail** — it filtered its input to `CAUSES`, then checked membership in `CAUSES`.
- **T14 could not fail** — both greps were file-wide, and this PR took the dedup literal from 1 → 2 occurrences.
- **The parity derivation read the wrong literal** — the internal `PAIR_VERDICT` value, not the `UNVERIFIABLE_ROWS` field that reaches the JSON.

Also fixed: `unknown` was filed under the single-config title with an unperformable remedy; the create swallowed its own failure; the dedup query failed open; nothing closed the issue on recovery; `(( configs < 2 ))` read a zero-padded count as octal and fell through to the *confident* state; the `heartbeat-live-reconcile` create-only citation was false; W10's `p0-critical` conjunct was satisfiable by this PR's own new filer; the producer side of `configs` was pinned by nothing (hardcoding it to `1` survived both suites); both anti-vacuity floors had enough slack to delete the tests under review.

Two docs asserted states this PR disproves: the detector header ("the only continuous fleet-wide coverage there is") and `ci-ssh-token-replace.md`, which told the operator at a halt gate to wait for a `dead` verdict that cannot arrive — a stale sibling copy is *invisible* to a `prd_terraform`-scoped scan, so the verdict reads `clean`. Both corrected.

Ref #7134
Refs #7159

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- gate-override: net-issue-flow -->
**#7159** — not deferred engineering work: it is the production **credential decision** this PR was written to surface and deliberately does not take (choosing the Doppler read-token shape; the options differ in prd read blast radius). It cannot be folded inline under the cost-of-filing auto-flip, because the blocker is authority, not size. Filing it is also *required* by `wg-block-pr-ready-on-undeferred-operator-steps`, which blocks `gh pr ready` on an operator action with no tracker — so the two gates are in tension here, and this override resolves it in the direction that keeps the deferral durable rather than leaving it buried in a merged PR body.
