### PR TITLE
fix(ci): the one image we exec as root was the only mirror not preserving digests

### DIFF
--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -19,12 +19,23 @@ on:
   # for a CVE base-image rebuild of an already-released version). It takes the
   # tag name as `ref` — NOT a free-form version — so it can never mint a
   # tagless image that blinds the cloud-init drift-guard (#4692 / #4676 AC6).
+  #
+  # CAUTION on the default (rebuild) path: it re-runs `docker build` and pushes the SAME
+  # tag, so the tag's GHCR digest MOVES. Anything pinning that tag by @sha256 —
+  # cloud-init-inngest.yml pins the dedicated host's payload — is pinned to bytes the tag
+  # no longer points at. Use `mirror_only` when the goal is only to get an already-published
+  # tag onto zot; it cannot move a digest because it never builds.
   workflow_dispatch:
     inputs:
       ref:
         description: 'Existing vinngest-vX.Y.Z tag to (re)publish (e.g., vinngest-v1.1.11)'
         required: true
         type: string
+      mirror_only:
+        description: 'Backfill only: crane-copy the EXISTING GHCR manifest to zot, no rebuild (digest-preserving)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -144,7 +155,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Skipped entirely under `mirror_only`. Not an optimisation: a rebuild re-pushes the
+      # same tag and MOVES its GHCR digest, which is the one thing a digest backfill must
+      # not do. `crane copy` reads the published manifest from GHCR, so the local image this
+      # step would produce is not needed for the mirror.
       - name: Build + verify + push
+        if: ${{ !inputs.mirror_only }}
         env:
           IMAGE: ghcr.io/jikig-ai/soleur-inngest-bootstrap
           TAG: ${{ steps.tag.outputs.tag }}
@@ -217,13 +233,29 @@ jobs:
           docker push "$IMAGE:$TAG"
           echo "Pushed $IMAGE:$TAG"
 
-      # --- #6122 (ADR-096) Phase 2: dual-push the inngest-bootstrap image to the self-hosted
-      # zot registry. The plain `docker build`/`docker push` above leaves the image in the
-      # runner's local docker, so `docker tag` + `docker push 127.0.0.1:5000/...` mirrors it
-      # over the CF Tunnel bridge directly (no crane/buildx-localhost issue). GHCR push stays
-      # primary (break-glass through the Phase-5 soak). Additive: a zot/bridge failure must not
-      # fail the GHCR release (bridge continue-on-error; teardown if:always()). This image is
-      # NOT cosign-signed (no id-token perm) — parity with the GHCR side, no sign step.
+      # --- #6122 (ADR-096) Phase 2: mirror the inngest-bootstrap image to the self-hosted
+      # zot registry, DIGEST-PRESERVING (#7144 finding 2).
+      #
+      # This was `docker tag` + `docker push`, chosen because the build leaves the image in
+      # the runner's local docker so re-pushing over the CF Tunnel bridge needed no extra
+      # tooling. That convenience was the defect: docker re-uploads and re-creates the
+      # manifest, so zot served a DIFFERENT digest than GHCR for the same tag — silently,
+      # because nothing compared them.
+      #
+      # It matters because cloud-init.yml's web-host arm substitutes the zot ref INTO $IREF
+      # (`if docker pull "$ZIREF"; then IREF="$ZIREF"`) and then execs that payload AS ROOT.
+      # An unpinnable zot copy therefore left the root-executed path on a mutable tag, and
+      # pinning only the GHCR literal would not have closed it. ADR-155 named this as the
+      # blocker for its Alternative C; #7144 finding 2 inherits it.
+      #
+      # `crane copy` is registry->registry and preserves the manifest bytes, so a single
+      # @sha256 resolves on BOTH registries. That is also what makes `mirror_only` possible:
+      # backfilling an already-published tag no longer needs — or is permitted — a rebuild.
+      #
+      # GHCR push stays primary (break-glass through the Phase-5 soak). Additive on the BUILD
+      # path: a zot/bridge failure must not fail the GHCR release (bridge continue-on-error;
+      # teardown if:always()). This image is NOT cosign-signed (no id-token perm) — parity
+      # with the GHCR side, no sign step.
       - name: Bridge to zot registry (CF Tunnel)
         id: zot_bridge
         continue-on-error: true
