### PR TITLE
fix(lint): encryption-posture must not read a shell redirect as the luksOpen mapper

### DIFF
--- a/scripts/lint-encryption-posture.py
+++ b/scripts/lint-encryption-posture.py
@@ -246,6 +246,11 @@ def resolve_mapper_operand(file_text: str, raw_token: str) -> str | None:
 # A trailing bare "-" after it (stdin) is its VALUE, not a positional operand.
 _LUKSOPEN_VALUE_FLAGS = {"--key-file"}
 
+# Shell redirections: `>f` `>>f` `2>f` `2>>f` `<f` `2>&1` (shlex strips the quotes, so
+# `2>>"$LOG"` arrives as `2>>$LOG`). An operand never starts with a digit-then-angle or
+# a bare angle bracket, so this cannot swallow a real device or mapper name.
+_REDIRECT_RE = re.compile(r"^\d*(?:>>?|<<?)&?\d*")
+
 
 def _luksopen_positionals(tail: str) -> list[str]:
     """Tokenize the text after `luksOpen` on one logical line and return its
@@ -262,6 +267,14 @@ def _luksopen_positionals(tail: str) -> list[str]:
         tokens = shlex.split(tail)
     except ValueError:
         return []
+    # A SHELL REDIRECTION IS NOT AN OPERAND. `cryptsetup luksOpen ... "$DEV" git-data
+    # 2>>"$LOG"` is a legal, and now shipped (#7204), way to capture the command's stderr
+    # into a stage detail file — but shlex yields the redirect as a trailing token, so
+    # positionals[-1] became `2>>$LOG` and the mapper stopped resolving. The failure mode is
+    # a FALSE FAIL (the store looks unbacked by any luksFormat+luksOpen apparatus), which on
+    # this linter means a red gate on a correctly-encrypted store. Same class as the
+    # line-continuation strip above: a trailing token that is syntax, not an argument.
+    tokens = [t for t in tokens if not _REDIRECT_RE.match(t)]
     positionals: list[str] = []
     i = 0
     n = len(tokens)


### PR DESCRIPTION
**main is RED.** This restores it.

## What broke

#7197 merged at `16:34:58Z`. This one-file fix was pushed to that branch at the same second, and auto-merge had already captured the head — so `main` carries the `2>>` redirect on the `luksOpen` line **without** the parser change that reads it. The commit exists on the feature branch (`63e8ea3d7`) and never reached main.

```
FAIL: hcloud_volume.git_data_luks device_binding.mapper 'git-data' does not resolve
to any cryptsetup luksFormat+luksOpen apparatus under apps/*/infra/
```

## Why the parser was wrong

#7204 appended `2>>"$GIT_DATA_LUKS_DETAIL"` to the `luksOpen` line so that command's stderr reaches the stage detail file. `shlex` yields the redirect as a trailing token, so `_luksopen_positionals` returned `['$DEV','git-data','2>>$LOG']` and `scan_apparatus` keys on `positionals[-1]` — the redirect, not the mapper.

The result is a **false FAIL on a correctly-encrypted volume**, emitted by the gate whose entire job is asserting that volume is encrypted. Nothing about the store changed; only the parser's view of it did.

Fixed at the parser rather than by relocating the redirect — a redirection is syntax, not an operand, and the next author to add one hits the same wall. The function already strips a trailing line-continuation backslash for exactly this reason. An operand can never begin with a digit-then-angle or a bare angle bracket, so the filter cannot swallow a real device or mapper name.

## Mutation-proven against real main

"The gate is green again" is not evidence the gate works:

| | result |
|---|---|
| main + fix | **PASS** — 0 failing checks |
| mapper renamed to `WRONG-MAPPER` | **FAIL** — 2 failing checks |
| restored (`diff -q` byte-identical) | **PASS** — 0 failing checks |
| `scripts/lint-encryption-posture.test.sh` | **PASS=45 FAIL=0** |

Ref #7204

🤖 Generated with [Claude Code](https://claude.com/claude-code)