### PR TITLE
docs(learnings): the ugrep OOM diagnosis, and three refuted guard designs

### DIFF
--- a/knowledge-base/project/learnings/2026-08-02-ps-named-it-2-1-220-so-a-grep-that-ate-the-box-read-as-a-claude-leak.md
+++ b/knowledge-base/project/learnings/2026-08-02-ps-named-it-2-1-220-so-a-grep-that-ate-the-box-read-as-a-claude-leak.md
@@ -1,0 +1,279 @@
+# Learning: `ps` named it "2.1.220", so a grep that ate the box read as a Claude Code leak
+
+## Problem
+
+On 2026-08-01 a parallel session ran a one-line regex search against a **single
+21 kB markdown file**. It reached **9.5 GB RSS in 171 s at 99% CPU and was still
+climbing**, driving a 31 GB box to 691 MB free with swap at 88.5%. The operator's
+terminal crashed, killing six sessions at once.
+
+This had happened before, more than once, and had never been root-caused. The
+reason is the single most useful thing in this file:
+
+**The process is invisible as a cause.** Claude Code's shell snapshot installs a
+bash **function** named `grep` that transparently re-execs the `claude` binary
+with `argv[0]=ugrep`. So `ps` renders the runaway as `COMMAND 2.1.220` — the
+claude *version directory* — never as `grep` and never as `ugrep`. Every prior
+occurrence therefore read as "Claude Code is leaking memory," which is a
+believable-and-wrong story that survives casual inspection. Nobody looks for a
+regex engine when the process table says the agent is at fault.
+
+Verify the shim before theorising about any grep-shaped resource anomaly:
+
+```
+$ type -t grep       # -> function   (NOT file)
+$ declare -f grep    # -> re-execs "${CLAUDE_CODE_EXECPATH}" with argv[0]=ugrep
+```
+
+## Both prescribed mechanisms were wrong, and measurement said so
+
+The fix was specified before it was measured. **Both halves of the specification
+were refuted by hard-capped probes** (`ulimit -v` + `timeout` on every run; the
+reproducer was never once run uncapped).
+
+### 1. The trigger is not what it looks like
+
+The prescribed detector was "bounded repeat `{n,m}` **AND** alternation `|`".
+That is wrong **on both sides**:
+
+| Pattern | Alternation? | Result |
+|---|---|---|
+| `.{0,80}cannot[^.]{0,120}` | **no** | blowup — killed at cap |
+| `.{0,8}(NEVER\|MUST NOT)` | **yes** | 8.8 MB / 0.1 s |
+
+Alternation is nearly irrelevant. Had the prescribed heuristic shipped, it would
+have blocked the cheap case and allowed the one that froze the desktop — a guard
+that is worse than nothing, because it *reads* as protection.
+
+### …and the replacement cost model was ALSO wrong (caught at review)
+
+The plan replaced that heuristic with "two or more BOUNDED repeats, cost =
+∏(upper+1), deny at ≥ 500". **That model is wrong in both directions**, which is
+the more interesting finding, because it was itself derived from measurement and
+therefore felt settled.
+
+**Width of the repeated class is the discriminator — not the bound product.**
+Re-measured 2026-08-02, hard-capped (`ulimit -v 2000000` + `timeout`), against a
+31 kB fixture:
+
+| Pattern | ∏(upper+1) | Peak RSS | Plan's verdict |
+|---|---|---|---|
+| `[0-9]{0,80}x[0-9]{0,120}` | 9801 | **7.5 MB** | deny ❌ |
+| `[0-9a-f]{8}-…-[0-9a-f]{12}` (UUID) | 14625 | **7.5 MB** | deny ❌ |
+| `[0-9]{4}-[0-9]{2}-[0-9]{2}T…` (ISO ts) | 1215 | **7.5 MB** | deny ❌ |
+| `^\+(<{7}\|={7}\|>{7})` | 512 | **7.4 MB** | deny ❌ |
+| `.{0,16}q[^.]{0,16}` | 289 | **BLOWUP** | allow ❌ |
+| `.{0,20}(a\|b\|c\|d\|e\|f)[^.]{0,20}` | 441 | **BLOWUP** | allow ❌ |
+
+A **narrow** class (`[0-9]`, `[0-9a-f]`, a literal) stays cheap even at a product
+of 9801, because DFA state count scales with the SIZE of the repeated set. Only
+`.` and a negated class `[^…]` are wide enough to explode. The wide-class ladder,
+one literal between two repeats:
+
+| ∏(upper+1) | 25 | 49 | 81 | 121 | 169 | 289 |
+|---|---|---|---|---|---|---|
+| Peak RSS | 7.7 MB | 8.3 MB | 12 MB | 30 MB | 103 MB | **BLOWUP** |
+
+Note the 441 row of the comparison table above: **the plan's own "highest
+observed-safe product 441 (44 MB)" datapoint does not reproduce** — that exact
+pattern blows up. So the planned
+threshold of 500 sat *above* the real danger point (~150), and would have shipped
+a guard that misses genuine blowups while denying **22 benign call sites in this
+repo** — including the conflict-marker regex inside `guardrails.sh` itself.
+
+A **single** bounded repeat is always cheap, however large: `.{0,10000}cannot` =
+60 MB / 0.6 s. GNU grep runs the reproducer in 7 MB / 0.1 s.
+
+The shipped model: count only bounded repeats over a WIDE atom (`.`, `[^…]`, or a
+group close, counted conservatively); fewer than two → allow; else deny at
+∏(upper+1) ≥ **150**.
+
+### 2. `ulimit -v` is categorically incompatible with this toolchain
+
+The prescribed backstop was `ulimit -v ~4 GB`. Measured: **vitest dies instantly
+at every cap tested — 6, 8, 12, 16, 24 and even 32 GB — at only 97 MB of actual
+RSS**, with `WebAssembly.instantiate(): Out of memory`. Uncapped it passes (12702
+tests, 898 MB peak).
+
+V8/WASM *reserves* enormous virtual address space; `ulimit -v` counts
+**reservations, not usage**. A 32 GB cap on a 31 GB box still fails. The quantity
+that actually exhausts a machine is RSS, so the backstop must be a cgroup v2
+`memory.max`, which limits RSS.
+
+## What shipped: nothing. PR #7151 was closed unmerged.
+
+That is the finding, not a footnote. Two guards were built, fully tested
+(74/74 and 26/26), mutation-tested twice (10/10 and 7/7 killed), shellcheck
+clean, and green on a 243/243 full suite. An 8-agent review then established
+that **neither one worked**.
+
+### The cost model was refuted three times, each time by measurement
+
+Each model was *derived from measurement* and therefore felt settled. Each was
+measured against fixtures its own author chose.
+
+| # | Model | Refuted by |
+|---|---|---|
+| 1 | bounded repeat **AND** alternation | A no-alternation pattern blows up; a bounded-repeat-plus-alternation pattern costs 8.8 MB. Wrong on both sides. |
+| 2 | ∏(upper+1) ≥ 500 over any bounded repeat | Denies UUIDs, ISO timestamps, SHA-256 pairs and the conflict-marker regex *inside `guardrails.sh` itself* (~7 MB each); allows a genuine blowup at product 289 — including the plan's own "highest observed-safe 441" datapoint, which does not reproduce. |
+| 3 | ∏(upper+1) ≥ 150 over a **wide** atom (`.`, `[^…]`) | Positive classes of any width blow up when the literal between them is reachable. |
+
+**The third refutation is the one that ends the approach.** Same pattern, same
+bound product; the only variable is whether the literal occurs in the subject:
+
+| Pattern | Literal in corpus? | Peak RSS |
+|---|---|---|
+| `[0-9]{0,80}x[0-9]{0,120}` | no | 7.3 MB |
+| `[0-9]{0,80}5[0-9]{0,120}` | **yes** | **1.67 GB — killed** |
+| `[a-z]{0,80}q[a-z]{0,120}` | yes | **killed** |
+| `[[:print:]]{0,80}q[[:print:]]{0,120}` | yes | **killed** |
+| `.{0,80}Z[^.]{0,120}` (wide, literal absent) | no | **killed** |
+
+The first row was fixture **G21 — the evidence for "narrow classes are cheap."**
+It measured 7.5 MB only because `x` never appears in the subject, so ugrep
+prefilters on the literal and never builds the DFA. Every "cheap" datapoint in
+the calibration ladder shares that confound.
+
+Real cost is a function of **class size × bound magnitude × literal
+reachability against the specific input**. A static regex-shape heuristic in a
+PreToolUse hook cannot see the third factor at all, because the input is a file
+it has not read. That is not a threshold to retune; it is a missing variable.
+
+### Transferable lesson
+
+**A calibration ladder is only as good as the axis you forgot to vary.** All
+three models were built by sweeping *one* axis (alternation, then bound product,
+then class width) while holding the corpus fixed. The corpus was the variable
+that mattered. Before trusting any measured threshold, ask: *what did I hold
+constant across every datapoint, and would varying it change the verdict?*
+
+## The guard also leaked, in ways the tests could not see
+
+Independent of the model, review found seven forms that reach the shim and are
+**not** gated — `X=$(grep …)`, backtick substitution, `(grep …)` subshell,
+`G=grep; $G …`, `P='…'; grep "$P"`, `eval "grep …"`, and `grep -f patternfile`.
+Command substitution is the common one: `count=$(grep -c …)` is a first-class
+agent idiom, and the 2026-08-01 incident is described as exactly "a one-liner".
+
+Arming compared the token to the literal string `grep`; `xargs -n1` yields
+`$(grep`, `` `grep ``, `(grep`, none of which match. The header comment asserted
+that exact-token arming "is what makes every non-shim form safe" — a confident
+claim about a predicate (*does this word resolve to the bash function*) that the
+code did not implement (*is this word spelled `grep`*).
+
+Also measured false negatives inside the model: `{n,}` over a wide class blows
+up (`.{16,}q[^.]{16,}` → 1.07 GB) but was discarded as "unbounded, ignore", and
+its fixture used a narrow pattern so it pinned the wrong contract; and
+`\\.{0,16}q[^.]{0,16}` → 1.19 GB, allowed, because the "not preceded by a
+backslash" test misfires on an escaped backslash.
+
+## Guard 2 never executed once
+
+`memory-cap.sh` was committed `100644`. `settings.json` invokes the path
+directly, so every SessionStart died at `exec` with `EXIT=126`. Both sibling
+SessionStart hooks are `100755`.
+
+**Nothing could catch it.** The suite runs `bash "$HOOK"`, which ignores the mode
+bit; so does `scripts/test-all.sh`. The live verification of AC7a — a real cgroup
+created, `memory.max` read back at 12 GiB — was reached through `bash
+memory-cap.sh`, a path production never uses. 26 green assertions, a 7/7 mutation
+battery, a live kernel readback and 243/243 CI all sat on top of a hook that
+could not run.
+
+**Verify through the invocation production uses, not one that merely reaches the
+same code.** The repo already had this gate for `scripts/followthroughs/*.sh`
+(`followthrough-exec-bit.test.sh`, which deliberately asserts the *index* mode
+via `git ls-files -s`); its glob does not reach `.claude/hooks/`.
+
+And when it did run, the design was wrong in four independent ways:
+
+- **It escaped the terminal's kill switch.** The cgroup was created as a
+  *sibling* of the terminal's systemd scope, so `claude` was no longer a scope
+  member and closing the terminal would not reap it. "Never modify the terminal's
+  own scope" is what caused this; the side effect was never checked.
+- **The cap sat above the harm point.** The desktop froze at 9.5 GB; the cap was
+  12 GB. It would not have fired before the freeze it was built to prevent.
+  Sizing was measured against *honest* workloads (4.9× `tsc`) and never against
+  the *harm* threshold.
+- **No aggregate bound.** Per-pid keying means N sessions × 12 GB on a 31 GB box.
+  Two honest 11 GB sessions pass both guards and reproduce the freeze.
+- **Swap was never capped.** `memory.swap.max` defaults to `max`, so a capped
+  runaway still drives the 2 GB swapfile to exhaustion — and "swap at 88.5%" is
+  the *observed symptom* of the original incident.
+
+The sanctioned API existed and was missed: systemd adopts a live PID into a scope
+via `StartTransientUnit` with `PIDs=`, verified working on this box with no sudo.
+With `--slice=soleur-agents.slice` it also supplies the aggregate bound. The
+"move a live process vs. launch into a capped scope" framing was a false
+dichotomy. Related: the documented `systemctl daemon-reload` GC caveat **does not
+reproduce** on systemd 259 — a load-bearing comment describing a risk that isn't
+real while omitting the one that is.
+
+## A confirmed RCE in the hook layer (pre-existing, 10 files)
+
+`guardrails.sh` and nine siblings parse hook input as:
+
+```sh
+eval "$(echo "$INPUT" | jq -r '@sh "COMMAND=\(.tool_input.command // "") …"')"
+```
+
+`jq @sh` shell-quotes each **array element as a separate word**, so a non-string
+`.tool_input.command` makes `eval` read word 1 as an assignment and words 2+ as a
+command:
+
+```
+input : {"tool_input":{"command":["x","touch","/tmp/…/PWNED"]}}
+jq    : COMMAND='x' 'touch' '/tmp/…/PWNED' TOOL_NAME='Bash' FILE_PATH=''
+result: marker file created — the hook executed it
+```
+
+Confirmed by execution, before the permission prompt, with full operator
+privileges. Pre-existing on `main`; filed separately. Fix: force a scalar in jq
+(`| if type=="string" then . else tojson end`) or drop `eval` for `mapfile -d ''`.
+
+Note the fail-open half is *correct* — a PreToolUse hook that denies every
+command on a jq hiccup bricks the session. The defect is that the disarm is
+**silent**: malformed JSON yields empty stdout, exit 0, no incident. That is
+precisely why the plan's own broken discoverability probe (a `printf` emitting
+invalid JSON) was indistinguishable from a working guard, and could never have
+returned a deny for *any* rule.
+
+## Sharp edges worth keeping
+
+- **Never re-run the reproducer uncapped.** Every probe here ran under
+  `ulimit -v 2000000` + `timeout`.
+- **Verifying that a memory cap kills does not require allocating the cap.** The
+  kill mechanism was proven in a separate **256 MB** cgroup (`oom_kill 1`, exit
+  137) — same kernel path, bounded blast radius. Testing a 12 GB cap by
+  allocating 12 GB risks reproducing the incident.
+- **A probe returning the same result on every arm — including a known-positive
+  control — is an un-run instrument, not a clean result.** The first cost probe
+  reported empty for the control; only after the control provably fired (rc=124
+  timeout, rc=139 at 1.69 GB) were the other rows worth reading.
+- Moving a process into a new cgroup does **not** migrate its existing charge:
+  `memory.current` reads 0 after the move and grows with new allocations.
+- **`\grep` is not an escape hatch** — backslash suppresses *alias* expansion,
+  not *function* lookup. The real bypasses are `command grep` and a
+  path-qualified grep. Note GNU `xargs` already strips a leading backslash
+  outside quotes, so tokenization delivered this behaviour, not the guard's own
+  normalization.
+- The shim is **not** `export -f`'d: `bash -c 'grep --version'` gets GNU grep
+  3.12. So the dangerous call can only originate in a top-level Bash-tool command
+  string — which is exactly what a PreToolUse hook sees. The 54 hook scripts that
+  call `grep` are structurally out of scope. This is the strongest argument for
+  the lexical layer, and it points at the design that should have been chosen:
+  PreToolUse supports `updatedInput`, so rewriting `grep` → `command grep`
+  sidesteps classification entirely — no cost model, no false positives, no false
+  negatives. The caveat is that the shim injects
+  `-G --ignore-files --hidden -I --exclude-dir=.git`, so recursive invocations
+  need a carve-out.
+
+## Residual
+
+Under a cap the blowup dies by **SIGSEGV after ~45 s at 2.7 GB** (measured at a
+3 GB cap) — ugrep does not handle allocation failure gracefully. A memory cap
+bounds the damage; it does not prevent ~45 s of 100% CPU.
+
+**The operator's exposure is unchanged as of this writing.** The diagnosis is
+solid and the mechanism is understood; no guard is in place. Follow-ups carry the
+two candidate designs.

--- a/knowledge-base/project/plans/2026-08-01-fix-ugrep-oom-guards-plan.md
+++ b/knowledge-base/project/plans/2026-08-01-fix-ugrep-oom-guards-plan.md
@@ -1,0 +1,341 @@
+---
+title: "fix: guard against runaway ugrep OOM that crashes the operator's terminal"
+type: fix
+lane: procedural
+brand_survival_threshold: single-user incident
+requires_cpo_signoff: true
+branch: feat-one-shot-ugrep-oom-guards
+pr: 7151
+created: 2026-08-01
+---
+
+# fix: guard against runaway ugrep OOM that crashes the operator's terminal
+
+> ## STATUS: CLOSED UNMERGED (2026-08-02). NOTHING IN THIS PLAN SHIPPED.
+>
+> PR #7151 was closed after an 8-agent review established that **both guards were
+> broken**. Every threshold, calibration figure and phase below is retained as a
+> record of what was tried and refuted — **none of it is live guidance**.
+>
+> - Guard 1's cost model was refuted **three times**; the final refutation showed
+>   cost depends on literal reachability against the specific input, which a
+>   static regex-shape heuristic cannot observe. Seven bypass forms
+>   (`$(grep …)`, backtick, subshell, `$VAR`, `eval`, `-f patternfile`) also
+>   reached the shim ungated.
+> - Guard 2 was committed non-executable and **never ran once**; when run
+>   manually it escaped the terminal's kill switch, capped above the 9.5 GB harm
+>   point, left swap uncapped, and had no aggregate bound.
+>
+> The diagnosis chain and all measurements are preserved in
+> `knowledge-base/project/learnings/2026-08-02-ps-named-it-2-1-220-so-a-grep-that-ate-the-box-read-as-a-claude-leak.md`.
+
+## Overview
+
+Claude Code's shell snapshot installs a bash **function** named `grep` that transparently
+re-execs the `claude` binary with `argv[0]=ugrep`. Certain regex shapes make ugrep's DFA
+construction allocate without bound. On 2026-08-01 a parallel session's one-liner against a
+single 21 kB markdown file reached **9.5 GB RSS in 171 s at 99% CPU and was still climbing**,
+driving a 31 GB box to 691 MB free with swap at 88.5%. The operator confirms prior Warp
+crashes match this signature.
+
+The process is invisible as a cause: `ps` shows `COMMAND 2.1.220` (the claude version
+directory), not `ugrep`, so every prior occurrence read as "Claude Code is leaking memory."
+That misattribution is why it went un-root-caused across multiple crashes.
+
+Two guards:
+
+- **Guard 1 (primary):** a `guardrails.sh` PreToolUse rule that blocks the dangerous regex
+  shape pre-flight, telling the agent to use `command grep`.
+- **Guard 2 (backstop):** a memory cap so an unpredicted blowup dies alone.
+
+## Research Reconciliation — Spec vs. Codebase
+
+Both prescribed mechanisms were measured against reality. **Both required correction.**
+All numbers below are from hard-capped probes run in this worktree on 2026-08-01
+(`ulimit -v` + `timeout` on every run; the reproducer was never run uncapped).
+
+| Prescribed | Reality (measured) | Plan response |
+|---|---|---|
+| Guard 1 detects "bounded repeat `{n,m}` **AND** alternation `\|`" | **Wrong on both sides.** `.{0,80}cannot[^.]{0,120}` — *no alternation* — blows up (870 MB, killed at cap). `.{0,8}(NEVER\|MUST NOT)` — bounded repeat *and* alternation — costs 8.8 MB / 0.1 s. Alternation is nearly irrelevant; the driver is **≥2 bounded repeats**, cost scaling with the product of their upper bounds. | Replace the heuristic with a measured cost model (below). |
+| Guard 2 caps processes via `ulimit -v ~4 GB` | **Categorically incompatible.** vitest dies instantly at **every** cap tested — 6, 8, 12, 16, 24, **32 GB** — at only 97 MB actual RSS, with `WebAssembly.instantiate(): Out of memory`. Uncapped it passes (12702 tests, 898 MB peak). V8/WASM *reserves* vast virtual address space; `ulimit -v` counts reservations, not usage. A 32 GB cap on a 31 GB box still fails. | Reject `ulimit -v`. Ship a **cgroup v2 `memory.max`** cap, which limits RSS not VA. |
+| `command grep` bypasses the shim | Confirmed. `command grep` and `/usr/bin/grep` → GNU grep 3.12. | Block message may safely recommend `command grep`. |
+| (not specified) | **`\grep` does NOT bypass the shim.** Backslash suppresses *alias* expansion, not *function* lookup — verified: `\foo` still ran the function. | Guard must treat `\grep` as shimmed, not as an escape hatch. |
+
+### Measured cost model (Guard 1) — SUPERSEDED, REFUTED TWICE OVER (see below)
+
+Two-bounded-repeat patterns, product of upper bounds vs. observed cost:
+
+| Pattern | Product | Peak RSS | Verdict |
+|---|---|---|---|
+| `.{0,10}(6-alt)[^.]{0,10}` | 100 | 12 MB | safe |
+| `.{0,20}(6-alt)[^.]{0,20}` | 400 | 44 MB | safe |
+| `.{0,25}(6-alt)[^.]{0,25}` | 625 | 162 MB | elevated |
+| `.{0,30}(6-alt)[^.]{0,30}` | 900 | 672 MB | bad |
+| `.{0,35}(6-alt)[^.]{0,35}` | 1225 | killed at cap | blowup |
+| `.{0,40}cannot[^.]{0,40}` (**no alternation**) | 1600 | killed at cap | blowup |
+| `.{0,80}(6-alt)[^.]{0,120}` (**the reproducer**) | 9600 | killed at cap | blowup |
+
+A **single** bounded repeat is always cheap, regardless of size: `.{0,10000}cannot` = 60 MB /
+0.6 s; `.{0,2000}(6-alt)` = 97 MB / 0.9 s. GNU grep runs the reproducer in 7 MB / 0.1 s.
+
+**Model:** parse every bounded quantifier (`{n,m}`, `{,m}`, `{n}`; treat `{n,}` as unbounded
+and ignore). If fewer than two are bounded → allow. Otherwise cost = ∏(upper+1); block when
+cost ≥ **500**. Calibration: highest observed-safe product is 441 (44 MB); lowest clearly-bad
+is 961 (672 MB). 500 sits between, on the safe side.
+
+> **SUPERSEDED at review (2026-08-02). The model above is wrong in BOTH
+> directions and was NOT shipped.** Re-measured hard-capped (`ulimit -v
+> 2000000` + `timeout`), the bound product is not predictive — the **width of
+> the repeated class** is:
+>
+> | Pattern | ∏(upper+1) | Peak RSS | Model above says |
+> |---|---|---|---|
+> | `[0-9]{0,80}x[0-9]{0,120}` | 9801 | 7.5 MB | deny ❌ |
+> | `[0-9a-f]{8}-…-[0-9a-f]{12}` (UUID) | 14625 | 7.5 MB | deny ❌ |
+> | `[0-9]{4}-[0-9]{2}-[0-9]{2}T…` (ISO ts) | 1215 | 7.5 MB | deny ❌ |
+> | `^\+(<{7}\|={7}\|>{7})` | 512 | 7.4 MB | deny ❌ |
+> | `.{0,16}q[^.]{0,16}` | 289 | **BLOWUP** | allow ❌ |
+> | `.{0,20}(a\|b\|c\|d\|e\|f)[^.]{0,20}` | 441 | **BLOWUP** | allow ❌ |
+>
+> The last row is this table's own "highest observed-safe" datapoint, and it
+> **does not reproduce** — so the 500 threshold sat ABOVE the real danger point
+> and would have shipped a guard that misses genuine blowups while denying **22
+> benign call sites in this repo**, including the conflict-marker regex inside
+> `guardrails.sh` itself.
+>
+> **Second replacement model (also NOT shipped — refuted in turn):** count only
+> bounded repeats over a WIDE atom (`.`, `[^…]`, group close); deny at
+> ∏(upper+1) ≥ **150**, between the measured 121 knee (30 MB) and 169 elbow
+> (103 MB).
+>
+> **THIRD REFUTATION — this is what ended the approach.** The wide/narrow split
+> is also wrong: a *positive* class of any width blows up when the literal
+> between the repeats is reachable in the subject. Same pattern, same product;
+> the only variable is the corpus:
+>
+> | Pattern | Literal present? | Peak RSS |
+> |---|---|---|
+> | `[0-9]{0,80}x[0-9]{0,120}` | no | 7.3 MB |
+> | `[0-9]{0,80}5[0-9]{0,120}` | **yes** | **1.67 GB — killed** |
+> | `[a-z]{0,80}q[a-z]{0,120}` | yes | **killed** |
+> | `[[:print:]]{0,80}q[[:print:]]{0,120}` | yes | **killed** |
+>
+> The first row was the fixture used to PROVE narrow classes are cheap — it
+> measured cheap only because `x` never occurs in the subject, so ugrep
+> prefilters on the literal and never builds the DFA. Every "cheap" datapoint in
+> both ladders shares that confound. Cost is class size × bound magnitude ×
+> literal reachability against a file the hook has not read, so a static
+> regex-shape heuristic cannot classify it. Not a threshold to retune — a
+> missing variable.
+
+## User-Brand Impact
+
+**If this lands broken, the user experiences:** a false block on a legitimate `grep`, costing
+one retry with `command grep` (the block message states the fix). A Guard 2 mis-sizing is more
+serious: too low a cap kills the agent's own toolchain mid-run.
+
+**If this leaks, the user's data is exposed via:** no new data surface. Both guards are local
+process-control; the hook reads only the command string it is already handed and writes no
+new artifact beyond the existing incident ledger.
+
+**Brand-survival threshold:** `single-user incident` — the failure this fixes already froze the
+operator's desktop repeatedly, and a wrongly-sized Guard 2 could break every build on the box.
+
+## Implementation Phases
+
+### Phase 1 — Guard 1: `guardrails:block-catastrophic-grep-repeat` (contract first)
+
+Add to `.claude/hooks/guardrails.sh`, following the `block-stash-in-worktrees` pattern
+(prose-rule comment at the top, `emit_incident` + `permissionDecision: deny` JSON).
+
+Load-bearing implementation constraints, each derived from reading the existing hook:
+
+1. **Scan `$COMMAND`, not `$SCAN`.** `strip_command_bodies` blanks quoted bodies, and a grep
+   pattern is *always* inside quotes — scanning `$SCAN` would see nothing and the guard would
+   never fire.
+2. **Tokenize with `xargs -n1`** (the pattern the `require-milestone` and `block-recursive-delete`
+   gates already use). This strips quotes so the pattern arrives as one token, *and* it removes
+   the false-positive class that scanning raw `$COMMAND` would create: in
+   `git commit -m "... grep -noE '.{0,80}(a|b)' ..."` the whole message is a single token whose
+   command word is `git`, so no `grep` token exists to trigger on.
+3. **Only fire on shimmed invocations.** Skip when the `grep` token is preceded by `command`, or
+   is path-qualified (`/usr/bin/grep`, `/bin/grep`). Do **not** skip on `\grep` — measured to
+   still hit the function.
+4. **Verify at implementation time** whether the snapshot also shims `egrep`/`fgrep`
+   (`declare -f egrep fgrep`); include them only if shimmed.
+5. The guard's own detection regex and its test fixtures must not themselves embed a
+   blowup-shaped pattern. (The original "≥500-cost" phrasing referenced the retired
+   bound-product model — see the STATUS banner.)
+
+Tests in `.claude/hooks/guardrails.test.sh` (auto-discovered by `scripts/test-all.sh` via the
+`.claude/hooks/*.test.sh` glob), reusing the existing `mk_payload`/`decision_of` harness and its
+non-git-CWD isolation. Cases: the reproducer → `deny`; the no-alternation blowup
+`.{0,80}cannot[^.]{0,120}` → `deny`; `.{0,8}(A|B)` → allow; `.{0,10000}foo` (single bound) → allow;
+`command grep` + reproducer → allow; `/usr/bin/grep` + reproducer → allow; `\grep` + reproducer
+→ deny; a `git commit -m` whose *message* quotes the reproducer → allow.
+
+### Phase 2 — Guard 2: cgroup RSS cap (fail-soft)
+
+`ulimit -v` is rejected by Phase 0 measurement. Ship a cgroup v2 cap instead.
+
+Verified feasible on this box: cgroup v2 (`cgroup2fs`), the parent `app.slice` has
+`subtree_control=memory pids`, and a probe `mkdir` + `echo … > memory.max` succeeded and was
+readable back. No `sudo` required (the Bash tool has none).
+
+Cap value from measurement: heaviest real workload is `tsc --noEmit` at **2.45 GB** peak RSS
+(66 s); full vitest peaks at **898 MB**. A **12 GB** cap is ~4.9× the heaviest observed
+workload while bounding a runaway to ~38% of the 31 GB box — the reproducer would have died
+there instead of reaching 9.5 GB and climbing.
+
+Applied idempotently and **fail-soft** at SessionStart: any error (no delegation, controller
+absent, write refused) logs and continues. A guard that can block a session is worse than the
+bug it prevents.
+
+**Known residual, to be stated in the PR body:** under a cap the blowup dies by **SIGSEGV**
+after ~45 s at 2.7 GB (measured at a 3 GB cap) — ugrep does not handle allocation failure
+gracefully. Guard 2 bounds damage; it does not prevent 45 s of 100% CPU. Guard 1 is the real fix.
+
+### Phase 3 — Rule + learning
+
+- New hard rule in `AGENTS.md` (index pointer) + `AGENTS.rules.md` (body), annotated
+  `[hook-enforced: guardrails.sh guardrails:block-catastrophic-grep-repeat]`, following
+  `cq-agents-md-why-single-line` and `cq-rule-ids-are-immutable`. **Budget verified:** the
+  authority (`python3 scripts/lint-agents-rule-budget.py AGENTS.md AGENTS.rules.md`) reports
+  `[OK] B_ALWAYS=42547` against the 46000 cap — ~3.4 kB headroom, so the rule fits. Re-run
+  after the edit.
+- Learning file under `knowledge-base/project/learnings/` documenting the diagnosis chain,
+  **including the `COMMAND 2.1.220` red herring** — the reason this survived multiple crashes
+  un-diagnosed — and both measured corrections (alternation is not the trigger; `ulimit -v` is
+  incompatible with V8/WASM).
+
+## Acceptance Criteria
+
+### Pre-merge
+
+1. `bash .claude/hooks/guardrails.test.sh` passes, including all eight cases in Phase 1.
+2. The reproducer, submitted as a Bash payload, returns `permissionDecision: "deny"`.
+3. `.{0,8}(NEVER|MUST NOT)` and `.{0,10000}foo` both return no decision (allow) — the guard is
+   not the noisy "bounded + alternation" rule that was originally prescribed.
+4. A `git commit -m` payload whose message quotes the reproducer returns allow (no
+   false-positive on documentation of the pattern).
+5. `python3 scripts/lint-agents-rule-budget.py AGENTS.md AGENTS.rules.md 2>&1` reports `[OK]`
+   after the rule lands (stderr captured — WARN/REJECT print there).
+6. `bash scripts/test-all.sh` is green, modulo the pre-existing failure recorded below.
+7. Guard 2 verification, all three: (a) the cap is applied and `memory.max` reads back the
+   intended value; (b) `cd apps/web-platform && ./node_modules/.bin/vitest run test/` passes
+   **under the cap** — the check `ulimit -v` failed; (c) a deliberate hog dies at the cap while
+   the session survives.
+8. Guard 2 fail-soft: with cgroup writes forced to fail, the session still starts.
+
+### Pre-existing (not introduced here)
+
+Baseline `vitest run test/` on this worktree's merge-base reports **1 failed / 12702 passed /
+354 skipped**. The single failure is pre-existing on `origin/main` and out of scope; per
+`wg-when-tests-fail-and-are-confirmed-pre` it must be identified by name in the PR body and,
+if not already tracked, filed.
+
+## Observability
+
+```yaml
+liveness_signal:
+  what: guardrails.sh emit_incident "guardrails-block-catastrophic-grep-repeat" deny
+  cadence: on each blocked invocation
+  alert_target: existing incident ledger (lib/incidents.sh), weekly rule-usage aggregator
+  configured_in: .claude/hooks/guardrails.sh
+error_reporting:
+  destination: incident ledger; hook stderr
+  fail_loud: Guard 1 fails closed (deny on match). Guard 2 fails OPEN by design —
+    a cap that cannot be applied must never block a session.
+failure_modes:
+  - mode: guard blocks a legitimate grep (false positive)
+    detection: deny incidents for this rule id in the ledger
+    alert_route: weekly aggregator; threshold breach → retune the cost model
+  - mode: guard misses a blowup shape (false negative)
+    detection: Guard 2 cap hit; process dies at memory.max
+    alert_route: cgroup memory.events oom counter
+  - mode: cgroup cap unapplied (no delegation)
+    detection: SessionStart logs the fail-soft branch
+    alert_route: session log
+logs:
+  where: incident ledger + hook stderr (local, operator machine)
+  retention: as per existing ledger rotation
+discoverability_test:
+  # CORRECTED at /work. The originally planned probe used a single-quoted
+  # `printf` whose `\"` sequences printf itself unescapes, emitting INVALID
+  # JSON. guardrails.sh's jq extraction then fails and falls back to
+  # COMMAND="" — so every guard no-ops and the probe returns empty. As
+  # written it could never have produced a deny, for ANY rule: a fail-open
+  # verification. Build the payload with jq so the quoting is machine-made.
+  command: >-
+    jq -nc --arg c 'grep -noE ".{0,80}(a|b)[^.]{0,120}" f.md'
+    '{tool_name:"Bash",tool_input:{command:$c}}'
+    | bash .claude/hooks/guardrails.sh
+  expected_output: JSON with permissionDecision "deny"
+```
+
+No SSH anywhere; both guards are local to the operator machine.
+
+## Domain Review
+
+**Domains relevant:** none
+
+Infrastructure/tooling change confined to agent-harness guardrails on the operator's own
+machine. No user-facing surface, no data model, no vendor, no UI file in Files to Edit — the
+Product/UX mechanical override does not fire.
+
+## Architecture Decision (ADR/C4)
+
+No ADR. This adds a guardrail rule to an existing hook and a local resource cap; it establishes
+no new ownership boundary, substrate, or trust boundary.
+
+**C4:** checked all three of `model.c4`, `views.c4`, `spec.c4` for impact — the change adds no
+external human actor (operator is already modeled), no external system or vendor, no container
+or data store, and no actor↔surface access relationship. Local process-control on an existing
+developer-harness surface. No C4 edit required.
+
+## Encryption Posture
+
+Not applicable — no persistent store and no new cross-component connection.
+
+## Files to Edit
+
+- `.claude/hooks/guardrails.sh` — add the rule + its prose-rule comment
+- `.claude/hooks/guardrails.test.sh` — add the eight fixtures
+- `AGENTS.md` — index pointer
+- `AGENTS.rules.md` — rule body
+- Guard 2: SessionStart hook + an idempotent cap script (exact paths resolved at `/work` after
+  reading the SessionStart wiring)
+
+## Files to Create
+
+- `knowledge-base/project/learnings/2026-08-01-<topic>.md` (date chosen at write time)
+
+## Open Code-Review Overlap
+
+None — no open `code-review` issue references `guardrails.sh`, `AGENTS.rules.md`, or the
+SessionStart hook path.
+
+## Risks & Mitigations
+
+- **Guard 1 false positives.** ~~Mitigated by the measured threshold (nothing under 441
+  product is blocked)~~ — REFUTED. 441 is the datapoint review showed to be a BLOWUP, and
+  the false-positive class was far larger than this mitigation assumed (22 benign call
+  sites in this repo under the original model). See the STATUS banner.
+- **Guard 2 breaks the toolchain.** This is precisely what `ulimit -v` would have done — the
+  reason it is rejected. The cgroup cap is validated against a real vitest run (AC7b) before
+  merge, not assumed.
+- **Guard 2 invasiveness.** Applying a cgroup to the live Claude Code process tree touches
+  process supervision under the terminal's scope. Fail-soft on every error; never modify the
+  terminal's own scope.
+
+## Sharp Edges
+
+- A guard scanning `$SCAN` instead of `$COMMAND` silently never fires — the pattern lives
+  inside quotes, which `strip_command_bodies` blanks. This is the single easiest way to ship a
+  guard that tests green in principle and protects nothing; assert the deny path, not just the
+  allow path.
+- `\grep` is not an escape hatch. Backslash suppresses alias expansion, not function lookup.
+- Do not "verify" Guard 2 by re-running the reproducer uncapped. It will take the machine down
+  again. Every probe in this plan ran under `ulimit -v` + `timeout`, and the plan's own
+  measurements were obtained that way.
+- A single bounded repeat, however large, is cheap. Blocking on one bound would be pure noise.


### PR DESCRIPTION
Preserves the knowledge from #7151, which is being **closed unmerged** because both guards it built were broken. Documentation only — no product code, no hooks, no config.

## Why #7151 is not merging

Two guards were built, fully tested (74/74 and 26/26), mutation-tested twice (10/10 and 7/7 killed), shellcheck clean, and green on a 243/243 full suite. An 8-agent review established that neither worked.

**Guard 1's cost model was refuted three times**, each time by measurement, and each model *felt settled because it was measured* — against fixtures its own author chose.

| # | Model | Refuted by |
|---|---|---|
| 1 | bounded repeat AND alternation | Wrong on both sides (plan phase) |
| 2 | ∏(upper+1) ≥ 500 | Denies UUIDs, ISO timestamps and the conflict-marker regex inside `guardrails.sh` itself; allows a real blowup at product 289 |
| 3 | ∏(upper+1) ≥ 150 over a *wide* atom | Positive classes of any width blow up when the literal is reachable |

The third is decisive. Same pattern, same bound product — the only variable is the corpus:

| Pattern | Literal present? | Peak RSS |
|---|---|---|
| `[0-9]{0,80}x[0-9]{0,120}` | no | 7.3 MB |
| `[0-9]{0,80}5[0-9]{0,120}` | **yes** | **1.67 GB — killed** |
| `[a-z]{0,80}q[a-z]{0,120}` | yes | **killed** |

The first row was the fixture used to *prove* narrow classes are cheap. Cost is class size × bound magnitude × literal reachability against a file the hook has not read — not a threshold to retune, a missing variable.

Guard 1 also left seven forms ungated (`$(grep …)`, backtick, subshell, `$VAR`, `eval`, `-f patternfile`), including the most common agent idiom.

**Guard 2 never executed once** — committed `100644`, so every SessionStart died at `exec` with 126. Nothing could catch it: the suite and `test-all.sh` both run `bash "$HOOK"`, which ignores the mode bit, and the live AC verification went through that same path. When run manually it escaped the terminal's kill switch, capped above the 9.5 GB harm point, left swap uncapped, and had no aggregate bound.

## What this PR keeps

- The **diagnosis chain** — the shim → `argv[0]=ugrep` → DFA blowup mechanism, and the `ps`-names-it-`2.1.220` red herring that kept it un-root-caused across multiple crashes.
- **All measurements**, including the ones that refuted the author's own models.
- The **transferable lesson**: a calibration ladder is only as good as the axis you forgot to vary.
- That a guard can be green everywhere and still never run, and that verification must go through the invocation production uses.

## Follow-ups

- #7165 — the `updatedInput` rewrite-to-`command grep` design (replaces classification entirely)
- #7166 — the memory backstop on `StartTransientUnit` + a shared `soleur-agents.slice`
- #7164 — a confirmed pre-existing RCE in the hook input parsing (10 files, independent of this work)

## Operator exposure

**Unchanged.** The mechanism is understood; no guard is in place. The follow-ups carry the candidate designs.

## Net-issue-flow

<!-- gate-override: net-issue-flow -->

Files 3, closes 0. Deliberate, and none is foldable inline:

- **#7164** — a pre-existing RCE across 10 hooks, present on `main` before this work and unrelated to it. A documentation PR is the wrong vehicle for a security fix to the hook input layer; it needs its own change with its own fixtures.
- **#7165** — replaces a classification approach that measurement refuted three times. Folding a fourth model in here, under merge pressure, is precisely the failure this PR exists to record.
- **#7166** — a systemd `StartTransientUnit` redesign with five open decisions (cap value, `memory.high` vs `memory.max`, swap bound, OOM victim selection, aggregate slice). Far past the <=100-line / <=4-file auto-flip.

The counterfactual is worse: this PR exists *because* #7151 is being closed unmerged, so the alternative to filing is losing the diagnosis and all three refuted models entirely.