@@ -237,7 +269,7 @@ jobs:
           cloudflared-version: "2026.5.0"
           cloudflared-sha256: "0095e46fdc88855d801c4d304cb1f5dd4bd656116c47ab94c2ad0ae7cda1c7ec"
 
-      - name: Mirror inngest image GHCR→zot (docker tag + push)
+      - name: Mirror inngest image GHCR→zot (crane, digest-preserving)
         id: zot_mirror
         if: steps.zot_bridge.outcome == 'success'
         # The continue-on-error marker below is BELT: the zot mirror is a SECONDARY/shadow
@@ -245,12 +277,21 @@ jobs:
         # pull-side fallback), so a mirror failure must NEVER red this build. #6274:
         # a transient `connection reset` mid blob-upload over the CF-tunnel bridge
         # was failing the whole job. Sibling of reusable-release.yml's mirror step.
-        continue-on-error: true
+        #
+        # BELT OFF under mirror_only: there the mirror is not a secondary copy alongside a
+        # release, it IS the deliverable, and a silent degrade would hand back a green run
+        # whose whole purpose (zot serving the GHCR digest) did not happen. Same reasoning
+        # as the degrade path itself — a success code that fires regardless of success is
+        # the failure mode this PR exists to remove.
+        continue-on-error: ${{ !inputs.mirror_only }}
         env:
           IMAGE: ghcr.io/jikig-ai/soleur-inngest-bootstrap
           TAG: ${{ steps.tag.outputs.tag }}
+          # Typed boolean, consumed only as a string comparison below — never interpolated
+          # into the script body.
+          MIRROR_ONLY: ${{ inputs.mirror_only }}
         run: |
-          # No `set -e` — every failure path exits 0 so this build stays green
+          # No `set -e` — on the BUILD path every failure exits 0 so this build stays green
           # (SUSPENDERS to the continue-on-error belt). A persistent miss surfaces
           # as mirror_status=degraded → ::warning:: + step summary AND (#6278) a Slack
           # ⚠️ via the "Post to Slack (inngest mirror status)" step below — degrade-only
@@ -277,20 +318,62 @@ jobs:
           degraded() {
             local rc="$1"
             echo "mirror_status=degraded" >> "$GITHUB_OUTPUT"
-            echo "::warning::zot mirror degraded for ${ZOT:-<image>} (rc=${rc}) — build UNAFFECTED (GHCR primary/break-glass); zot redundancy reduced, backfill via 'docker pull ghcr + docker push zot'. If disk-full: see SOLEUR_ZOT_DISK / Better Stack registry_disk_prd."
-            echo "⚠️ zot mirror degraded (rc=${rc}) — inngest image push failed; GHCR unaffected, backfill needed." >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::zot mirror degraded for ${ZOT:-<image>} (rc=${rc}) — build UNAFFECTED (GHCR primary/break-glass); zot redundancy reduced, backfill via the mirror_only dispatch of this workflow (crane, digest-preserving — NOT 'docker pull + docker push', which re-creates the manifest and breaks digest parity). If disk-full: see SOLEUR_ZOT_DISK / Better Stack registry_disk_prd."
+            echo "⚠️ zot mirror degraded (rc=${rc}) — inngest image mirror failed; GHCR unaffected, backfill needed." >> "$GITHUB_STEP_SUMMARY"
+            # On the BUILD path the mirror is secondary, so exit 0 and let the release stand.
+            # Under mirror_only the mirror IS the run, so a degrade must be a RED run — an
+            # exit 0 here would report success for a backfill that did not happen, and the
+            # caller would then pin a digest zot cannot serve.
+            if [ "${MIRROR_ONLY:-false}" = "true" ]; then
+              echo "::error::mirror_only backfill FAILED (rc=${rc}) — zot does not serve the GHCR digest for ${TAG}. Do not pin until this is green."
+              exit 1
+            fi
             exit 0
           }
+
+          # Install crane, SHA-pinned. Same version as build-inngest-config-bundle.yml and
+          # reusable-release.yml — keep the three in step.
+          CRANE_VERSION="v0.20.2"
+          CRANE_SHA256="c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b"
+          curl -fsSL -o /tmp/crane.tgz \
+            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" || degraded "$?"
+          echo "${CRANE_SHA256}  /tmp/crane.tgz" | sha256sum -c - || degraded "$?"
+          sudo tar -xzf /tmp/crane.tgz -C /usr/local/bin crane || degraded "$?"
+          rm -f /tmp/crane.tgz
 
           # Full org namespace (jikig-ai/…) to match the ci-deploy.sh pull path
           # (zot_ref="${ZOT_REGISTRY_URL}/${IMAGE#ghcr.io/}") + zot-entry-gate.sh. A bare
           # `soleur-inngest-bootstrap` is an orphan repo nothing reads (#6122 namespace fix).
           ZOT="127.0.0.1:5000/${IMAGE#ghcr.io/}"
