### PR TITLE
fix(drift): restore token-drift scanning while the service account is unusable

### DIFF
--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -665,6 +665,31 @@ jobs:
               echo "write in \`emit_json\` (\`scripts/check-cloudflare-token-drift.sh\`). Coverage"
               echo "cannot be assessed until the detector publishes a parseable \`configs\` field"
               echo "again."
+            elif [[ "$CONFIGS" == "1" ]]; then
+              # INTERIM STATE (#7234) — DO NOT send the operator hunting a regression.
+              # 1/13 is the DELIBERATE, documented state while the project-scoped service
+              # account is unusable. Without this branch the else-arm below rewrites #7175
+              # twice daily telling the operator to "work down the three narrowings" and
+              # naming N3 ("repointed at a config-scoped service token, reads 1/13") as the
+              # fault — which is a verbatim description of the intended configuration. An
+              # issue that instructs the operator to undo a deliberate change is worse than
+              # no issue: it burns the one channel this detector has.
+              echo "**This 1/13 is expected and tracked — do not undo it.** The scan is"
+              echo "deliberately running on the config-scoped \`secrets.DOPPLER_TOKEN\`"
+              echo "(\`prd_terraform\`) while **#7234** is open."
+              echo ""
+              echo "The project-scoped \`doppler_service_account\` minted for this scan is live"
+              echo "and correctly shaped — account, \`viewer\` project membership, token, and the"
+              echo "\`DOPPLER_TOKEN_DRIFT\` secret all exist — and it was MEASURED to see nothing:"
+              echo "\`doppler configs -p soleur\` returns \`null\`, and reading \`prd\` returns"
+              echo "\`Could not find requested config 'prd'\`. \`workplace_permissions = []\` yields"
+              echo "\`workplace_role: no_access\`, which denies the project visibility a \`viewer\`"
+              echo "membership cannot confer on its own."
+              echo ""
+              echo "So this run scanned the 13 token-shaped keys \`prd_terraform\` carries — the"
+              echo "\`CI_SSH_ACCESS_TOKEN\` pair and 10 \`CF_API_TOKEN*\` among them — and reported"
+              echo "\`${COVERAGE_RATIO}\` honestly rather than calling it clean. **No action is"
+              echo "needed on this issue.** It closes when #7234 restores the fan-out."
             else
               echo "**There is nothing here to widen.** \`DOPPLER_TOKEN_DRIFT\` is a"
               echo "\`doppler_service_account_token\` belonging to"

--- a/.github/workflows/scheduled-terraform-drift.yml
+++ b/.github/workflows/scheduled-terraform-drift.yml
@@ -156,7 +156,29 @@ jobs:
           # the whole `soleur` project (apps/web-platform/infra/token-drift-service-account.tf),
           # so unlike the config-scoped `DOPPLER_TOKEN` every other step here uses, it can
           # enumerate and READ all 13 configs. That is the swap #7159 asked for.
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_DRIFT }}
+          # RESTORED to secrets.DOPPLER_TOKEN pending #7234. The project-scoped service
+          # account minted by #7162 is live and correctly shaped -- account, `viewer` project
+          # membership and token all exist -- and it can see NOTHING. Measured against the
+          # real credential:
+          #
+          #   doppler configs -p soleur --json          -> null  (0 configs)
+          #   doppler secrets -p soleur -c prd          -> "Could not find requested config 'prd'"
+          #
+          # so it cannot enumerate AND cannot read. `workplace_permissions = []` (the least
+          # privileged value satisfying the provider's ExactlyOneOf) yields workplace_role
+          # no_access, and workplace visibility turns out to be a precondition for project
+          # access rather than something a project membership can confer alone.
+          #
+          # The premise that a service-account credential can enumerate a project's configs
+          # was INFERRED from the provider shipping the resource type; it was never probed.
+          # Everything else in #7159 was measured and three premises were falsified that way.
+          #
+          # DOPPLER_CONFIGS_FLOOR deliberately STAYS 13. This credential reads 1 config, so
+          # the scan will report `degraded` at 1/13 on every run -- which is the honest state
+          # and keeps the operator channel armed. Do NOT "fix" the red by lowering the floor
+          # to 1: that is the floor-edited-down-to-match-a-narrowed-grant shape, and the
+          # runtime `configs_floor < 13` assertion below forces `degraded` anyway.
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           DOPPLER_PROJECT: soleur
           # NO DOPPLER_CONFIG. A project-scoped identity takes no direction from it, and
           # with 13 configs in play the name reads as "which config this scans" — which is

--- a/apps/web-platform/infra/token-drift-service-account.tf
+++ b/apps/web-platform/infra/token-drift-service-account.tf
@@ -18,6 +18,15 @@
 # FOUR RESOURCES, ONE CREDENTIAL: the account (the identity), the project membership (the GRANT),
 # the token (the secret value) and the repo Actions secret (the sink the workflow reads as
 # `secrets.DOPPLER_TOKEN_DRIFT`). Exactly ONE consumer — the `token_drift` step. The rung-2
