### PR TITLE
fix(hooks): repair A9 — the designated-responder gate could never fail

### DIFF
--- a/.claude/hooks/hook-input-contract.test.sh
+++ b/.claude/hooks/hook-input-contract.test.sh
@@ -379,23 +379,55 @@ a8_envelope_pairing() {
 # `Write|Edit` and `Write|Edit|MultiEdit|NotebookEdit` are different strings
 # that both fire on a Write.
 a9_designated_responder() {
-  local settings="$REPO_ROOT/.claude/settings.json"
+  local settings="$SCRIPT_DIR/../settings.json"
   if [[ ! -f "$settings" ]]; then bad "A9 .claude/settings.json not found"; return; fi
-  local uncovered
-  uncovered="$(jq -r --args '
-    [ .hooks.PreToolUse[]
-      | . as $e
-      | ($e.matcher // "") as $m
-      | ($e.hooks[].command | sub(".*/";"")) as $c
-      | select($ARGS.positional | index(($c | sub("\\.sh$";""))))
-      | ($m | split("|"))[]
-    ] | unique as $needed
-    | [ .hooks.PreToolUse[]
-        | select([.hooks[].command | sub(".*/";"")] | index("guardrails.sh"))
-        | (.matcher // "" | split("|"))[]
-      ] | unique as $covered
-    | ($needed - $covered) | join(",")
-  ' "$settings" "${INSCOPE20[@]}" 2>/dev/null || echo "<jq-fail>")"
+
+  # The first version of this assertion COULD NOT FAIL, and it guarded the
+  # invariant the whole designated-responder design rests on.
+  #
+  # It passed the settings path as `jq -r --args '<prog>' "$settings" "${INSCOPE20[@]}"`.
+  # With `--args`, EVERY remaining argument becomes a positional string — the
+  # filename included — so jq never opened the file, read empty stdin, emitted
+  # nothing and exited 0. `uncovered` was always "" and `want "" ""` always
+  # passed. Measured: deleting `.hooks.PreToolUse` outright, and removing
+  # guardrails.sh from the Bash matcher (leaving 17 migrated hooks with NO
+  # responder), both left the suite fully green.
+  #
+  # That is the same defect class this file exists to prevent — a check that
+  # reports success having asserted nothing — so it gets the same treatment the
+  # rest of the suite gets: feed the document on stdin, bind the hook list with
+  # --argjson, and prove non-vacuity before trusting the result.
+  local in20 out needed uncovered
+  in20="$(printf '%s\n' "${INSCOPE20[@]}" | jq -Rsc 'split("\n") - [""]')"
+  out="$(jq -r --argjson in20 "$in20" '
+    . as $d
+    | ([ $d.hooks.PreToolUse[] | . as $e
+         | ($e.hooks[].command | sub(".*/";"") | sub("\\.sh$";"")) as $c
+         | select($in20 | index($c))
+         | (($e.matcher // "") | split("|"))[] ] | unique) as $needed
+    | ([ $d.hooks.PreToolUse[]
+         | select([.hooks[].command | sub(".*/";"")] | index("guardrails.sh"))
+         | ((.matcher // "") | split("|"))[] ] | unique) as $covered
+    | "\($needed | length)\t\(($needed - $covered) | join(","))"
+  ' < "$settings" 2>/dev/null)" || out=""
+
+  if [[ -z "$out" ]]; then
+    # jq errored (malformed settings, PreToolUse absent). NOT a pass — the
+    # old form turned exactly this into silence.
+    bad "A9 could not evaluate .claude/settings.json — refusing to read a jq failure as coverage"
+    return
+  fi
+  needed="${out%%$'\t'*}"
+  uncovered="${out#*$'\t'}"
+
+  # Positive control: if no migrated hook is registered at all, the difference
+  # is trivially empty and the assertion proves nothing.
+  if [[ "${needed:-0}" -lt 1 ]]; then
+    bad "A9 non-vacuity control failed: zero matchers resolved for the ${#INSCOPE20[@]} in-scope hooks" \
+        "settings.json registers none of them — the coverage check would pass vacuously"
+    return
+  fi
+  ok "A9 non-vacuity control: $needed matcher(s) resolved for the in-scope hooks"
   want "A9 every tool triggering a migrated hook also triggers guardrails.sh" "" "$uncovered"
 }
 
@@ -450,7 +482,7 @@ a11_mechanism_ban() {
 # A13 — per-file source hygiene across all 20 in-scope hooks.
 # ===========================================================================
 a13_source_hygiene() {
-  local hook f n bad_src=() missing=()
+  local hook f n bad_src=() missing=() missing_call=()
   for hook in "${INSCOPE20[@]}"; do
     f="$SCRIPT_DIR/$hook.sh"
     n="$(grep -cE 'source .*lib/hook-input\.sh' "$f" || true)"
@@ -458,6 +490,18 @@ a13_source_hygiene() {
     # Fail-soft source is defect 2 one line above where every test points.
     grep -E 'source .*lib/hook-input\.sh' "$f" | grep -qE '\|\|[[:space:]]*(true|:)|2>/dev/null' \
       && bad_src+=("$hook")
+    # The `source` line alone is NOT the contract. A mutation battery showed
+    # that DELETING the entire `if ! hook_parse_input … fi` block from a hook
+    # left this suite fully green while the hook exited 0, wrote no incident
+    # row, and ran every guard it owns against an empty command — defect 2
+    # restored verbatim. Twelve of these twenty hooks have sibling suites that
+    # never mention the input contract, so for them a grep for the word
+    # `source` was the only thing standing between the fix and silent
+    # regression. Assert the three call-site verbs too.
+    local v
+    for v in hook_parse_input hook_input_report hook_input_should_ask; do
+      [[ "$(grep -cE "(^|[^A-Za-z_])${v}\b" "$f")" -ge 1 ]] || missing_call+=("$hook:$v")
+    done
   done
   if (( ${#missing[@]} == 0 )); then
     ok "A13 all ${#INSCOPE20[@]} in-scope hooks source the helper exactly once"
@@ -468,6 +512,11 @@ a13_source_hygiene() {
     ok "A13 every helper source is FAIL-HARD (no '|| true', '|| :', '2>/dev/null')"
   else
     bad "A13 fail-soft source found — leaves hook_parse_input undefined" "${bad_src[@]}"
+  fi
+  if (( ${#missing_call[@]} == 0 )); then
+    ok "A13 every in-scope hook invokes parse + report + should_ask at its call site"
+  else
+    bad "A13 hook(s) source the helper but never call it — the parse gate is absent" "${missing_call[@]}"
   fi
 }
 


### PR DESCRIPTION
## The gate that could never fail

`test-design-reviewer` returned **after** #7168 merged and ran a 22-mutation battery against the
merged tree. A9 guarded the invariant the entire designated-responder design rests on, and it was
structurally incapable of failing:

```bash
jq -r --args '<prog>' "$settings" "${INSCOPE20[@]}"
```

With `--args`, **every** remaining argument becomes a positional string — the **filename included**.
jq never opened `settings.json`, read empty stdin, emitted nothing, exited 0. `uncovered` was always
`""`, so `want "" ""` always passed.

**Measured against the merged tree — both of these left the suite fully green:**

| Mutation | Before | After |
|---|---|---|
| delete `.hooks.PreToolUse` entirely | SURVIVED | **CAUGHT** — refuses to read a jq failure as coverage |
| remove `guardrails.sh` from the `Bash` matcher (17 migrated hooks left with **no responder**) | SURVIVED | **CAUGHT** — names the uncovered matcher |
| delete a hook's whole `if ! hook_parse_input … fi` block | SURVIVED | **CAUGHT** — names the hook and missing verb |

The second is ADR-157's exact failure mode: 19 hooks report-and-exit *because* `guardrails.sh` is
wired to the same matcher and emits the one prompt. If it isn't, an unparseable payload produces
**zero** prompts, silently.

This is the same defect class the file exists to prevent — a check reporting success having asserted
nothing — so it gets the same treatment: document on stdin, hook list via `--argjson`, and a
**non-vacuity control** before the result is trusted. A jq failure is now an explicit `bad`, never
silence; a run where zero matchers resolve fails loudly rather than comparing two empty sets. (A
second latent bug goes with the rewrite: the old program rebound `.` to an intermediate array, so
even fed correctly its second half would have errored.)

**The production invariant does hold** — `needed == covered == [Bash, Edit, MultiEdit, NotebookEdit,
Write]`. This was an unarmed smoke detector in a house that is not on fire.

## Second finding, same commit

A13 grepped only for the `source` line. **Deleting an entire parse block** from a hook left the suite
green while that hook exited 0, wrote no incident row, and ran every guard it owns against an empty
command — **defect 2 restored verbatim**. Twelve of the twenty hooks have sibling suites that never
mention the input contract, so for them a grep for the word `source` was the only thing between the
fix and silent regression. A13 now asserts the three call-site verbs.

## Verification

- Contract suite **50/50** at baseline and after restore
- All three previously-surviving mutations now **CAUGHT**, each by a *relevant* assertion label
- `shellcheck -s bash -x -P .claude/hooks -P .claude/hooks/lib`: **0 findings**
- ADR-129 trap-ownership lint: clean

## Not in scope

The remaining eight findings — chiefly that **exit codes are asserted nowhere** (`exit 2` *is* the
deny channel), that **A3's absence assertion has no per-hook reachability control** (inserting
`exit 0` into 9 of 10 hooks still reports "no attacker-named command executed"), and that several
properties claimed over 20 hooks are instantiated on **1** — are filed as **#7190**, each with the
mutation that demonstrates it.

Ref #7164

🤖 Generated with [Claude Code](https://claude.com/claude-code)