-          retry docker tag "$IMAGE:$TAG" "$ZOT:$TAG" || degraded "$?"
-          retry docker push "$ZOT:$TAG" || degraded "$?"
+          # Registry -> registry, so this reads the PUBLISHED GHCR manifest and needs no
+          # local image. crane inherits both logins from ~/.docker/config.json (GHCR from
+          # docker/login-action above, zot from the bridge action).
+          retry crane copy "$IMAGE:$TAG" "$ZOT:$TAG" || degraded "$?"
+
+          # Digest parity is the entire point of using crane, so ASSERT it — do not infer it
+          # from a zero exit. An empty source digest counts as failure: `|| true` on the
+          # capture means an auth/network fault yields "", and "" == "" would otherwise read
+          # as a match and certify nothing.
+          SRC_DIGEST=$(crane digest "$IMAGE:$TAG" 2>/dev/null || true)
+          DST_DIGEST=$(crane digest "$ZOT:$TAG" 2>/dev/null || true)
+          echo "ghcr=${SRC_DIGEST:-<none>} zot=${DST_DIGEST:-<none>}"
+          echo "ghcr_digest=$SRC_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "zot_digest=$DST_DIGEST" >> "$GITHUB_OUTPUT"
+          if [ -z "$SRC_DIGEST" ] || [ "$SRC_DIGEST" != "$DST_DIGEST" ]; then
+            echo "::error::zot digest parity FAILED for $TAG — ghcr=${SRC_DIGEST:-<none>} zot=${DST_DIGEST:-<none>}. A cloud-init @sha256 pin on this tag would not resolve on zot."
+            degraded 1
+          fi
 
           echo "mirror_status=ok" >> "$GITHUB_OUTPUT"