+#
+# INTERIM (#7234), 2026-08-03: that is currently FALSE — this credential has ZERO
+# consumers. It was measured unable to enumerate or read the project (`doppler configs
+# -p soleur` -> null; reading `prd` -> "Could not find requested config 'prd'"), so the
+# token-drift step was restored to the config-scoped `secrets.DOPPLER_TOKEN`. These
+# resources are deliberately LEFT PROVISIONED so #7234 can probe which permission shape
+# grants project visibility without a gated re-apply. Do NOT garbage-collect the secret
+# as an orphan, and do NOT wire it into anything else as a convenient spare — it grants
+# nothing today and its intended consumer is the token-drift step, once #7234 lands.
 # rehearsal orphan sweep in the same workflow is deliberately NOT wired to it.
 #
 # autonomy-considered: provider-mint-applied (Doppler service account + membership + token and

--- a/plugins/soleur/test/token-drift-workflow-causes.test.sh
+++ b/plugins/soleur/test/token-drift-workflow-causes.test.sh
@@ -1160,12 +1160,29 @@ fi
 # ---------------------------------------------------------------------------
 # C1-C3 — the CREDENTIAL the step is wired to, and the guard on its floor.
 # ---------------------------------------------------------------------------
-echo "C1: the step's DOPPLER_TOKEN is sourced from secrets.DOPPLER_TOKEN_DRIFT"
+echo "C1: the step's DOPPLER_TOKEN is the documented interim credential (see #7234)"
+# INTERIM STATE, PINNED DELIBERATELY. The TARGET is secrets.DOPPLER_TOKEN_DRIFT -- the
+# project-scoped service-account token. It is minted and live, and it was MEASURED to see
+# nothing at all:
+#
+#   doppler configs -p soleur --json   -> null   (0 configs)
+#   doppler secrets -p soleur -c prd   -> "Could not find requested config 'prd'"
+#
+# `workplace_permissions = []` (the least-privileged value satisfying the provider's
+# ExactlyOneOf) yields workplace_role no_access, and that denies project visibility which a
+# `viewer` project membership cannot restore on its own. Until #7234 settles whether a
+# narrower-than-all_enclave_projects permission exists, the step runs on the config-scoped
+# credential so drift detection keeps running at all -- 1 of 13, reported honestly as
+# `degraded` rather than silently as `clean`.
+#
+# This assertion is NOT relaxed to "either value": it pins the interim credential exactly,
+# so any THIRD value still fails, and flipping back to DOPPLER_TOKEN_DRIFT fails here as a
+# reminder to re-verify enumeration against the real credential first.
 WF_TOKEN=$(step_get "id:token_drift" env.DOPPLER_TOKEN) || WF_TOKEN=""
-if [[ "$WF_TOKEN" == '${{ secrets.DOPPLER_TOKEN_DRIFT }}' ]]; then
-  pass "DOPPLER_TOKEN: \${{ secrets.DOPPLER_TOKEN_DRIFT }}"
+if [[ "$WF_TOKEN" == '${{ secrets.DOPPLER_TOKEN }}' ]]; then
+  pass "DOPPLER_TOKEN: \${{ secrets.DOPPLER_TOKEN }} (interim per #7234; target is DOPPLER_TOKEN_DRIFT)"
 else
-  fail "the step's DOPPLER_TOKEN is '${WF_TOKEN}' — DOPPLER_TOKEN_DRIFT is the doppler_service_account_token holding a viewer membership on the whole soleur project, and it is the ONLY thing that can read all 13 configs. Any other value is narrowing N3: a config-scoped doppler_service_token is config-scoped by construction, ignores DOPPLER_CONFIG, and reads 1 of 13"
+  fail "the step's DOPPLER_TOKEN is '${WF_TOKEN}' — expected the interim \${{ secrets.DOPPLER_TOKEN }} per #7234. If this is the flip BACK to DOPPLER_TOKEN_DRIFT, first re-run the enumeration probe against the real credential (mint an ephemeral service-account token, run 'doppler configs -p soleur --json', confirm 13) and update this assertion in the same change — the last time that premise went unmeasured the scan read 0 of 13"
 fi
 
 echo "C2: the bare secrets.DOPPLER_TOKEN and DOPPLER_CONFIG are both gone from the step"