-          echo "Pushed $ZOT:$TAG"
+          echo "Mirrored $ZOT:$TAG at $SRC_DIGEST (digest-preserving)"
+          {
+            echo "### inngest-bootstrap zot mirror"
+            echo ""
+            echo "| ref | digest |"
+            echo "| --- | --- |"
+            echo "| \`$IMAGE:$TAG\` | \`$SRC_DIGEST\` |"
+            echo "| \`$ZOT:$TAG\` | \`$DST_DIGEST\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Tear down cloudflared registry bridge
         if: always()

--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -258,7 +258,13 @@ jobs:
       # with the GHCR side, no sign step.
       - name: Bridge to zot registry (CF Tunnel)
         id: zot_bridge
-        continue-on-error: true
+        # BELT OFF under mirror_only, for the same reason as the mirror step below. The
+        # mirror is gated on `zot_bridge.outcome == 'success'`, so a soft-failed bridge
+        # SKIPS the mirror and leaves the job GREEN — under mirror_only that is a run
+        # reporting success for a backfill that never ran, and the caller would then pin a
+        # digest zot cannot serve. Belt stays ON for push/rebuild, where the bridge is
+        # secondary to the GHCR release (#6274).
+        continue-on-error: ${{ !inputs.mirror_only }}
         uses: ./.github/actions/cf-tunnel-registry-bridge
         with:
           # DOPPLER_TOKEN_PRD, NOT the generic DOPPLER_TOKEN (#6122 cutover fix): the bridge
@@ -301,8 +307,9 @@ jobs:
           set -uo pipefail
 
           # Bounded retry to self-heal a transient TCP reset over the CF-tunnel
-          # bridge. 3 attempts, 5s then 15s backoff. Idempotent ops only (docker
-          # tag is local; docker push re-runs safely).
+          # bridge. 3 attempts, 5s then 15s backoff. Idempotent ops only — `crane copy`
+          # re-runs safely (it re-resolves the source manifest and skips blobs the
+          # destination already has), as does the SHA-checked crane download.
           retry() {
             local n=1 max=3 rc=0
             local -a sleeps=(0 5 15)

--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -781,6 +781,9 @@ jobs:
       - name: Run cloud-init inngest-bootstrap pin drift-guard
         run: bash apps/web-platform/infra/cloud-init-inngest-bootstrap.test.sh
 
+      - name: Run inngest-bootstrap mirror_only false-green guard
+        run: bash apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
+
       - name: Run journald persistent-storage tests
         run: bash apps/web-platform/infra/journald-config.test.sh
 

--- a/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
+++ b/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Structural + behavioral gate for the `mirror_only` backfill path of
+# .github/workflows/build-inngest-bootstrap-image.yml (#7144 finding 2).
+#
+# WHY A DEDICATED SUITE. This workflow publishes the image cloud-init.yml's web-host arm
+# execs AS ROOT, and `mirror_only` exists so a caller can backfill an already-published tag
+# onto zot and then PIN it by @sha256. That makes exactly one property load-bearing:
+#
+#   a GREEN mirror_only run must mean "zot serves the GHCR digest for this tag".
+#
+# Every assertion below defends that biconditional from the *false-green* side, because a
+# run that reports success while mirroring nothing is what causes a pin to a digest zot
+# cannot serve — which sends every fresh boot down the GHCR-fallback branch and fires
+# `inngest_ghcr_fallback` permanently. Precedent for the failure class:
+# knowledge-base/engineering/operations/post-mortems/2026-07-29-v0244-1-published-green-with-an-unpullable-image-postmortem.md
+#
+# THE COUPLING THAT MOTIVATES (3). The mirror step is gated on
+# `steps.zot_bridge.outcome == 'success'`. A `continue-on-error: true` bridge therefore
+# SOFT-FAILS into a SKIPPED mirror and a GREEN job — the belt-off on the mirror step alone
+# does not close it, because a skipped step never reaches its own degrade path. Both steps
+# must drop the belt under mirror_only, or the guarantee above is false.
+#
+# EVERY structural assertion parses the file as YAML, never greps it. This file's own
+# header names `continue-on-error`, `mirror_only` and `crane copy` at length, and the
+# workflow's does the same — a bare grep matches the prose describing the property and
+# passes vacuously (cq-assert-anchor-not-bare-token).
+#
+# The behavioral leg EXECUTES the workflow's own extracted `degraded()` — the real function
+# body, not a model of it — under both MIRROR_ONLY values.
+set -euo pipefail
+
+WF=".github/workflows/build-inngest-bootstrap-image.yml"
+[[ -f "$WF" ]] || { echo "FAIL - $WF not found (run from the repo root)"; exit 1; }
+
+pass=0
+fail=0
+ok() { pass=$((pass + 1)); printf 'ok   - %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf 'FAIL - %s\n' "$1"; }
+
+python3 -c 'import yaml' 2>/dev/null || pip3 install --quiet pyyaml
+
+SCRATCH="$(mktemp -d -t ib-mirror.XXXXXXXX)"
+trap 'rm -rf "$SCRATCH"' EXIT INT TERM HUP
+
+# --- structural assertions, parsed as YAML ------------------------------------------------
+# The python leg writes one TSV verdict per line; bash reports them. Same split as the
+# sibling workflow suites (workspaces-luks-cutover-workflow.test.sh).
+python3 - "$WF" "$SCRATCH" > "$SCRATCH/verdicts.tsv" <<'PY'
+import sys, yaml
+
+wf = yaml.safe_load(open(sys.argv[1]))
+scratch = sys.argv[2]
+verdicts = []
+
+def check(name, cond, detail=""):
+    # Strip tabs/newlines: the bash reader splits on tabs, so an embedded one in a YAML
+    # value would desync the loop and manufacture a phantom verdict.
+    d = str(detail)[:200].replace("\t", " ").replace("\n", " ").replace("\r", " ")
+    verdicts.append(("ok" if cond else "FAIL", name.replace("\t", " "), d))
+
+# PyYAML parses the bare `on:` key as the boolean True (YAML 1.1). Accept either.
+on = wf.get("on", wf.get(True)) or {}
+inputs = ((on.get("workflow_dispatch") or {}).get("inputs")) or {}
+
+mo = inputs.get("mirror_only")
+check("workflow_dispatch declares a mirror_only input", isinstance(mo, dict), sorted(inputs))
+if isinstance(mo, dict):
+    # Typed boolean, not string: a string input makes every falsy caller value ("false",
+    # "") a TRUTHY GHA expression, which would silently skip the build on the release path.
+    check("mirror_only is type boolean", mo.get("type") == "boolean", mo.get("type"))
+    check("mirror_only defaults to false", mo.get("default") is False, repr(mo.get("default")))
+    check("mirror_only is not required (release path omits it)",
+          mo.get("required") in (False, None), repr(mo.get("required")))
+
+steps = ((wf.get("jobs") or {}).get("build") or {}).get("steps") or []
+by_id = {s.get("id"): s for s in steps if s.get("id")}
+named = {str(s.get("name", "")): s for s in steps}
+
+# EXACT-STRING equality throughout. The risk on every one of these is OPERAND INVERSION
+# (`inputs.mirror_only` where `!inputs.mirror_only` belongs), and an inversion is invisible
+# to a substring check while flipping the meaning completely.
+GUARD = "${{ !inputs.mirror_only }}"
+
+build = next((s for s in steps if str(s.get("name", "")).startswith("Build + verify + push")), None)
+check("build step exists", build is not None)
+if build:
+    # (2) The rebuild must not run under mirror_only: `docker build` + push of the SAME tag
+    # MOVES the tag's GHCR digest, which is the one thing a digest backfill must not do.
+    check("build step is skipped under mirror_only (exact !inputs.mirror_only)",
+          build.get("if") == GUARD, repr(build.get("if")))
+
+bridge = by_id.get("zot_bridge")
+check("zot_bridge step exists", bridge is not None)
+if bridge:
+    # (3) THE COUPLING. See the header. A hardcoded `true` here re-opens the false-green.
+    check("zot_bridge drops continue-on-error under mirror_only (exact !inputs.mirror_only)",
+          bridge.get("continue-on-error") == GUARD, repr(bridge.get("continue-on-error")))
+
+mirror = by_id.get("zot_mirror")
+check("zot_mirror step exists", mirror is not None)
+if mirror:
+    check("zot_mirror drops continue-on-error under mirror_only (exact !inputs.mirror_only)",
+          mirror.get("continue-on-error") == GUARD, repr(mirror.get("continue-on-error")))
+    # Asserted so the coupling that makes (3) load-bearing cannot be silently removed:
+    # if this gate ever goes away, the bridge belt stops mattering and this suite would
+    # otherwise keep passing while guarding a property that no longer exists.
+    check("zot_mirror is gated on zot_bridge succeeding (the coupling behind the belt-off)",
+          mirror.get("if") == "steps.zot_bridge.outcome == 'success'", repr(mirror.get("if")))
+
+    env = mirror.get("env") or {}
+    check("MIRROR_ONLY reaches the script via env:, not interpolation",
+          env.get("MIRROR_ONLY") == "${{ inputs.mirror_only }}", repr(env.get("MIRROR_ONLY")))
+
+    body = mirror.get("run") or ""
+    open(f"{scratch}/mirror-body.sh", "w").write(body)
+
+    # (1) crane copy replaces docker tag+push. Registry->registry preserves the manifest
+    # bytes, so ONE @sha256 resolves on both registries; `docker tag`+`push` re-creates the
+    # manifest and was the original defect.
+    check("mirror uses `crane copy` for the GHCR->zot hop", "crane copy" in body)
+    check("no `docker push` to the zot ref survives", 'docker push "$ZOT' not in body)
+    check("no `docker tag` to the zot ref survives", 'docker tag "$IMAGE:$TAG" "$ZOT' not in body)
+    check("crane tarball is SHA-pinned before extraction", "sha256sum -c -" in body)
+
+    # (2 of the parity assertion) An EMPTY source digest must count as failure. `|| true` on
+    # the capture means an auth/network fault yields "", and "" == "" would otherwise read
+    # as a match and certify nothing.
+    check("parity check treats an EMPTY source digest as failure",
+          '-z "$SRC_DIGEST"' in body, "expected a -z guard on SRC_DIGEST")
+    check("parity check compares the two digests",
+          '"$SRC_DIGEST" != "$DST_DIGEST"' in body)
+    # Ordering matters: a `mirror_status=ok` written before the comparison would certify
+    # the run regardless of the verdict.
+    if "mirror_status=ok" in body and '-z "$SRC_DIGEST"' in body:
+        check("mirror_status=ok is written AFTER the parity check, not before",
+              body.index('-z "$SRC_DIGEST"') < body.index("mirror_status=ok"))
+
+    # (4) degraded() must exit 1 under mirror_only. Asserted structurally here and
+    # EXECUTED in the behavioral leg below.
+    check("degraded() has a mirror_only arm", 'MIRROR_ONLY:-false' in body)
+
+with open(f"{scratch}/verdicts.tsv", "w") as fh:
+    for status, name, detail in verdicts:
+        fh.write(f"{status}\t{name}\t{detail}\n")
+PY
+
+while IFS=$'\t' read -r status name detail; do
+  [[ -n "${status:-}" ]] || continue
+  if [[ "$status" == "ok" ]]; then ok "$name"; else no "$name${detail:+ — got $detail}"; fi
+done < "$SCRATCH/verdicts.tsv"
+
+# --- behavioral leg: run the workflow's OWN degraded(), both modes -------------------------
+# Structural assertion (4) proves the arm is present; only execution proves it EXITS. The
+# whole point of the arm is the exit code, and a `return 1` or a misplaced `fi` would keep
+# every structural check green while handing back a green run.
+BODY="$SCRATCH/mirror-body.sh"
+if [[ ! -s "$BODY" ]]; then
+  no "mirror step run body could not be extracted (behavioral leg skipped)"
+else
+  bash -n "$BODY" && ok "extracted mirror body parses as bash" || no "extracted mirror body is not valid bash"
+
+  # Extract just the degraded() definition, by brace matching on the closing line at the
+  # function's own indentation. Running the full body would need a live registry.
+  python3 - "$BODY" "$SCRATCH/degraded.sh" <<'PY'
+import sys, re
+lines = open(sys.argv[1]).read().splitlines()
+start = next(i for i, l in enumerate(lines) if re.match(r"^(\s*)degraded\(\)\s*\{", l))
+indent = re.match(r"^(\s*)", lines[start]).group(1)
+end = next(i for i in range(start + 1, len(lines)) if lines[i] == f"{indent}}}")
+open(sys.argv[2], "w").write("\n".join(lines[start:end + 1]) + "\n")
+PY
+
+  run_degraded() {
+    # Subshell so `exit` inside degraded() ends only this invocation. GITHUB_* point at
+    # scratch files because the real function appends to both.
+    (
+      set -uo pipefail
+      GITHUB_OUTPUT="$SCRATCH/out.$1"; GITHUB_STEP_SUMMARY="$SCRATCH/sum.$1"
+      export GITHUB_OUTPUT GITHUB_STEP_SUMMARY
+      : > "$GITHUB_OUTPUT"; : > "$GITHUB_STEP_SUMMARY"
+      MIRROR_ONLY="$1" TAG="vinngest-v0.0.0-test" ZOT="127.0.0.1:5000/test/image"
+      export MIRROR_ONLY TAG ZOT
+      # shellcheck source=/dev/null
+      source "$SCRATCH/degraded.sh"
+      degraded 7
+    ) >"$SCRATCH/log.$1" 2>&1
+  }
+
+  # BUILD path: the mirror is secondary to the GHCR release, so a degrade must NOT red it.
+  if run_degraded false; then
+    ok "degraded() exits 0 on the build path (mirror is secondary; release stands)"
+  else
+    no "degraded() exited non-zero with MIRROR_ONLY=false — this would red every release on a transient mirror fault"
+  fi
+  grep -q "mirror_status=degraded" "$SCRATCH/out.false" \
+    && ok "degraded() records mirror_status=degraded on the build path" \
+    || no "degraded() did not write mirror_status=degraded (the Slack degrade step keys on it)"
+
+  # mirror_only: the mirror IS the run. A zero exit here is the false-green this file exists
+  # to prevent — it would certify a backfill that did not happen and license a bad pin.
+  if run_degraded true; then
+    no "degraded() exited 0 with MIRROR_ONLY=true — a failed backfill would report SUCCESS and license a pin to a digest zot cannot serve"
+  else
+    ok "degraded() exits non-zero under mirror_only (a failed backfill reds the run)"
+  fi
+  grep -q "::error::" "$SCRATCH/log.true" \
+    && ok "degraded() emits an ::error:: annotation under mirror_only" \
+    || no "degraded() emitted no ::error:: under mirror_only"
+fi
+
+echo ""
+echo "passed: $pass  failed: $fail"
+(( fail == 0 )) || exit 1


### PR DESCRIPTION
## Why

`build-inngest-bootstrap-image.yml` mirrored GHCR→zot with `docker tag` + `docker push`. Docker re-uploads and re-creates the manifest, so **zot served a different digest than GHCR for the same tag** — silently, because nothing compared them.

That is load-bearing rather than cosmetic, because `cloud-init.yml`'s web-host arm substitutes the zot ref *into* `$IREF` and then execs that payload **as root**:

```sh
ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.24"
if docker pull "$ZIREF"; then IREF="$ZIREF"; ... fi
docker pull "$IREF"
```

So the root-executed path resolved through a mutable tag, and pinning only the GHCR literal would not close it — the zot branch overwrites the very variable being pinned. ADR-155 named this as the blocker for its Alternative C, and #7144 finding 2 inherits it as the precondition on flipping `web_colocate_inngest`.

The sibling mirrors were already correct: `reusable-release.yml` (app image) and `build-inngest-config-bundle.yml` (config bundle) both use digest-preserving `crane copy`, on the same SHA-pinned crane `v0.20.2` adopted here. **The only mirror still on `docker tag + push` was the one whose payload runs as root on the scheduler.**

## What changed

1. **`crane copy` instead of `docker tag` + `docker push`.** Registry-to-registry, so the manifest bytes are preserved and one `@sha256` resolves on both registries.

2. **Digest parity is asserted, not assumed.** The step compares `crane digest` on both refs. An empty source digest counts as failure — the capture uses `|| true`, so an auth fault yields `""`, and `"" == ""` would otherwise read as a match and certify nothing.

3. **A `mirror_only` dispatch input.** Because crane reads the published manifest, a backfill no longer needs a rebuild. This matters more than it sounds: the existing `workflow_dispatch` path **rebuilds and re-pushes the same tag, so the tag's GHCR digest moves** — and `cloud-init-inngest.yml` pins the dedicated host's payload by that digest. Using the existing dispatch to "re-mirror" `v1.1.24` would have invalidated a live pin. `mirror_only` skips the build entirely.

4. **The degrade contract inverts under `mirror_only`.** On the build path the mirror is a secondary copy and must never red a release. In a backfill the mirror *is* the run, so `degraded()` exits 1 and `continue-on-error` is off. An exit 0 there would report success for a backfill that did not happen, and the caller would then pin a digest zot cannot serve.

## Verification

- `actionlint` clean on the changed steps. The one `SC2015` note is pre-existing on `origin/main`, in the `set +e` teardown.
- `cutover-inngest-workflow.test.sh` 334/334, `inngest-host.test.sh` 41/41, `cloud-init-inngest-bootstrap.test.sh` 80/80.
- GHCR digest for `v1.1.24` independently confirmed as `sha256:6cdaa63d1496642e681898a831234b712f75d3b09bd0844bcabec3de74b0a0f8` from two sources (GitHub packages API, `crane digest`), matching the pin already in `cloud-init-inngest.yml`.
- Zot's current digest could not be read from a workstation — it is dark behind the CF Tunnel (`/v2/` → HTTP 000). The new parity assertion measures it in CI, which is the right place for it. If the digests already agree, the backfill is a no-op and the assertion passes.

## After this merges

Dispatch the backfill from `main`, then verify parity:

```
gh workflow run build-inngest-bootstrap-image.yml \
  -f ref=vinngest-v1.1.24 -f mirror_only=true
```

Only once that is green can `cloud-init.yml` pin both refs and `web_colocate_inngest` flip to `true` (#7144 finding 2, tracked on the feature branch).

## Changelog

Fixed: the inngest-bootstrap zot mirror now preserves image digests (`crane copy`), so the root-executed bootstrap payload can be pinned by `@sha256` on both registries. Adds a rebuild-free `mirror_only` backfill mode and a digest-parity assertion.

Ref #7144

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

<!-- gate-override: net-issue-flow -->

**net-issue-flow override.** #7228 was not filed by this PR. It is the incident-tracking record for the sibling branch `feat-one-shot-resend-inbound-webhook-500` (PR #7158), filed from that branch's `tasks.md` task 0.1, and it references this PR only to record a blocking dependency ("finding 2 at 2 of 4 steps, blocked on #7203"). The gate attributes it here because it was created after this PR and bare-references the number; that is a contextual-citation false positive, not a filing. Option (d) does not apply — no `[mandates-filing]` rule forced it, and guessing a rule id would be worse than saying so.