@@ -1175,10 +1192,14 @@ STEP_YAML=$(step_get "id:token_drift" .) || { echo "FATAL: could not dump the to
 _bare_token=$(grep -Ec 'secrets\.DOPPLER_TOKEN[[:space:]]*\}\}' <<<"$STEP_YAML")
 _has_cfg=0
 step_get "id:token_drift" env.DOPPLER_CONFIG >/dev/null 2>&1 && _has_cfg=1
-if [[ "$_bare_token" == "0" && "$_has_cfg" == "0" ]]; then
-  pass "no bare secrets.DOPPLER_TOKEN reference and no DOPPLER_CONFIG in the step"
+# DOPPLER_CONFIG must STAY absent even on the interim credential. The detector enumerates
+# and loops configs; it takes no direction from DOPPLER_CONFIG, and re-adding it would
+# restore the "this scans one named config" mental model the ladder replaced. The bare-token
+# half of this assertion is suspended while #7234 is open (C1 pins the credential instead).
+if [[ "$_has_cfg" == "0" ]]; then
+  pass "no DOPPLER_CONFIG in the step (the detector enumerates; it takes no config direction)"
 else
-  fail "the step still references the bare secrets.DOPPLER_TOKEN (${_bare_token} time(s)) or declares DOPPLER_CONFIG (present=${_has_cfg}) — a project-scoped identity takes no direction from DOPPLER_CONFIG, so leaving it reads as 'which config this scans', which is the wrong mental model for a detector that loops over all of them; and a surviving bare DOPPLER_TOKEN is the config-scoped credential this change exists to replace"
+  fail "the step declares DOPPLER_CONFIG (present=${_has_cfg}) — the detector loops over enumerated configs, so naming one reads as 'which config this scans', the wrong mental model for a fan-out detector. Even on the interim config-scoped credential the config is implied by the token, never by this variable"
 fi
 
 echo "C3: an unset, empty or unparseable floor WRITES the outputs and THEN exits 2"

--- a/plugins/soleur/test/token-drift-workflow-causes.test.sh
+++ b/plugins/soleur/test/token-drift-workflow-causes.test.sh
@@ -1185,7 +1185,7 @@ else
   fail "the step's DOPPLER_TOKEN is '${WF_TOKEN}' — expected the interim \${{ secrets.DOPPLER_TOKEN }} per #7234. If this is the flip BACK to DOPPLER_TOKEN_DRIFT, first re-run the enumeration probe against the real credential (mint an ephemeral service-account token, run 'doppler configs -p soleur --json', confirm 13) and update this assertion in the same change — the last time that premise went unmeasured the scan read 0 of 13"
 fi
 
-echo "C2: the bare secrets.DOPPLER_TOKEN and DOPPLER_CONFIG are both gone from the step"
+echo "C2: DOPPLER_CONFIG is absent, and the bare token appears exactly once (the one C1 pins)"
 # Asserted over the PARSED step (comments stripped), because the step's own comment block
 # explains at length why DOPPLER_CONFIG is absent and names it four times.
 STEP_YAML=$(step_get "id:token_drift" .) || { echo "FATAL: could not dump the token_drift step" >&2; exit 2; }
@@ -1196,10 +1196,15 @@ step_get "id:token_drift" env.DOPPLER_CONFIG >/dev/null 2>&1 && _has_cfg=1
 # and loops configs; it takes no direction from DOPPLER_CONFIG, and re-adding it would
 # restore the "this scans one named config" mental model the ladder replaced. The bare-token
 # half of this assertion is suspended while #7234 is open (C1 pins the credential instead).
-if [[ "$_has_cfg" == "0" ]]; then
-  pass "no DOPPLER_CONFIG in the step (the detector enumerates; it takes no config direction)"
+# `_bare_token` is KEPT, not dropped. It greps the WHOLE step YAML, so it catches a
+# secrets.DOPPLER_TOKEN appearing in a `with:` block or a second env key — surface C1 does
+# not see, since C1 inspects env.DOPPLER_TOKEN alone. Asserting == 1 pins "exactly the one
+# C1 pins, and no other": deleting this check would silently un-guard the extra-reference
+# case for the duration of #7234.
+if [[ "$_has_cfg" == "0" && "$_bare_token" == "1" ]]; then
+  pass "no DOPPLER_CONFIG in the step, and exactly 1 bare secrets.DOPPLER_TOKEN (the interim credential C1 pins)"
 else
-  fail "the step declares DOPPLER_CONFIG (present=${_has_cfg}) — the detector loops over enumerated configs, so naming one reads as 'which config this scans', the wrong mental model for a fan-out detector. Even on the interim config-scoped credential the config is implied by the token, never by this variable"
+  fail "the step declares DOPPLER_CONFIG (present=${_has_cfg}) or references the bare secrets.DOPPLER_TOKEN ${_bare_token} time(s), expected exactly 1 — the detector loops over enumerated configs, so naming one in DOPPLER_CONFIG reads as 'which config this scans', the wrong mental model for a fan-out detector; and a SECOND bare-token reference is a surface C1 does not inspect"
 fi
 
 echo "C3: an unset, empty or unparseable floor WRITES the outputs and THEN exits 2"

--- a/scripts/followthroughs/token-drift-coverage-7159.sh
+++ b/scripts/followthroughs/token-drift-coverage-7159.sh
@@ -93,6 +93,17 @@ case "$COVERAGE" in
       echo "TRANSIENT: coverage ${COVERAGE} at ${RATIO} — reads as the credential not yet minted (the terraform apply is behind the web-platform-infra-apply reviewer gate). Retrying next sweep." >&2
       exit 2
     fi
+    # THE DOCUMENTED INTERIM STATE IS NOT A FAILURE. #7234: the project-scoped service
+    # account was measured unable to enumerate or read, so the scan runs on the
+    # config-scoped credential and reports 1/13 every run. Without this arm the FAIL
+    # below fires on EVERY sweep, forever, reopening the issue and telling the operator
+    # to "check the service-account membership role" -- which was measured correct. A
+    # follow-through that comments a wrong remedy twice a day is the noise channel this
+    # substrate exists to avoid.
+    if [[ "$RATIO" == 1/* ]]; then
+      echo "TRANSIENT: coverage ${COVERAGE} at ${RATIO} — the documented #7234 interim (scan on the config-scoped credential; the service account sees 0 configs by measurement). Not a regression; retrying next sweep until #7234 restores the fan-out." >&2
+      exit 2
+    fi
     echo "FAIL: run ${RUN_ID} reported coverage: ${COVERAGE} at ${RATIO:-?}. The credential landed but reaches fewer configs than the declared floor — check the service-account membership role and its environments scope." >&2
     exit 1
     ;;


### PR DESCRIPTION
## Summary

Restores Cloudflare token-drift scanning. PR #7162 swapped the scan onto a project-scoped Doppler service account; the credential is live and correctly shaped, and it can see nothing — so detection went from 1 config to **0**.

## The measurement that should have happened at plan time

Minted an ephemeral token for the **same** service account Terraform created, tested, revoked it in one command:

```
doppler configs -p soleur --json    ->  null    (0 configs)
doppler secrets -p soleur -c prd    ->  {"error":"Could not find requested config 'prd'"}
```

It cannot enumerate **and** cannot read. `workplace_permissions = []` — chosen as the least-privileged value satisfying the provider's `ExactlyOneOf` constraint — yields `workplace_role: no_access`, and workplace visibility is a precondition for project access that a `viewer` project membership cannot confer alone.

The premise that a service-account credential can enumerate a project's configs was **inferred** from the pinned provider shipping the resource type. It was never probed. Three other #7159 premises were falsified by measurement; this one, the load-bearing one, was not.

## What this changes

One line: the token-drift step's `DOPPLER_TOKEN` goes back to `secrets.DOPPLER_TOKEN`.

**`DOPPLER_CONFIGS_FLOOR` deliberately stays 13.** The scan will report `degraded` at `1/13` on every run. That is the honest state and it keeps the operator channel armed. Lowering the floor to 1 to make it green is precisely the floor-edited-down-to-match-a-narrowed-grant shape — and #7162's own runtime `configs_floor < 13` assertion forces `degraded` regardless, so the green path does not exist.

## Everything #7162 built stays, and it worked

The first live run on the broken credential reported `degraded` at `0/13`, left #7175 open, and did not fire the close arm. Before #7162 that same state printed `verdict: clean`. The ladder is what turned a silent failure into a loud one within minutes of merge — this PR is the follow-up it made possible, not a rollback of it.

## Test changes

`C1` is **re-pointed, not relaxed**: it pins the interim credential exactly, so a third value still fails (mutation-proven — `secrets.SOME_OTHER_TOKEN` → 57/58), and flipping back to `DOPPLER_TOKEN_DRIFT` fails here as a reminder to re-measure enumeration first. `C2` keeps its `DOPPLER_CONFIG`-must-be-absent half and suspends the bare-token half while #7234 is open.

## User-Brand Impact

- **Artifact:** the `CF_API_TOKEN*` and `CI_SSH_ACCESS_TOKEN_ID/_SECRET` values in `prd_terraform` — the credentials whose staleness produced the 63-hour ADR-154 outage.
- **Vector:** with the scan at 0 configs, a Cloudflare or Access token can go stale and reach production entirely undetected. This PR restores detection over the 13 keys `prd_terraform` carries.
- **Brand-survival threshold:** `single-user incident`.

## Test plan

- [x] Consumer suite — 58/58
- [x] Producer suite — 80/80
- [x] `lint-workflows.sh`, `shellcheck -S warning` — rc=0
- [x] Mutation: a third credential value still fails C1 (57/58)
- [ ] ⏳ Post-merge: next scheduled run reports `degraded` at `1/13` — loud and accurate, not clean

Ref #7234

Generated with [Claude Code](https://claude.com/claude-code)
