### PR TITLE
fix(ci): the mirror guard passed a full revert of the change it guards

### DIFF
--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -516,8 +516,30 @@ jobs:
           # reclaimed layer yields green parity and a `blob unknown` on the host's docker pull.
           # `crane validate --remote` fetches the manifest AND every blob, which is the
           # property a pin actually depends on.
-          retry crane validate --remote "$ZOT:$TAG" \
-            || degraded blobs_missing "$?" "manifest digest matches but crane validate --remote failed — zot may have gc'd a layer; a pin would fail at docker pull with 'blob unknown'"
+          #
+          # DARK-LAUNCHED, NON-BLOCKING (wg-dark-launch-deploy-gates). This check has never
+          # run against this zot: `crane copy`/`crane digest` are known to work over the
+          # loopback bridge, but whether `validate` applies the same localhost-insecure
+          # heuristic is UNVERIFIED, and it could not be verified before merge because the
+          # bridge itself is down (#7242). A gate proven only against a mock is
+          # runtime-unvalidated, and if the heuristic differs this would degrade EVERY release
+          # and hard-red every backfill — a self-inflicted outage in the workflow that exists
+          # to prevent one.
+          #
+          # PROMOTION CRITERION: once `blob_validate=ok` has been observed on >=1 real run
+          # (any trigger), delete this branch and restore the blocking form:
+          #   retry crane validate --remote "$ZOT:$TAG" \
+          #     || degraded blobs_missing "$?" "manifest digest matches but blobs are missing"
+          # Until then a failure is recorded and reported, and nothing is gated on it.
+          blob_rc=0
+          retry crane validate --remote "$ZOT:$TAG" || blob_rc=$?
+          if [ "$blob_rc" = 0 ]; then
+            echo "blob_validate=ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "blob_validate=failed" >> "$GITHUB_OUTPUT"
+            echo "::warning::[dark-launch, NON-BLOCKING] crane validate --remote failed for ${ZOT}:${TAG} (rc=${blob_rc}). Either zot gc'd a layer (a pin would fail at docker pull with 'blob unknown') OR crane validate does not speak plain-HTTP to the loopback bridge the way copy/digest do. Resolve which BEFORE promoting this to a gate, and before pinning cloud-init to this tag."
+            echo "⚠️ blob validation failed for \`${TAG}\` (rc=${blob_rc}) — NON-BLOCKING while dark-launched; see the run log before pinning." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           echo "mirror_status=ok" >> "$GITHUB_OUTPUT"
           echo "mirror_reason=ok" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -107,6 +107,14 @@ jobs:
 
       - name: Read pinned inngest-cli + vector versions + SHAs from *.tf
         id: pin
+        # Gated to match the ONLY step that consumes its outputs (`Build + verify + push`
+        # reads steps.pin.outputs.* in its env). Ungated, this ran under mirror_only as dead
+        # work that could still RED the run: it uses `set -euo pipefail` and the two
+        # inngest.tf greps carry no `|| true`, while mirror_only checks out an OLD tag's tree
+        # — whose infra/ layout is exactly what a backfill has no control over. Failing a
+        # digest backfill because a years-old tag spelled a terraform variable differently is
+        # a fault with no relationship to the mirror.
+        if: ${{ !inputs.mirror_only }}
         # Reads only from tracked files (no untrusted github.event.* input).
         run: |
           set -euo pipefail
@@ -242,11 +250,25 @@ jobs:
       # manifest, so zot served a DIFFERENT digest than GHCR for the same tag — silently,
       # because nothing compared them.
       #
-      # It matters because cloud-init.yml's web-host arm substitutes the zot ref INTO $IREF
+      # It matters because cloud-init.yml's WEB-HOST arm substitutes the zot ref INTO $IREF
       # (`if docker pull "$ZIREF"; then IREF="$ZIREF"`) and then execs that payload AS ROOT.
       # An unpinnable zot copy therefore left the root-executed path on a mutable tag, and
-      # pinning only the GHCR literal would not have closed it. ADR-155 named this as the
-      # blocker for its Alternative C; #7144 finding 2 inherits it.
+      # pinning only the GHCR literal would not have closed it.
+      #
+      # PRECISION, because #7203 got this wrong in its own title: the DEDICATED inngest host
+      # (cloud-init-inngest.yml) is ALREADY digest-pinned. The unpinned root-exec is the WEB
+      # host arm, which apps/web-platform/infra/variables.tf records as DORMANT today
+      # (`web_colocate_inngest` defaults false post-ADR-100) — so this is a latent exposure
+      # that arms when that variable flips, not a live one.
+      #
+      # The SOLEUR-DEBT block in variables.tf is the authority for that trade; its `trigger:`
+      # clause makes digest-pinning $IREF a precondition of flipping the variable, and #7144
+      # finding 2 inherits it.
+      #
+      # #7203 cited "ADR-155" here. Do not restore that: ADR-155 on main is
+      # ADR-155-cross-gate-exemption-markers-in-the-rule-corpus, which has nothing to do with
+      # registries — the intended document was minted under the same number on an unmerged
+      # branch, so the citation resolved to an unrelated ADR for every reader on main.
       #
       # `crane copy` is registry->registry and preserves the manifest bytes, so a single
       # @sha256 resolves on BOTH registries. That is also what makes `mirror_only` possible:
@@ -258,13 +280,26 @@ jobs:
       # with the GHCR side, no sign step.
       - name: Bridge to zot registry (CF Tunnel)
         id: zot_bridge
-        # BELT OFF under mirror_only, for the same reason as the mirror step below. The
-        # mirror is gated on `zot_bridge.outcome == 'success'`, so a soft-failed bridge
-        # SKIPS the mirror and leaves the job GREEN — under mirror_only that is a run
-        # reporting success for a backfill that never ran, and the caller would then pin a
-        # digest zot cannot serve. Belt stays ON for push/rebuild, where the bridge is
-        # secondary to the GHCR release (#6274).
-        continue-on-error: ${{ !inputs.mirror_only }}
+        # Belt ON unconditionally, and that is deliberate — it is NOT the thing that decides
+        # whether a bridge failure reds the run. The mirror step below is no longer gated on
+        # this step's outcome; it reads `BRIDGE_OUTCOME` as env and branches INTERNALLY, so a
+        # bridge failure reaches the same `degraded()` emitter and the same step id every
+        # consumer already keys on. `degraded()` then decides: exit 0 on the build path,
+        # exit 1 under mirror_only.
+        #
+        # #7203 shipped `continue-on-error: ${{ !inputs.mirror_only }}` here plus an
+        # `if: steps.zot_bridge.outcome == 'success'` gate on the mirror. That closed the
+        # false-green for mirror_only ONLY, by job status, and left the BUILD path with the
+        # #6416 defect verbatim: a soft-failed bridge SKIPPED the mirror, a skipped step
+        # emits no outputs, so `mirror_status` stayed unset and every degrade signal this
+        # workflow owns — ::warning::, step summary, and the #6278 Slack ⚠️ — was unreachable
+        # in the one case worth reporting. The bridge is also the step the measured fault
+        # class actually kills (#7242: CF Access refusing the websocket upgrade), so that was
+        # the path with no signal.
+        #
+        # reusable-release.yml records the same conclusion at its own zot_bridge:
+        # "Do NOT re-gate this step on zot_bridge — that was the #6416 defect."
+        continue-on-error: true
         uses: ./.github/actions/cf-tunnel-registry-bridge
         with:
           # DOPPLER_TOKEN_PRD, NOT the generic DOPPLER_TOKEN (#6122 cutover fix): the bridge
@@ -277,7 +312,17 @@ jobs:
 
       - name: Mirror inngest image GHCR→zot (crane, digest-preserving)
         id: zot_mirror
-        if: steps.zot_bridge.outcome == 'success'
+        # NO `if:` — deliberately. GitHub prepends an implicit `success()` to a step with no
+        # status function, which is exactly the gate wanted here: run whenever the job is
+        # still healthy. Re-adding `if: steps.zot_bridge.outcome == 'success'` reinstates the
+        # #6416 defect, because a skipped step cannot emit `mirror_status` and every
+        # consumer below keys on that output. The bridge's own result arrives as
+        # BRIDGE_OUTCOME in `env:` and is branched on INSIDE the script.
+        #
+        # The step id is load-bearing and must not change: step outputs are namespaced by id,
+        # so handling bridge-down in a NEW sibling step would write an output no consumer
+        # reads (reusable-release.yml records this at its own zot_mirror).
+        #
         # The continue-on-error marker below is BELT: the zot mirror is a SECONDARY/shadow
         # copy during the ADR-096 soak (GHCR primary + break-glass; atomic GHCR
         # pull-side fallback), so a mirror failure must NEVER red this build. #6274:
@@ -296,15 +341,31 @@ jobs:
           # Typed boolean, consumed only as a string comparison below — never interpolated
           # into the script body.
           MIRROR_ONLY: ${{ inputs.mirror_only }}
+          # OUTCOME, never CONCLUSION. `zot_bridge` carries continue-on-error: true, which
+          # forces its CONCLUSION to 'success' while OUTCOME keeps the true result. Reading
+          # conclusion here would mask every bridge failure — the masking is the whole reason
+          # the #6416 defect was invisible.
+          BRIDGE_OUTCOME: ${{ steps.zot_bridge.outcome }}
         run: |
-          # No `set -e` — on the BUILD path every failure exits 0 so this build stays green
-          # (SUSPENDERS to the continue-on-error belt). A persistent miss surfaces
-          # as mirror_status=degraded → ::warning:: + step summary AND (#6278) a Slack
-          # ⚠️ via the "Post to Slack (inngest mirror status)" step below — degrade-only
-          # (this workflow fires on inngest-bootstrap infra changes, not a per-release
-          # operator event). Before #6278 the degrade was annotations-only; a sustained
-          # pre-cutover degrade now gets push-notification parity with reusable-release.yml.
+          # No `set -e` — on the BUILD path every failure routes through degraded(), which
+          # exits 0 so this build stays green (SUSPENDERS to the continue-on-error belt). A
+          # persistent miss surfaces as mirror_status=degraded → ::warning:: + step summary,
+          # and on the BUILD path also a Slack ⚠️ (#6278). Under mirror_only the run is RED
+          # and the Slack step is reached via `!cancelled()` — see that step's own comment;
+          # do not restate the delivery guarantee here, it drifted once already.
+          #
+          # `set -e` is deliberately NOT used: the crane-install rc is captured explicitly
+          # below, and `set -e` would abort at the failing command before the rc could be
+          # classified — emitting no mirror_status at all, which is the silence this file
+          # exists to remove.
           set -uo pipefail
+
+          # BACKSTOP for the above. Without `set -e`, a future fallible command added with no
+          # `|| degraded` route fails silently and execution falls through to
+          # `mirror_status=ok` — a green run with no mirror. The ERR trap makes that a named
+          # degrade instead of a false green. `set -E` propagates it into functions.
+          set -E
+          trap 'degraded unrouted "$?" "a command failed with no explicit || degraded route — this is a workflow bug, not an infrastructure fault"' ERR
 
           # Bounded retry to self-heal a transient TCP reset over the CF-tunnel
           # bridge. 3 attempts, 5s then 15s backoff. Idempotent ops only — `crane copy`
@@ -322,30 +383,72 @@ jobs:
             done
           }
 
+          # SIGNATURE: degraded <reason> <rc> [detail]
+          #
+          # `reason` is a first-class parameter, not decoration. Before this, all six call
+          # sites collapsed into one undifferentiated "degraded" bucket, so `mirror_status` —
+          # the only machine-readable output, and the thing the Slack gate reads — could not
+          # name a cause. A crane-tarball CHECKSUM MISMATCH on a binary about to be
+          # `sudo tar`-extracted into /usr/local/bin is the strongest supply-chain signal this
+          # workflow can emit, and it was rendering as a message about registry redundancy.
+          # reusable-release.yml derived the same rule: "Naming an unmeasured cause is the
+          # defect this whole PR exists to drain."
           degraded() {
-            local rc="$1"
+            local reason="$1" rc="$2" detail="${3:-}"
             echo "mirror_status=degraded" >> "$GITHUB_OUTPUT"
-            echo "::warning::zot mirror degraded for ${ZOT:-<image>} (rc=${rc}) — build UNAFFECTED (GHCR primary/break-glass); zot redundancy reduced, backfill via the mirror_only dispatch of this workflow (crane, digest-preserving — NOT 'docker pull + docker push', which re-creates the manifest and breaks digest parity). If disk-full: see SOLEUR_ZOT_DISK / Better Stack registry_disk_prd."
-            echo "⚠️ zot mirror degraded (rc=${rc}) — inngest image mirror failed; GHCR unaffected, backfill needed." >> "$GITHUB_STEP_SUMMARY"
-            # On the BUILD path the mirror is secondary, so exit 0 and let the release stand.
-            # Under mirror_only the mirror IS the run, so a degrade must be a RED run — an
-            # exit 0 here would report success for a backfill that did not happen, and the
-            # caller would then pin a digest zot cannot serve.
+            echo "mirror_reason=${reason}" >> "$GITHUB_OUTPUT"
+            # Mode-aware text. The build path and mirror_only have OPPOSITE meanings for the
+            # same failure, and a single string was wrong for one of them: under mirror_only
+            # there is no build to be "UNAFFECTED", and "backfill needed" describes a run
+            # whose entire purpose WAS the backfill.
             if [ "${MIRROR_ONLY:-false}" = "true" ]; then
-              echo "::error::mirror_only backfill FAILED (rc=${rc}) — zot does not serve the GHCR digest for ${TAG}. Do not pin until this is green."
+              echo "::error::mirror_only backfill FAILED for ${IMAGE}:${TAG} (reason=${reason} rc=${rc})${detail:+ — ${detail}} — zot does not serve the GHCR digest. DO NOT PIN until this is green. Re-run: gh workflow run build-inngest-bootstrap-image.yml -f ref=vinngest-${TAG} -f mirror_only=true"
+              echo "❌ mirror_only backfill FAILED for \`${IMAGE}:${TAG}\` (reason=\`${reason}\` rc=${rc}) — zot does not serve the GHCR digest; do not pin." >> "$GITHUB_STEP_SUMMARY"
               exit 1
             fi
+            echo "::warning::zot mirror degraded for ${ZOT:-$IMAGE}:${TAG} (reason=${reason} rc=${rc})${detail:+ — ${detail}} — build UNAFFECTED (GHCR primary/break-glass); zot redundancy reduced. Backfill: gh workflow run build-inngest-bootstrap-image.yml -f ref=vinngest-${TAG} -f mirror_only=true (crane, digest-preserving — NOT 'docker pull + docker push', which re-creates the manifest and breaks digest parity). If disk-full: see SOLEUR_ZOT_DISK / Better Stack registry_disk_prd."
+            echo "⚠️ zot mirror degraded for \`${TAG}\` (reason=\`${reason}\` rc=${rc}) — GHCR unaffected, backfill needed." >> "$GITHUB_STEP_SUMMARY"
+            # On the BUILD path the mirror is secondary, so exit 0 and let the release stand.
             exit 0
           }
 
+          # The bridge's result arrives as env, NOT as a step-level `if:` gate. A gate would
+          # SKIP this step, and a skipped step emits no `mirror_status` — so bridge-down, the
+          # fault class actually observed in the field (#7242: CF Access refusing the
+          # websocket upgrade), would produce a green run with no annotation, no summary line
+          # and no Slack. Branching here instead routes it through the same emitter as every
+          # other fault.
+          if [ "${BRIDGE_OUTCOME:-}" != "success" ]; then
+            degraded bridge_down 1 "cf-tunnel-registry-bridge outcome=${BRIDGE_OUTCOME:-<unset>}; zot was never reachable from this runner"
+          fi
+
           # Install crane, SHA-pinned. Same version as build-inngest-config-bundle.yml and
-          # reusable-release.yml — keep the three in step.
+          # reusable-release.yml — keep the three in step (asserted by the suite's
+          # cross-workflow parity check).
           CRANE_VERSION="v0.20.2"
           CRANE_SHA256="c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b"
-          curl -fsSL -o /tmp/crane.tgz \
-            "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" || degraded "$?"
-          echo "${CRANE_SHA256}  /tmp/crane.tgz" | sha256sum -c - || degraded "$?"
-          sudo tar -xzf /tmp/crane.tgz -C /usr/local/bin crane || degraded "$?"
+          # Retried: a transient GitHub-releases blip must not hard-RED a mirror_only backfill
+          # that would self-heal on attempt 2. reusable-release.yml wraps the identical block.
+          # The SHA check is INSIDE the retried function, so a corrupted download is re-fetched
+          # rather than accepted — and a genuinely drifted CRANE_SHA256 still fails all three
+          # attempts and reports `crane_verify`, which a re-dispatch cannot clear.
+          install_crane() {
+            curl -fsSL -o /tmp/crane.tgz \
+              "https://github.com/google/go-containerregistry/releases/download/${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" || return 10
+            echo "${CRANE_SHA256}  /tmp/crane.tgz" | sha256sum -c - || return 11
+            sudo tar -xzf /tmp/crane.tgz -C /usr/local/bin crane || return 12
+          }
+          # `|| rc=$?`, never a bare call followed by `rc=$?`: the bare form fires the ERR
+          # trap above (and, under any future `set -e`, aborts) before the rc can be
+          # classified, turning a specific supply-chain verdict into a generic `unrouted`.
+          rc=0
+          retry install_crane || rc=$?
+          case "$rc" in
+            0)  ;;
+            11) degraded crane_verify "$rc" "SHA256 mismatch on the crane tarball — SUPPLY-CHAIN signal, not a network fault; a re-dispatch re-fetches the same pinned URL and cannot clear it" ;;
+            12) degraded crane_extract "$rc" "tar extraction into /usr/local/bin failed" ;;
+            *)  degraded crane_download "$rc" "could not fetch crane ${CRANE_VERSION} from GitHub releases after 3 attempts" ;;
+          esac
           rm -f /tmp/crane.tgz
 
           # Full org namespace (jikig-ai/…) to match the ci-deploy.sh pull path
@@ -355,31 +458,90 @@ jobs:
           # Registry -> registry, so this reads the PUBLISHED GHCR manifest and needs no
           # local image. crane inherits both logins from ~/.docker/config.json (GHCR from
           # docker/login-action above, zot from the bridge action).
-          retry crane copy "$IMAGE:$TAG" "$ZOT:$TAG" || degraded "$?"
+          retry crane copy "$IMAGE:$TAG" "$ZOT:$TAG" || degraded copy "$?" "crane copy GHCR->zot failed after 3 attempts"
 
           # Digest parity is the entire point of using crane, so ASSERT it — do not infer it
-          # from a zero exit. An empty source digest counts as failure: `|| true` on the
-          # capture means an auth/network fault yields "", and "" == "" would otherwise read
-          # as a match and certify nothing.
-          SRC_DIGEST=$(crane digest "$IMAGE:$TAG" 2>/dev/null || true)
-          DST_DIGEST=$(crane digest "$ZOT:$TAG" 2>/dev/null || true)
+          # from a zero exit. An empty source digest counts as failure: a failed capture
+          # yields "", and "" == "" would otherwise read as a match and certify nothing.
+          #
+          # stderr is CAPTURED, not discarded. `2>/dev/null` collapsed 404 (tag absent), 401
+          # (the credential can push but not read manifests) and connection-reset into one
+          # undifferentiated "unresolvable" with the evidence destroyed — and under
+          # mirror_only that stderr is the ONLY evidence an operator has for a RED backfill.
+          #
+          # Read through a FILE, never `$(retry crane digest …)`: retry's ::notice:: goes to
+          # stdout and would be captured AS the digest, manufacturing a bogus MISMATCH.
+          digest_read() {
+            # $1 = ref, $2 = out file, $3 = err file
+            retry crane digest "$1" >"$2" 2>"$3"
+          }
+          digest_read "$IMAGE:$TAG" "$RUNNER_TEMP/src.digest" "$RUNNER_TEMP/src.err" || true
+          digest_read "$ZOT:$TAG"   "$RUNNER_TEMP/dst.digest" "$RUNNER_TEMP/dst.err" || true
+          # `retry`'s ::notice:: lines land on stdout too, so keep only a sha256: token.
+          SRC_DIGEST=$(grep -oE '^sha256:[0-9a-f]{64}$' "$RUNNER_TEMP/src.digest" | head -1 || true)
+          DST_DIGEST=$(grep -oE '^sha256:[0-9a-f]{64}$' "$RUNNER_TEMP/dst.digest" | head -1 || true)
+          SRC_ERR=$(tail -c 400 "$RUNNER_TEMP/src.err" 2>/dev/null | tr '\n' ' ' || true)
+          DST_ERR=$(tail -c 400 "$RUNNER_TEMP/dst.err" 2>/dev/null | tr '\n' ' ' || true)
           echo "ghcr=${SRC_DIGEST:-<none>} zot=${DST_DIGEST:-<none>}"
           echo "ghcr_digest=$SRC_DIGEST" >> "$GITHUB_OUTPUT"
           echo "zot_digest=$DST_DIGEST" >> "$GITHUB_OUTPUT"
-          if [ -z "$SRC_DIGEST" ] || [ "$SRC_DIGEST" != "$DST_DIGEST" ]; then
-            echo "::error::zot digest parity FAILED for $TAG — ghcr=${SRC_DIGEST:-<none>} zot=${DST_DIGEST:-<none>}. A cloud-init @sha256 pin on this tag would not resolve on zot."
-            degraded 1
-          fi
-
-          echo "mirror_status=ok" >> "$GITHUB_OUTPUT"
-          echo "Mirrored $ZOT:$TAG at $SRC_DIGEST (digest-preserving)"
+          # The discriminating values go to the step summary on BOTH paths. They used to be
+          # appended only AFTER mirror_status=ok, i.e. published on success and withheld on
+          # failure — inverted, since the summary is the layer that survives log truncation.
           {
             echo "### inngest-bootstrap zot mirror"
             echo ""
             echo "| ref | digest |"
             echo "| --- | --- |"
-            echo "| \`$IMAGE:$TAG\` | \`$SRC_DIGEST\` |"
-            echo "| \`$ZOT:$TAG\` | \`$DST_DIGEST\` |"
+            echo "| \`$IMAGE:$TAG\` | \`${SRC_DIGEST:-<none>}\` |"
+            echo "| \`$ZOT:$TAG\` | \`${DST_DIGEST:-<none>}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # "could not measure" and "measured, and they differ" are NOT the same fault and
+          # must not collapse into one bucket: the first is usually auth/reachability and a
+          # re-dispatch may clear it; the second means the copy landed wrong and pinning is
+          # unsafe. Splitting them is why stderr is captured above.
+          if [ -z "$SRC_DIGEST" ] || [ -z "$DST_DIGEST" ]; then
+            echo "::error::zot digest parity UNMEASURABLE for $TAG — ghcr=${SRC_DIGEST:-<none>} zot=${DST_DIGEST:-<none>}. This is not a proven mismatch: one or both reads failed."
+            degraded parity_unmeasured 1 "ghcr_err=${SRC_ERR:-<none>} zot_err=${DST_ERR:-<none>}"
+          fi
+          if [ "$SRC_DIGEST" != "$DST_DIGEST" ]; then
+            echo "::error::zot digest parity FAILED for $TAG — ghcr=${SRC_DIGEST} zot=${DST_DIGEST}. A cloud-init @sha256 pin on this tag would not resolve on zot."
+            degraded parity_mismatch 1 "ghcr=${SRC_DIGEST} zot=${DST_DIGEST}"
+          fi
+
+          # A matching digest proves zot holds the MANIFEST. It does not prove zot still holds
+          # the BLOBS: zot runs gc + dedupe, `crane digest` is a manifest HEAD, and `crane
+          # copy` skips blob upload when the destination HEADs the blob as present — so a
+          # reclaimed layer yields green parity and a `blob unknown` on the host's docker pull.
+          # `crane validate --remote` fetches the manifest AND every blob, which is the
+          # property a pin actually depends on.
+          retry crane validate --remote "$ZOT:$TAG" \
+            || degraded blobs_missing "$?" "manifest digest matches but crane validate --remote failed — zot may have gc'd a layer; a pin would fail at docker pull with 'blob unknown'"
+
+          echo "mirror_status=ok" >> "$GITHUB_OUTPUT"
+          echo "mirror_reason=ok" >> "$GITHUB_OUTPUT"
+          echo "Mirrored $ZOT:$TAG at $SRC_DIGEST (digest-preserving, blobs validated)"
+
+          # WHAT THIS GATE DOES NOT PROVE — state this wherever the gate is described.
+          # It asserts the manifest and blobs are in zot AND readable by the PUSH credential
+          # over the CF-tunnel bridge from a GitHub runner. It does NOT prove the HOST can
+          # pull: the host uses ZOT_PULL_* over the private NIC, and zot's accessControl can
+          # grant push-read without pull-read. There is currently no live probe of
+          # jikig-ai/soleur-inngest-bootstrap from the host side (web-probe.tf scopes to the
+          # web image; zot-entry-gate.sh is SUPERSEDED/UNWIRED), so a green run here is NOT
+          # sufficient evidence to write an @sha256 pin into cloud-init.yml.
+          #
+          # Retention is the second gap: cloud-init-registry.yml keeps only the 5
+          # most-recently-pushed v* tags per repo with deleteUntagged + hourly gc, and its own
+          # comment warns the count "can evict out of order under the ADR-096 crane-copy
+          # backfill path". A pin therefore has a bounded fuse unless the tag is carved out.
+          {
+            echo ""
+            echo "> **This does not license a pin.** Green here means zot serves the digest to"
+            echo "> the PUSH credential over the tunnel. Host-side pull (\`ZOT_PULL_*\`, private"
+            echo "> NIC) is unverified for this repo, and zot retention keeps only the 5 most"
+            echo "> recent \`v*\` tags. See the #7203 review findings."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Tear down cloudflared registry bridge
@@ -398,13 +560,27 @@ jobs:
         # on inngest-bootstrap infra changes, not an operator-triggered release), so a
         # degrade-only ⚠️ is the minimal push signal. Before the ADR-096 Phase-5 GHCR-push
         # retirement a sustained inngest-mirror degrade must not stay annotations-only.
-        if: steps.zot_mirror.outputs.mirror_status == 'degraded'
+        #
+        # `!cancelled() &&` is LOAD-BEARING, not decoration. GitHub prepends an implicit
+        # success() to any step `if:` with no status function — so with the bare expression
+        # this step was SKIPPED on every mirror_only degrade, because degraded() exits 1 with
+        # the belt off and the job is already failed by the time this is evaluated. The one
+        # mode whose whole purpose is to authorise a root-exec digest pin was the one mode
+        # with no push signal, while the mirror step's own comment claimed the opposite.
+        # A failed step's outputs ARE still readable, so mirror_status/mirror_reason resolve
+        # normally here. reusable-release.yml records the identical correction at its own
+        # Slack step after shipping a stale version of this same comment once.
+        if: ${{ !cancelled() && steps.zot_mirror.outputs.mirror_status == 'degraded' }}
         continue-on-error: true
         env:
           SLACK_RELEASES_WEBHOOK_URL: ${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}
           # Resolved image tag (internal, validated by "Resolve image tag") — env-injected,
           # never inline-interpolated into the run script.
           TAG: ${{ steps.tag.outputs.tag }}
+          # Named cause, so the message can say WHICH fault. Empty only if the step died
+          # before writing it.
+          MIRROR_REASON: ${{ steps.zot_mirror.outputs.mirror_reason }}
+          MIRROR_ONLY: ${{ inputs.mirror_only }}
         run: |
           set -uo pipefail
           WEBHOOK="${SLACK_RELEASES_WEBHOOK_URL:-}"
@@ -414,8 +590,16 @@ jobs:
           fi
           echo "::add-mask::$WEBHOOK"
 
-          MESSAGE="⚠️ inngest-bootstrap zot mirror degraded ($TAG) — GHCR unaffected, zot redundancy reduced; backfill needed."
-          # jq --arg keeps the payload injection-inert (TAG is JSON-escaped).
+          # Mode-aware: the same fault means opposite things on the two paths. On the build
+          # path the release stands and zot redundancy is reduced; under mirror_only the run
+          # IS the backfill, it is RED, and the operator must not pin.
+          REASON="${MIRROR_REASON:-unknown}"
+          if [ "${MIRROR_ONLY:-false}" = "true" ]; then
+            MESSAGE="❌ inngest-bootstrap mirror_only backfill FAILED ($TAG, reason=$REASON) — zot does not serve the GHCR digest. DO NOT pin cloud-init to this tag."
+          else
+            MESSAGE="⚠️ inngest-bootstrap zot mirror degraded ($TAG, reason=$REASON) — GHCR unaffected, zot redundancy reduced; backfill needed."
+          fi
+          # jq --arg keeps the payload injection-inert (TAG/REASON are JSON-escaped).
           PAYLOAD=$(jq -n --arg text "$MESSAGE" '{text: $text, unfurl_links: false}')
 
           # `|| echo 000` keeps a curl transport failure (timeout, DNS) on the ::warning

--- a/.github/workflows/build-inngest-bootstrap-image.yml
+++ b/.github/workflows/build-inngest-bootstrap-image.yml
@@ -360,12 +360,21 @@ jobs:
           # exists to remove.
           set -uo pipefail
 
-          # BACKSTOP for the above. Without `set -e`, a future fallible command added with no
+          # BACKSTOP for the above. Without `set -e`, a future fallible COMMAND added with no
           # `|| degraded` route fails silently and execution falls through to
           # `mirror_status=ok` — a green run with no mirror. The ERR trap makes that a named
           # degrade instead of a false green. `set -E` propagates it into functions.
+          #
+          # SCOPE, precisely: this covers a command exiting non-zero. It does NOT cover a
+          # `set -u` unbound-variable abort, which bypasses the ERR trap entirely (measured:
+          # exit 1, no trap line). On the build path continue-on-error then turns that into a
+          # green run with mirror_status UNSET — the exact silence this trap exists to remove.
+          # So assert the external variables this block depends on, rather than relying on the
+          # trap to catch their absence. RUNNER_TEMP is always set on ubuntu-latest without a
+          # container:, so this is a guard against future drift, not a live fault.
           set -E
           trap 'degraded unrouted "$?" "a command failed with no explicit || degraded route — this is a workflow bug, not an infrastructure fault"' ERR
+          : "${RUNNER_TEMP:?RUNNER_TEMP unset — the digest capture below writes there}"
 
           # Bounded retry to self-heal a transient TCP reset over the CF-tunnel
           # bridge. 3 attempts, 5s then 15s backoff. Idempotent ops only — `crane copy`
@@ -418,6 +427,12 @@ jobs:
           # websocket upgrade), would produce a green run with no annotation, no summary line
           # and no Slack. Branching here instead routes it through the same emitter as every
           # other fault.
+          #
+          # `!= "success"` here, where reusable-release.yml deliberately uses `== 'failure'`.
+          # The divergence is intentional and safe, not a porting slip: the sibling's bridge is
+          # gated, so `skipped` is reachable there and would produce a misleading "degraded".
+          # This bridge carries no `if:`, so it can only be `skipped` when success() is already
+          # false — in which case this step is skipped too, and the branch is unreachable.
           if [ "${BRIDGE_OUTCOME:-}" != "success" ]; then
             degraded bridge_down 1 "cf-tunnel-registry-bridge outcome=${BRIDGE_OUTCOME:-<unset>}; zot was never reachable from this runner"
           fi
@@ -480,6 +495,12 @@ jobs:
           # `retry`'s ::notice:: lines land on stdout too, so keep only a sha256: token.
           SRC_DIGEST=$(grep -oE '^sha256:[0-9a-f]{64}$' "$RUNNER_TEMP/src.digest" | head -1 || true)
           DST_DIGEST=$(grep -oE '^sha256:[0-9a-f]{64}$' "$RUNNER_TEMP/dst.digest" | head -1 || true)
+          # The `tr '\n' ' '` is a WORKFLOW-COMMAND INJECTION GUARD, not formatting — do not
+          # "keep the linebreaks for readability". This stderr is externally-influenced text
+          # from a registry, and it is interpolated into `echo "::error::…"` below. GitHub
+          # parses workflow commands per LINE, so a newline followed by `::add-mask::` or
+          # `::error::` in that stderr would be executed as a command. Collapsing newlines
+          # makes the whole capture a single un-parseable payload.
           SRC_ERR=$(tail -c 400 "$RUNNER_TEMP/src.err" 2>/dev/null | tr '\n' ' ' || true)
           DST_ERR=$(tail -c 400 "$RUNNER_TEMP/dst.err" 2>/dev/null | tr '\n' ' ' || true)
           echo "ghcr=${SRC_DIGEST:-<none>} zot=${DST_DIGEST:-<none>}"
@@ -531,8 +552,17 @@ jobs:
           #   retry crane validate --remote "$ZOT:$TAG" \
           #     || degraded blobs_missing "$?" "manifest digest matches but blobs are missing"
           # Until then a failure is recorded and reported, and nothing is gated on it.
+          # `timeout 300` is load-bearing, not hygiene. "Non-blocking" holds for EXIT CODES;
+          # it does not hold for wall clock, and this job declares no `timeout-minutes` (so it
+          # inherits GitHub's 360-minute default). The unverified case named above — crane
+          # guessing the wrong scheme against the tunnelled loopback listener — fails as a
+          # STALL, not a clean non-zero: the local port binds and accepts, then the origin hop
+          # hangs. Three retried stalls would burn the job timeout and RED a tag-push release
+          # from a check documented as unable to affect the outcome. `timeout` exits 124,
+          # which the else-arm reports as blob_validate=failed with the rc — better promotion
+          # evidence than a job timeout, and it keeps the dark-launch property intact.
           blob_rc=0
-          retry crane validate --remote "$ZOT:$TAG" || blob_rc=$?
+          retry timeout 300 crane validate --remote "$ZOT:$TAG" || blob_rc=$?
           if [ "$blob_rc" = 0 ]; then
             echo "blob_validate=ok" >> "$GITHUB_OUTPUT"
           else
@@ -590,8 +620,16 @@ jobs:
         # mode whose whole purpose is to authorise a root-exec digest pin was the one mode
         # with no push signal, while the mirror step's own comment claimed the opposite.
         # A failed step's outputs ARE still readable, so mirror_status/mirror_reason resolve
-        # normally here. reusable-release.yml records the identical correction at its own
-        # Slack step after shipping a stale version of this same comment once.
+        # normally here.
+        #
+        # This workflow is AHEAD of reusable-release.yml here, NOT in parity with it — do not
+        # go looking to "port the correction back". Measured: `cancelled()` occurs ZERO times
+        # in that file. Its `Post to Slack (release)` carries a plain-expression `if:`, and
+        # its own comment states the consequence outright ("this Slack step does not run at
+        # all"). Its failure-path signal is a DIFFERENT step — `Email notification (release
+        # FAILED)`, `if: failure()`, reading mirror_reason — so a blocking mirror failure
+        # there yields no Slack. Tracked separately (#7256); fixing it inline here would
+        # collide with the in-flight #7242 work on that same file.
         if: ${{ !cancelled() && steps.zot_mirror.outputs.mirror_status == 'degraded' }}
         continue-on-error: true
         env:

--- a/.github/workflows/infra-validation.yml
+++ b/.github/workflows/infra-validation.yml
@@ -45,6 +45,18 @@ on:
       - ".github/workflows/git-data-rung2-rehearsal.yml"
       - ".github/workflows/apply-web-platform-infra.yml"
       - ".github/workflows/scheduled-terraform-drift.yml"
+      # (#7203 review) inngest-bootstrap-mirror-only.test.sh asserts ~30 properties OF
+      # build-inngest-bootstrap-image.yml -- the mirror_only gating, the belt posture on both
+      # trigger paths, the bridge-outcome branch, and the behavioural degraded() contract.
+      # That workflow was not listed here, so the suite could not fire on the file it guards:
+      # a PR restoring `continue-on-error: true` under mirror_only, or re-adding the
+      # `if: steps.zot_bridge.outcome == 'success'` gate, touches no apps/*/infra/** path and
+      # would have skipped its own guard entirely. #7203 ran this job only incidentally,
+      # because it also ADDED the suite file under apps/web-platform/infra/.
+      # Same defect class as the #6454, #6178 and #7025 comments above.
+      # cutover-inngest-workflow.test.sh also reads this workflow (its BUILD_IMG variable),
+      # so the same one-line addition closes that pre-existing gap too.
+      - ".github/workflows/build-inngest-bootstrap-image.yml"
       # (#6178) cutover-inngest-workflow.test.sh asserts ~90 properties OF cutover-inngest.yml
       # -- the anchor derivation, the non-vacuity gate, the per-arm window split, the null-safe
       # bucketing, and the emitter-parity of the flip-FSM reason set. Without this path a PR that

--- a/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
+++ b/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
@@ -46,8 +46,11 @@ trap 'rm -rf "$SCRATCH"' EXIT INT TERM HUP
 # --- structural assertions, parsed as YAML ------------------------------------------------
 # The python leg writes one TSV verdict per line; bash reports them. Same split as the
 # sibling workflow suites (workspaces-luks-cutover-workflow.test.sh).
-python3 - "$WF" "$SCRATCH" > "$SCRATCH/verdicts.tsv" <<'PY'
-import sys, yaml
+# No `> "$SCRATCH/verdicts.tsv"` redirect here: the python block opens that same path itself.
+# Two writers to one path works only while nothing prints to stdout — any future print()
+# lands at offset 0 and corrupts verdict line 1.
+python3 - "$WF" "$SCRATCH" <<'PY'
+import re, sys, yaml
 
 wf = yaml.safe_load(open(sys.argv[1]))
 scratch = sys.argv[2]
@@ -75,70 +78,180 @@ if isinstance(mo, dict):
 
 steps = ((wf.get("jobs") or {}).get("build") or {}).get("steps") or []
 by_id = {s.get("id"): s for s in steps if s.get("id")}
-named = {str(s.get("name", "")): s for s in steps}
+
+
+def code_of(body):
+    """Shell body with whole-line and trailing comments removed.
+
+    LOAD-BEARING, not tidiness. Every `X in body` assertion below is a substring grep over
+    text that carries its OWN rationale comments, and this workflow's comments name every
+    construct being asserted at length. Measured on the #7203 tree: reverting the entire
+    change -- `crane copy` back to `docker tag` + `docker push` in brace form -- passed all
+    25 assertions, because `check("mirror uses crane copy", "crane copy" in body)` was
+    satisfied by the comment the same commit added inside the step. Stripping the comment
+    and re-running the identical mutant turned it RED, proving the comment was the sole
+    anchor. cq-assert-anchor-not-bare-token; the file header used to claim immunity from
+    this while having it.
+
+    Not a full lexer: `#` inside a double-quoted string would be over-stripped. No such
+    string exists in this body, and the failure direction is safe -- over-stripping can only
+    make an assertion FAIL, never pass vacuously.
+    """
+    out = []
+    for line in body.splitlines():
+        stripped = re.sub(r'(?<!\S)#.*$', '', line)
+        out.append(stripped)
+    return "\n".join(out)
+
 
 # EXACT-STRING equality throughout. The risk on every one of these is OPERAND INVERSION
 # (`inputs.mirror_only` where `!inputs.mirror_only` belongs), and an inversion is invisible
 # to a substring check while flipping the meaning completely.
 GUARD = "${{ !inputs.mirror_only }}"
 
-build = next((s for s in steps if str(s.get("name", "")).startswith("Build + verify + push")), None)
-check("build step exists", build is not None)
-if build:
-    # (2) The rebuild must not run under mirror_only: `docker build` + push of the SAME tag
-    # MOVES the tag's GHCR digest, which is the one thing a digest backfill must not do.
-    check("build step is skipped under mirror_only (exact !inputs.mirror_only)",
-          build.get("if") == GUARD, repr(build.get("if")))
+# ALL matches, not `next(...)`. A first-match lookup asserts about a representative rather
+# than about the set: adding a SECOND, unguarded "Build + verify + push (retry shim)" step
+# left the old suite fully green while a rebuild under mirror_only moved the tag's GHCR
+# digest -- the one thing a digest backfill must not do.
+builds = [s for s in steps if str(s.get("name", "")).startswith("Build + verify + push")]
+check("at least one build step exists", len(builds) >= 1, f"found {len(builds)}")
+check("EVERY build+push step is skipped under mirror_only (exact !inputs.mirror_only)",
+      all(s.get("if") == GUARD for s in builds),
+      repr([s.get("if") for s in builds]))
+
+# The `pin` step feeds ONLY the build step's env, and its greps have no `|| true` under
+# `set -euo pipefail` -- ungated it can red a backfill of an old tag whose infra/ layout
+# differs, a fault with no relationship to the mirror.
+pin = by_id.get("pin")
+check("the pin-reading step is gated to match the build step it feeds",
+      pin is not None and pin.get("if") == GUARD,
+      repr(pin.get("if")) if pin else "no step with id: pin")
+
+# NEGATIVE assertion, and the reason it exists: `mirror_only` skips the build, which makes
+# the GHCR login look vestigial to a future reader -- while it is in fact crane's SOLE
+# source of GHCR READ credential. #7203 established the precedent of gating build-path
+# steps on !inputs.mirror_only; applying that one step up silently breaks `crane copy`.
+login = next((s for s in steps if "login" in str(s.get("name", "")).lower()
+              and "ghcr" in str(s.get("name", "")).lower()), None)
+check("the GHCR login step exists", login is not None)
+if login:
+    check("GHCR login is NOT gated off under mirror_only (crane's source credential)",
+          login.get("if") is None, repr(login.get("if")))
 
 bridge = by_id.get("zot_bridge")
 check("zot_bridge step exists", bridge is not None)
 if bridge:
-    # (3) THE COUPLING. See the header. A hardcoded `true` here re-opens the false-green.
-    check("zot_bridge drops continue-on-error under mirror_only (exact !inputs.mirror_only)",
-          bridge.get("continue-on-error") == GUARD, repr(bridge.get("continue-on-error")))
+    # The belt is UNCONDITIONAL now. What makes a bridge failure red a mirror_only run is
+    # the internal BRIDGE_OUTCOME branch below, not this marker -- so that a bridge failure
+    # reaches the emitter on BOTH paths instead of skipping the step (#6416).
+    check("zot_bridge keeps continue-on-error: true unconditionally",
+          bridge.get("continue-on-error") is True, repr(bridge.get("continue-on-error")))
 
 mirror = by_id.get("zot_mirror")
 check("zot_mirror step exists", mirror is not None)
 if mirror:
     check("zot_mirror drops continue-on-error under mirror_only (exact !inputs.mirror_only)",
           mirror.get("continue-on-error") == GUARD, repr(mirror.get("continue-on-error")))
-    # Asserted so the coupling that makes (3) load-bearing cannot be silently removed:
-    # if this gate ever goes away, the bridge belt stops mattering and this suite would
-    # otherwise keep passing while guarding a property that no longer exists.
-    check("zot_mirror is gated on zot_bridge succeeding (the coupling behind the belt-off)",
-          mirror.get("if") == "steps.zot_bridge.outcome == 'success'", repr(mirror.get("if")))
+    # THE #6416 INVARIANT, stated as a NEGATIVE. A gate on the bridge's outcome SKIPS this
+    # step, and a skipped step emits no `mirror_status` -- so every degrade signal the
+    # workflow owns becomes unreachable in the one case worth reporting. The previous
+    # revision asserted the OPPOSITE (that the gate was present), which would have turned
+    # this suite red the moment anyone ported the known-good sibling fix.
+    check("zot_mirror is NOT gated on the bridge outcome (a skipped step cannot emit)",
+          mirror.get("if") is None, repr(mirror.get("if")))
 
     env = mirror.get("env") or {}
     check("MIRROR_ONLY reaches the script via env:, not interpolation",
           env.get("MIRROR_ONLY") == "${{ inputs.mirror_only }}", repr(env.get("MIRROR_ONLY")))
+    # OUTCOME, never CONCLUSION: continue-on-error forces conclusion to 'success' while
+    # outcome keeps the true result. Reading conclusion masks every bridge failure.
+    check("the bridge result reaches the script as OUTCOME, not conclusion",
+          env.get("BRIDGE_OUTCOME") == "${{ steps.zot_bridge.outcome }}",
+          repr(env.get("BRIDGE_OUTCOME")))
 
     body = mirror.get("run") or ""
+    code = code_of(body)
     open(f"{scratch}/mirror-body.sh", "w").write(body)
 
     # (1) crane copy replaces docker tag+push. Registry->registry preserves the manifest
     # bytes, so ONE @sha256 resolves on both registries; `docker tag`+`push` re-creates the
-    # manifest and was the original defect.
-    check("mirror uses `crane copy` for the GHCR->zot hop", "crane copy" in body)
-    check("no `docker push` to the zot ref survives", 'docker push "$ZOT' not in body)
-    check("no `docker tag` to the zot ref survives", 'docker tag "$IMAGE:$TAG" "$ZOT' not in body)
-    check("crane tarball is SHA-pinned before extraction", "sha256sum -c -" in body)
+    # manifest and was the original defect. Asserted against `code`, so the step's own
+    # rationale comments cannot satisfy it.
+    check("mirror uses `crane copy` for the GHCR->zot hop", "crane copy" in code)
+    # Brace-form-tolerant: `docker push "${ZOT}:${TAG}"` walked past the old dollar-only
+    # patterns, which is how a full revert of this change passed the suite.
+    check("no `docker push` to the zot ref survives",
+          not re.search(r'docker\s+push\s+"?\$\{?ZOT', code))
+    check("no `docker tag` onto the zot ref survives",
+          not re.search(r'docker\s+tag\s+.*\$\{?ZOT', code))
 
-    # (2 of the parity assertion) An EMPTY source digest must count as failure. `|| true` on
-    # the capture means an auth/network fault yields "", and "" == "" would otherwise read
-    # as a match and certify nothing.
-    check("parity check treats an EMPTY source digest as failure",
-          '-z "$SRC_DIGEST"' in body, "expected a -z guard on SRC_DIGEST")
-    check("parity check compares the two digests",
-          '"$SRC_DIGEST" != "$DST_DIGEST"' in body)
-    # Ordering matters: a `mirror_status=ok` written before the comparison would certify
-    # the run regardless of the verdict.
-    if "mirror_status=ok" in body and '-z "$SRC_DIGEST"' in body:
-        check("mirror_status=ok is written AFTER the parity check, not before",
-              body.index('-z "$SRC_DIGEST"') < body.index("mirror_status=ok"))
+    # ORDERED, not merely present. The name says "before extraction"; substring membership
+    # cannot support that verb, and swapping the two lines so an unverified tarball is
+    # extracted as root passed the old check.
+    if "sha256sum -c -" in code and "tar -xzf" in code:
+        check("crane tarball is SHA-verified BEFORE extraction (ordered)",
+              code.index("sha256sum -c -") < code.index("tar -xzf"))
+    else:
+        check("crane tarball is SHA-verified BEFORE extraction (ordered)", False,
+              "one of sha256sum/tar is missing entirely")
+
+    # The bridge branch must exist AND must route to degraded(), not merely mention the var.
+    check("a bridge-down branch routes to degraded()",
+          re.search(r'BRIDGE_OUTCOME.*\n(?:.*\n)?\s*degraded\s+bridge_down', code) is not None,
+          "expected a BRIDGE_OUTCOME test whose body calls `degraded bridge_down`")
+
+    # CONSEQUENCE, not presence. Deleting `degraded 1` from the mismatch branch left the old
+    # suite 25/25 green while execution fell through to `mirror_status=ok` -- parity became
+    # advisory, which is the exact false-green this file exists to prevent.
+    check("an unmeasurable parity read routes to degraded()",
+          re.search(r'-z "\$SRC_DIGEST".*\n(?:.*\n)*?\s*degraded\s+parity_unmeasured', code) is not None)
+    check("a parity MISMATCH routes to degraded()",
+          re.search(r'"\$SRC_DIGEST" != "\$DST_DIGEST".*\n(?:.*\n)*?\s*degraded\s+parity_mismatch', code) is not None)
+    # A matching manifest digest does not prove the blobs are still present: zot runs gc +
+    # dedupe and `crane copy` skips blobs the destination already HEADs as present.
+    #
+    # Anchored at CALL POSITION, not as a bare substring. Comment-stripping is not enough
+    # here: degraded()'s own message string names this construct ("manifest digest matches
+    # but crane validate --remote failed"), and a message is not a comment, so `code` still
+    # contains the token after the call is deleted. Measured — the bare-substring form
+    # survived a mutation that replaced the invocation with `true`. cq-assert-anchor-not-bare-token
+    # applies to STRING LITERALS too, not just comments.
+    check("blob presence is validated at call position, not inferred from the digest",
+          re.search(r'^\s*retry\s+crane\s+validate\s+--remote\s+"\$ZOT', code, re.M) is not None,
+          "expected a `retry crane validate --remote \"$ZOT...` invocation at line start")
+
+    # Ordering: a `mirror_status=ok` written before the comparison certifies regardless of
+    # the verdict. Unconditional now -- the old `if ... in body` form silently emitted NO
+    # verdict when either token vanished, so deleting the token dropped an assertion instead
+    # of failing one.
+    have_ok = "mirror_status=ok" in code
+    have_guard = '-z "$SRC_DIGEST"' in code
+    check("mirror_status=ok is written AFTER the parity check, not before",
+          have_ok and have_guard and code.index('-z "$SRC_DIGEST"') < code.index("mirror_status=ok"),
+          f"ok={have_ok} guard={have_guard}")
 
     # (4) degraded() must exit 1 under mirror_only. Asserted structurally here and
     # EXECUTED in the behavioral leg below.
-    check("degraded() has a mirror_only arm", 'MIRROR_ONLY:-false' in body)
+    check("degraded() has a mirror_only arm", 'MIRROR_ONLY:-false' in code)
+    # The ERR trap is the backstop for the deliberate absence of `set -e`: without it a
+    # future fallible command with no `|| degraded` route falls through to mirror_status=ok.
+    # Anchored on `trap` at COMMAND position (line start), for the same reason as the
+    # validate check above: a bare `trap ... ERR` substring is satisfied by any line that
+    # merely mentions the construct.
+    check("an ERR trap routes unrouted failures to degraded()",
+          re.search(r"^\s*trap\s+'degraded\s+unrouted.*'\s+ERR\s*$", code, re.M) is not None,
+          "expected a `trap 'degraded unrouted ...' ERR` at command position")
+
+# The Slack degrade step must carry a STATUS FUNCTION. Without one GitHub prepends an
+# implicit success(), so the step is skipped on exactly the mirror_only degrades it exists
+# to report -- the mode that authorises a root-exec digest pin had no push signal at all.
+slack = next((s for s in steps if "slack" in str(s.get("name", "")).lower()), None)
+check("the Slack degrade step exists", slack is not None)
+if slack:
+    slack_if = str(slack.get("if") or "")
+    check("the Slack gate carries a status function (else implicit success() skips it)",
+          any(fn in slack_if for fn in ("!cancelled()", "always()", "failure()")),
+          repr(slack_if))
 
 with open(f"{scratch}/verdicts.tsv", "w") as fh:
     for status, name, detail in verdicts:
@@ -172,19 +285,30 @@ open(sys.argv[2], "w").write("\n".join(lines[start:end + 1]) + "\n")
 PY
 
   run_degraded() {
+    # $1 = the MIRROR_ONLY value under test. Slot name, not the value, so the empty-string
+    # case gets its own files.
+    local slot="${2:-$1}"
     # Subshell so `exit` inside degraded() ends only this invocation. GITHUB_* point at
     # scratch files because the real function appends to both.
     (
       set -uo pipefail
-      GITHUB_OUTPUT="$SCRATCH/out.$1"; GITHUB_STEP_SUMMARY="$SCRATCH/sum.$1"
+      GITHUB_OUTPUT="$SCRATCH/out.$slot"; GITHUB_STEP_SUMMARY="$SCRATCH/sum.$slot"
       export GITHUB_OUTPUT GITHUB_STEP_SUMMARY
       : > "$GITHUB_OUTPUT"; : > "$GITHUB_STEP_SUMMARY"
       MIRROR_ONLY="$1" TAG="vinngest-v0.0.0-test" ZOT="127.0.0.1:5000/test/image"
-      export MIRROR_ONLY TAG ZOT
+      IMAGE="ghcr.io/jikig-ai/soleur-inngest-bootstrap"
+      export MIRROR_ONLY TAG ZOT IMAGE
       # shellcheck source=/dev/null
       source "$SCRATCH/degraded.sh"
-      degraded 7
-    ) >"$SCRATCH/log.$1" 2>&1
+      degraded test_reason 7
+      # SENTINEL. Reached only if degraded() RETURNED instead of EXITING. Without this the
+      # two are indistinguishable here — `degraded` is the subshell's last command, so
+      # `return 1` and `exit 1` both make the subshell exit 1. In the real step body
+      # degraded() is called at top level with no `set -e`, so a `return` lets execution
+      # fall through to `mirror_status=ok`: a green run with no mirror. The file header
+      # claims this leg catches exactly that mutant; before the sentinel it did not.
+      echo "SENTINEL_REACHED_degraded_returned_instead_of_exiting"
+    ) >"$SCRATCH/log.$slot" 2>&1
   }
 
   # BUILD path: the mirror is secondary to the GHCR release, so a degrade must NOT red it.
@@ -207,8 +331,66 @@ PY
   grep -q "::error::" "$SCRATCH/log.true" \
     && ok "degraded() emits an ::error:: annotation under mirror_only" \
     || no "degraded() emitted no ::error:: under mirror_only"
+
+  # PUSH path. On `push: tags` the inputs context is empty, so `${{ inputs.mirror_only }}`
+  # renders the EMPTY STRING — not "false". "false" is only ever produced by an explicit
+  # dispatch with the box unchecked, so both prior fixtures tested a value the release path
+  # never sees. This pins the `:-` colon form: rewriting it to `${MIRROR_ONLY-false}` (bare,
+  # substitutes on unset only) would make the empty string fall through to the mirror_only
+  # arm and RED every tag-push release on a transient mirror fault.
+  if run_degraded "" empty; then
+    ok "degraded() exits 0 when MIRROR_ONLY is the empty string (the real push-path value)"
+  else
+    no "degraded() exited non-zero with MIRROR_ONLY='' — this reds every tag-push release on a transient mirror fault"
+  fi
+
+  # The sentinel must never print on ANY path — see run_degraded().
+  if grep -rqs "SENTINEL_REACHED" "$SCRATCH"/log.*; then
+    no "degraded() RETURNED instead of exiting — execution would fall through to mirror_status=ok (green run, no mirror)"
+  else
+    ok "degraded() exits rather than returns on every path (no fall-through to mirror_status=ok)"
+  fi
+
+  # Named cause, not just a status. A single 'degraded' bucket cannot tell a supply-chain
+  # checksum mismatch from a transient TCP reset, and mirror_reason is what the Slack
+  # message and any future consumer read.
+  grep -q "mirror_reason=test_reason" "$SCRATCH/out.false" \
+    && ok "degraded() records the named reason as mirror_reason" \
+    || no "degraded() did not write mirror_reason (the Slack message and step summary key on it)"
 fi
+
+# --- cross-workflow crane pin parity -------------------------------------------------------
+# The mirror step's own comment says "keep the three in step". That was unenforced prose; a
+# drifted pin in one workflow is exactly the sort of thing a comment cannot catch.
+CRANE_SHA_EXPECTED="c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137f44b"
+for wf in .github/workflows/build-inngest-bootstrap-image.yml \
+          .github/workflows/build-inngest-config-bundle.yml \
+          .github/workflows/reusable-release.yml; do
+  if [[ ! -f "$wf" ]]; then
+    no "crane pin parity: $wf not found"
+  elif grep -qF "$CRANE_SHA_EXPECTED" "$wf"; then
+    ok "crane SHA256 pin matches across workflows — $(basename "$wf")"
+  else
+    no "crane SHA256 pin DRIFTED in $wf (expected $CRANE_SHA_EXPECTED)"
+  fi
+done
 
 echo ""
 echo "passed: $pass  failed: $fail"
+
+# ANTI-VACUITY FLOOR. Without it the ONLY merge gate is `fail == 0`, and a suite that ran
+# ZERO assertions satisfies that trivially: neutering the verdict emitter printed
+# `passed: 0  failed: 0` and exited 0, i.e. CI green over a suite asserting nothing. A green
+# run must carry evidence that the assertions actually executed.
+#
+# A FLOOR (-lt), never equality: one assertion is legitimately conditional, so the count has
+# real variance and pinning it exactly would flake on every addition. Derived from a green
+# run, not from the number expected. The sibling this file is modelled on
+# (workspaces-luks-cutover-workflow.test.sh) carries the same shape.
+MIN_ASSERTIONS=30
+if (( pass + fail < MIN_ASSERTIONS )); then
+  echo "FAIL - only $((pass + fail)) assertions ran (floor $MIN_ASSERTIONS) — a green run here would be vacuous"
+  exit 1
+fi
+
 (( fail == 0 )) || exit 1

--- a/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
+++ b/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
@@ -219,6 +219,15 @@ if mirror:
     check("blob presence is validated at call position, not inferred from the digest",
           re.search(r'^\s*retry\s+crane\s+validate\s+--remote\s+"\$ZOT', code, re.M) is not None,
           "expected a `retry crane validate --remote \"$ZOT...` invocation at line start")
+    # DARK-LAUNCH POSTURE (wg-dark-launch-deploy-gates). The blob check is runtime-unvalidated
+    # against this registry, so it must NOT gate until observed passing on a real run. Pinned
+    # in both directions: it must record a verdict (so the promotion criterion is measurable)
+    # and it must NOT route to degraded() (so a heuristic mismatch cannot red every release).
+    check("blob validation records a verdict for the promotion criterion",
+          re.search(r'^\s*echo "blob_validate=ok" >> "\$GITHUB_OUTPUT"', code, re.M) is not None)
+    check("blob validation is NON-BLOCKING while dark-launched (does not reach degraded)",
+          re.search(r'crane\s+validate\s+--remote[^\n]*\|\|\s*degraded', code) is None,
+          "a dark-launched gate must not route to degraded() until promoted")
 
     # Ordering: a `mirror_status=ok` written before the comparison certifies regardless of
     # the verdict. Unconditional now -- the old `if ... in body` form silently emitted NO

--- a/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
+++ b/apps/web-platform/infra/inngest-bootstrap-mirror-only.test.sh
@@ -15,16 +15,34 @@
 # `inngest_ghcr_fallback` permanently. Precedent for the failure class:
 # knowledge-base/engineering/operations/post-mortems/2026-07-29-v0244-1-published-green-with-an-unpullable-image-postmortem.md
 #
-# THE COUPLING THAT MOTIVATES (3). The mirror step is gated on
-# `steps.zot_bridge.outcome == 'success'`. A `continue-on-error: true` bridge therefore
-# SOFT-FAILS into a SKIPPED mirror and a GREEN job — the belt-off on the mirror step alone
-# does not close it, because a skipped step never reaches its own degrade path. Both steps
-# must drop the belt under mirror_only, or the guarantee above is false.
+# WHY THE MIRROR IS NOT GATED ON THE BRIDGE. An earlier revision of this file gated the
+# mirror on `steps.zot_bridge.outcome == 'success'` and asserted that gate as REQUIRED.
+# That is the #6416 defect: a `continue-on-error: true` bridge SOFT-FAILS into a SKIPPED
+# mirror, and a skipped step never reaches its own degrade path — so `mirror_status` stays
+# unset and every signal this workflow owns (::warning::, step summary, Slack) is
+# unreachable in the one case worth reporting. The bridge is also the step the measured
+# fault class actually kills (#7242).
 #
-# EVERY structural assertion parses the file as YAML, never greps it. This file's own
-# header names `continue-on-error`, `mirror_only` and `crane copy` at length, and the
-# workflow's does the same — a bare grep matches the prose describing the property and
-# passes vacuously (cq-assert-anchor-not-bare-token).
+# So the invariant is the INVERSE of what this header used to prescribe: `zot_bridge` keeps
+# `continue-on-error: true` UNCONDITIONALLY, `zot_mirror` carries NO `if:`, and the bridge
+# result reaches the script as the BRIDGE_OUTCOME env var to be branched on internally.
+# The belt-off under mirror_only lives on the MIRROR step alone, and what makes a bridge
+# failure red a mirror_only run is `degraded bridge_down` exiting 1 — not the scheduler.
+#
+# Structural assertions parse the file as YAML rather than grepping the raw text, and every
+# assertion over a step's `run:` BODY runs against `code_of(body)` — comments stripped.
+# Both matter: this file's own header names `continue-on-error`, `mirror_only` and
+# `crane copy` at length, and the workflow's does the same, so a bare grep matches the prose
+# DESCRIBING the property and passes vacuously (cq-assert-anchor-not-bare-token). That is
+# not hypothetical — it is measured: before comment-stripping, reverting the entire change
+# passed all 25 assertions. Note that `code_of` strips comments but NOT string literals, so
+# an assertion can still be satisfied by a `degraded()` message naming the construct;
+# anchor those at call position (see the crane-validate and ERR-trap checks).
+#
+# The cross-workflow crane-pin leg at the end greps three files directly rather than parsing
+# them — it compares a pinned literal, not a property of this workflow's structure. It anchors
+# on the ASSIGNMENT (`^\s*CRANE_SHA256="<sha>"`), because a bare whole-file match is satisfied
+# by a comment recording the OLD pin above a drifted one.
 #
 # The behavioral leg EXECUTES the workflow's own extracted `degraded()` — the real function
 # body, not a model of it — under both MIRROR_ONLY values.
@@ -76,8 +94,24 @@ if isinstance(mo, dict):
     check("mirror_only is not required (release path omits it)",
           mo.get("required") in (False, None), repr(mo.get("required")))
 
-steps = ((wf.get("jobs") or {}).get("build") or {}).get("steps") or []
+jobs = wf.get("jobs") or {}
+steps = ((jobs.get("build")) or {}).get("steps") or []
 by_id = {s.get("id"): s for s in steps if s.get("id")}
+
+# --- JOB-LEVEL SURFACE. Every step-level belt below is defeatable one indent level up, and
+# that surface was completely unparsed: a job-level `if: !inputs.mirror_only` skips the WHOLE
+# job under mirror_only (workflow reports SUCCESS, nothing mirrored, no mirror_status, no
+# Slack), and a job-level `continue-on-error: true` reports the workflow green while the
+# mirror step fails. Both are one-line edits and both passed the previous revision 42/0.
+check("the workflow has exactly the `build` job (a second job is an unparsed surface)",
+      sorted(jobs) == ["build"], repr(sorted(jobs)))
+_bj = jobs.get("build") or {}
+check("jobs.build carries no job-level if: (it would skip the whole mirror)",
+      "if" not in _bj, repr(_bj.get("if")))
+check("jobs.build carries no job-level continue-on-error: (it would mask a red mirror)",
+      "continue-on-error" not in _bj, repr(_bj.get("continue-on-error")))
+check("jobs.build carries no matrix strategy (it would race duplicate mirrors of one tag)",
+      "strategy" not in _bj, repr(_bj.get("strategy")))
 
 
 def code_of(body):
@@ -93,14 +127,41 @@ def code_of(body):
     anchor. cq-assert-anchor-not-bare-token; the file header used to claim immunity from
     this while having it.
 
-    Not a full lexer: `#` inside a double-quoted string would be over-stripped. No such
-    string exists in this body, and the failure direction is safe -- over-stripping can only
-    make an assertion FAIL, never pass vacuously.
+    Quote-aware, and it has to be. The naive `re.sub(r'(?<!\S)#.*$', '')` over-strips at a
+    `#` inside a string -- and such a string EXISTS in this body today (the step-summary line
+    ending `See the #7203 review findings.`). That is not a cosmetic truncation:
+
+      * three assertions below are NEGATIVE (`no docker push`, `no docker tag`, the
+        dark-launch non-blocking check). Over-stripping DELETES the text they search for, so
+        they pass vacuously -- the failure direction is NOT safe, contrary to what this
+        docstring used to claim.
+      * measured: reverting to `docker tag`/`docker push` while ending the line with a
+        `(see #7203)` comment-shaped suffix passed the whole suite; the identical edit
+        spelled `(see issue 7203)` was killed. The `#` was doing all of the evasion.
+
+    So track quote state and only treat an UNQUOTED `#` at a word boundary as a comment.
+    Backslash escapes are honoured. Heredocs are not modelled -- this body has none, and a
+    future one would over-strip (loud FAIL on positives) rather than under-strip.
     """
     out = []
     for line in body.splitlines():
-        stripped = re.sub(r'(?<!\S)#.*$', '', line)
-        out.append(stripped)
+        res, quote, i, esc = [], None, 0, False
+        while i < len(line):
+            ch = line[i]
+            if esc:
+                res.append(ch); esc = False; i += 1; continue
+            if ch == "\\" and quote != "'":
+                res.append(ch); esc = True; i += 1; continue
+            if quote:
+                if ch == quote:
+                    quote = None
+                res.append(ch); i += 1; continue
+            if ch in ("'", '"'):
+                quote = ch; res.append(ch); i += 1; continue
+            if ch == "#" and (i == 0 or line[i - 1].isspace()):
+                break
+            res.append(ch); i += 1
+        out.append("".join(res))
     return "\n".join(out)
 
 
@@ -109,15 +170,57 @@ def code_of(body):
 # to a substring check while flipping the meaning completely.
 GUARD = "${{ !inputs.mirror_only }}"
 
-# ALL matches, not `next(...)`. A first-match lookup asserts about a representative rather
-# than about the set: adding a SECOND, unguarded "Build + verify + push (retry shim)" step
-# left the old suite fully green while a rebuild under mirror_only moved the tag's GHCR
-# digest -- the one thing a digest backfill must not do.
-builds = [s for s in steps if str(s.get("name", "")).startswith("Build + verify + push")]
-check("at least one build step exists", len(builds) >= 1, f"found {len(builds)}")
-check("EVERY build+push step is skipped under mirror_only (exact !inputs.mirror_only)",
+
+def _branch_calls(code, cond_line, call):
+    """True iff `call` appears in cond_line's branch body at exactly one extra indent level.
+
+    Bounding the nesting is the point. An unbounded `(?:.*\\n)*?` between the condition and
+    the call matches at ANY depth, so wrapping the call in a second `if` — which is how a
+    degrade gets silently restricted to one path — satisfies it. Requiring the call at
+    cond_indent + 2 means it runs whenever the branch is taken.
+    """
+    lines = code.splitlines()
+    try:
+        start = lines.index(cond_line)
+    except ValueError:
+        return False
+    indent = len(cond_line) - len(cond_line.lstrip())
+    want = " " * (indent + 2) + call
+    for line in lines[start + 1:]:
+        if line.strip() == "fi" and (len(line) - len(line.lstrip())) == indent:
+            return False
+        if line.startswith(want):
+            return True
+    return False
+
+# Matched by WHAT THE STEP DOES, not by what it is called. A name-prefix filter
+# (`startswith("Build + verify + push")`) is scoped to a label an author controls: a step
+# named "Rebuild + push (retry shim)" running the identical `docker build`/`docker push` was
+# invisible to it, so the assertion literally named "EVERY build+push step" was quantifying
+# over one name, not over the set of steps that can move the tag's GHCR digest.
+def _rebuilds_tag(s):
+    # UNION of content and name, deliberately. Content alone misses nothing dangerous, but
+    # name alone caught a case content does not: a step CALLED "Build + verify + push ..."
+    # whose body does not (yet) build. That one is benign today and one edit from not being,
+    # so keep both arms — a step claiming to be the build step must carry the guard whether
+    # or not it currently earns the name.
+    body = str(s.get("run") or "")
+    uses = str(s.get("uses") or "")
+    return bool(
+        re.search(r'^\s*docker\s+(build|buildx\s+build)\b', body, re.M)
+        or re.search(r'^\s*docker\s+push\b', body, re.M)
+        or re.search(r'docker/build-push-action', uses)
+        or str(s.get("name", "")).startswith("Build + verify + push")
+    )
+
+
+builds = [s for s in steps if _rebuilds_tag(s)]
+check("at least one build/push step exists (else the filter is broken, not the workflow)",
+      len(builds) >= 1, f"found {len(builds)}")
+# `all([])` is vacuously True, which is why the non-empty check above is load-bearing.
+check("EVERY step that can rebuild/push the tag is skipped under mirror_only",
       all(s.get("if") == GUARD for s in builds),
-      repr([s.get("if") for s in builds]))
+      repr([(s.get("name"), s.get("if")) for s in builds]))
 
 # The `pin` step feeds ONLY the build step's env, and its greps have no `|| true` under
 # `set -euo pipefail` -- ungated it can red a backfill of an old tag whose infra/ layout
@@ -177,13 +280,19 @@ if mirror:
     # bytes, so ONE @sha256 resolves on both registries; `docker tag`+`push` re-creates the
     # manifest and was the original defect. Asserted against `code`, so the step's own
     # rationale comments cannot satisfy it.
-    check("mirror uses `crane copy` for the GHCR->zot hop", "crane copy" in code)
-    # Brace-form-tolerant: `docker push "${ZOT}:${TAG}"` walked past the old dollar-only
-    # patterns, which is how a full revert of this change passed the suite.
+    # CALL POSITION, not membership. `"crane copy" in code` is satisfied by degraded()'s own
+    # advisory message string ("...backfill via ... crane, digest-preserving..."), which
+    # code_of does NOT strip -- strings are not comments. Measured: a full revert kept the
+    # token alive from that string and passed.
+    check("mirror invokes `crane copy` at call position",
+          re.search(r'^\s*retry\s+crane\s+copy\s+"\$IMAGE:\$TAG"\s+"\$ZOT:\$TAG"', code, re.M) is not None,
+          "expected `retry crane copy \"$IMAGE:$TAG\" \"$ZOT:$TAG\"` at line start")
+    # Brace-form-tolerant AND command-position-anchored: `docker push "${ZOT}:${TAG}"` walked
+    # past the old dollar-only patterns, which is how a full revert of this change passed.
     check("no `docker push` to the zot ref survives",
-          not re.search(r'docker\s+push\s+"?\$\{?ZOT', code))
+          not re.search(r'(^|;|&&|\|\|)\s*docker\s+push\s+"?\$\{?ZOT', code, re.M))
     check("no `docker tag` onto the zot ref survives",
-          not re.search(r'docker\s+tag\s+.*\$\{?ZOT', code))
+          not re.search(r'(^|;|&&|\|\|)\s*docker\s+tag\s+[^\n]*\$\{?ZOT', code, re.M))
 
     # ORDERED, not merely present. The name says "before extraction"; substring membership
     # cannot support that verb, and swapping the two lines so an unverified tarball is
@@ -195,18 +304,34 @@ if mirror:
         check("crane tarball is SHA-verified BEFORE extraction (ordered)", False,
               "one of sha256sum/tar is missing entirely")
 
-    # The bridge branch must exist AND must route to degraded(), not merely mention the var.
-    check("a bridge-down branch routes to degraded()",
-          re.search(r'BRIDGE_OUTCOME.*\n(?:.*\n)?\s*degraded\s+bridge_down', code) is not None,
-          "expected a BRIDGE_OUTCOME test whose body calls `degraded bridge_down`")
+    # POLARITY + NESTING, not token adjacency. The previous form
+    # (`BRIDGE_OUTCOME.*\n(?:.*\n)?\s*degraded bridge_down`) proved only that the two tokens
+    # were near each other: inverting the operator to `= "success"` — a complete inversion of
+    # the #6416/#7242 guard — passed, and so did `= "failure"`, which fails OPEN on
+    # `skipped`/`cancelled`. Pin the exact condition, then require the call in its body.
+    BRIDGE_COND = 'if [ "${BRIDGE_OUTCOME:-}" != "success" ]; then'
+    check("the bridge branch tests the exact NOT-success condition (polarity pinned)",
+          BRIDGE_COND in code,
+          "expected the literal `if [ \"${BRIDGE_OUTCOME:-}\" != \"success\" ]; then`")
+    check("the bridge branch body calls degraded bridge_down",
+          _branch_calls(code, BRIDGE_COND, "degraded bridge_down"),
+          "expected `degraded bridge_down` inside that branch, at its own indent")
 
-    # CONSEQUENCE, not presence. Deleting `degraded 1` from the mismatch branch left the old
-    # suite 25/25 green while execution fell through to `mirror_status=ok` -- parity became
-    # advisory, which is the exact false-green this file exists to prevent.
-    check("an unmeasurable parity read routes to degraded()",
-          re.search(r'-z "\$SRC_DIGEST".*\n(?:.*\n)*?\s*degraded\s+parity_unmeasured', code) is not None)
-    check("a parity MISMATCH routes to degraded()",
-          re.search(r'"\$SRC_DIGEST" != "\$DST_DIGEST".*\n(?:.*\n)*?\s*degraded\s+parity_mismatch', code) is not None)
+    # CONSEQUENCE, not presence, and BOUNDED. Deleting `degraded 1` from the mismatch branch
+    # left an earlier revision 25/25 green while execution fell through to `mirror_status=ok`.
+    # The unbounded `(?:.*\n)*?` that replaced it was no better: it matched the call at ANY
+    # nesting depth, so wrapping it in `if [ "$MIRROR_ONLY" = true ]` — which restores the
+    # false-green on the BUILD path, the one that runs on every release — still passed.
+    UNMEAS_COND = 'if [ -z "$SRC_DIGEST" ] || [ -z "$DST_DIGEST" ]; then'
+    MISMATCH_COND = 'if [ "$SRC_DIGEST" != "$DST_DIGEST" ]; then'
+    check("the unmeasurable-parity branch tests the exact condition",
+          UNMEAS_COND in code, "expected the literal -z SRC/-z DST condition")
+    check("the unmeasurable-parity branch calls degraded parity_unmeasured UNCONDITIONALLY",
+          _branch_calls(code, UNMEAS_COND, "degraded parity_unmeasured"))
+    check("the parity-mismatch branch tests the exact condition",
+          MISMATCH_COND in code, "expected the literal SRC != DST condition")
+    check("the parity-mismatch branch calls degraded parity_mismatch UNCONDITIONALLY",
+          _branch_calls(code, MISMATCH_COND, "degraded parity_mismatch"))
     # A matching manifest digest does not prove the blobs are still present: zot runs gc +
     # dedupe and `crane copy` skips blobs the destination already HEADs as present.
     #
@@ -216,31 +341,53 @@ if mirror:
     # contains the token after the call is deleted. Measured — the bare-substring form
     # survived a mutation that replaced the invocation with `true`. cq-assert-anchor-not-bare-token
     # applies to STRING LITERALS too, not just comments.
-    check("blob presence is validated at call position, not inferred from the digest",
-          re.search(r'^\s*retry\s+crane\s+validate\s+--remote\s+"\$ZOT', code, re.M) is not None,
-          "expected a `retry crane validate --remote \"$ZOT...` invocation at line start")
+    # `timeout \d+` between retry and crane is REQUIRED, not merely tolerated: "non-blocking"
+    # holds for exit codes but not wall clock, and the job declares no timeout-minutes, so an
+    # unbounded stall against the tunnelled listener would burn the 360-minute default and RED
+    # a release from a check documented as unable to affect the outcome.
+    check("blob presence is validated at call position, under a wall-clock bound",
+          re.search(r'^\s*retry\s+timeout\s+\d+\s+crane\s+validate\s+--remote\s+"\$ZOT', code, re.M) is not None,
+          "expected `retry timeout <n> crane validate --remote \"$ZOT...` at line start")
     # DARK-LAUNCH POSTURE (wg-dark-launch-deploy-gates). The blob check is runtime-unvalidated
     # against this registry, so it must NOT gate until observed passing on a real run. Pinned
     # in both directions: it must record a verdict (so the promotion criterion is measurable)
     # and it must NOT route to degraded() (so a heuristic mismatch cannot red every release).
     check("blob validation records a verdict for the promotion criterion",
           re.search(r'^\s*echo "blob_validate=ok" >> "\$GITHUB_OUTPUT"', code, re.M) is not None)
+    # MULTI-LINE AWARE. `[^\n]*` cannot cross a line continuation, so promoting the gate
+    # exactly as this workflow's own PROMOTION CRITERION spells it — `retry ... \` newline
+    # `  || degraded blobs_missing ...` — slipped straight past. That is the single most
+    # likely edit anyone will ever make to this file, so it is the one the check must catch.
+    # Join continuations before searching.
+    _joined = re.sub(r'\\\n\s*', ' ', code)
     check("blob validation is NON-BLOCKING while dark-launched (does not reach degraded)",
-          re.search(r'crane\s+validate\s+--remote[^\n]*\|\|\s*degraded', code) is None,
-          "a dark-launched gate must not route to degraded() until promoted")
+          re.search(r'crane\s+validate\s+--remote.*?\|\|\s*degraded', _joined) is None,
+          "a dark-launched gate must not route to degraded() until promoted (line continuations joined)")
 
     # Ordering: a `mirror_status=ok` written before the comparison certifies regardless of
     # the verdict. Unconditional now -- the old `if ... in body` form silently emitted NO
     # verdict when either token vanished, so deleting the token dropped an assertion instead
     # of failing one.
-    have_ok = "mirror_status=ok" in code
-    have_guard = '-z "$SRC_DIGEST"' in code
+    # `.index()` returns the FIRST occurrence, so a decoy `if [ -z "$SRC_DIGEST" ]` inserted
+    # earlier relocates the index and the ordering assertion certifies the INVERTED order.
+    # Require the tokens to be unique, then compare — uniqueness is the property that makes
+    # the comparison mean anything.
+    n_guard = code.count(UNMEAS_COND)
+    n_ok = code.count('echo "mirror_status=ok"')
+    check("the parity guard and the ok-write each occur exactly once (no decoys)",
+          n_guard == 1 and n_ok == 1, f"guard={n_guard} ok={n_ok}")
     check("mirror_status=ok is written AFTER the parity check, not before",
-          have_ok and have_guard and code.index('-z "$SRC_DIGEST"') < code.index("mirror_status=ok"),
-          f"ok={have_ok} guard={have_guard}")
+          n_guard == 1 and n_ok == 1
+          and code.index(UNMEAS_COND) < code.index('echo "mirror_status=ok"'))
 
     # (4) degraded() must exit 1 under mirror_only. Asserted structurally here and
-    # EXECUTED in the behavioral leg below.
+    # EXECUTED in the behavioral leg below. EXACTLY ONE definition: bash binds the LAST
+    # definition executed before the call sites, while the behavioral leg's extractor takes
+    # the FIRST — so a second degraded() ending `exit 0` makes the behavioural leg test a
+    # function the workflow never calls, defeating all eight of its assertions at once.
+    check("degraded() is defined exactly once (a second definition shadows the tested one)",
+          len(re.findall(r'^\s*degraded\(\)\s*\{', code, re.M)) == 1,
+          f"found {len(re.findall(r'^[ ]*degraded\(\)', code, re.M))} definitions")
     check("degraded() has a mirror_only arm", 'MIRROR_ONLY:-false' in code)
     # The ERR trap is the backstop for the deliberate absence of `set -e`: without it a
     # future fallible command with no `|| degraded` route falls through to mirror_status=ok.
@@ -250,6 +397,12 @@ if mirror:
     check("an ERR trap routes unrouted failures to degraded()",
           re.search(r"^\s*trap\s+'degraded\s+unrouted.*'\s+ERR\s*$", code, re.M) is not None,
           "expected a `trap 'degraded unrouted ...' ERR` at command position")
+    # ARMED ONCE IS NOT ARMED THROUGHOUT. `trap - ERR` anywhere after it disarms the backstop
+    # for the whole remaining body — including the parity and blob regions — and the
+    # arming check alone cannot see that.
+    check("the ERR trap is never disarmed later in the body",
+          re.search(r'^\s*trap\s+-\s+ERR', code, re.M) is None,
+          "found a `trap - ERR` that disarms the unrouted-failure backstop")
 
 # The Slack degrade step must carry a STATUS FUNCTION. Without one GitHub prepends an
 # implicit success(), so the step is skipped on exactly the mirror_only degrades it exists
@@ -258,8 +411,12 @@ slack = next((s for s in steps if "slack" in str(s.get("name", "")).lower()), No
 check("the Slack degrade step exists", slack is not None)
 if slack:
     slack_if = str(slack.get("if") or "")
-    check("the Slack gate carries a status function (else implicit success() skips it)",
-          any(fn in slack_if for fn in ("!cancelled()", "always()", "failure()")),
+    # EXACT, not an allowlist. `failure()` was accepted by the old membership test and is NOT
+    # equivalent: it is true only once the job has already failed, i.e. only under
+    # mirror_only — which silently deletes the BUILD-path degrade ⚠️ that is the entire
+    # reason (#6278) this step exists. `always()` would also fire on cancellation.
+    check("the Slack gate is exactly `!cancelled() &&` guarded (not failure()/always())",
+          slack_if == "${{ !cancelled() && steps.zot_mirror.outputs.mirror_status == 'degraded' }}",
           repr(slack_if))
 
 with open(f"{scratch}/verdicts.tsv", "w") as fh:
@@ -375,12 +532,16 @@ CRANE_SHA_EXPECTED="c14340087103ba9dadf61d45acd20675490fd0ccbd56ac7901fc1b502137
 for wf in .github/workflows/build-inngest-bootstrap-image.yml \
           .github/workflows/build-inngest-config-bundle.yml \
           .github/workflows/reusable-release.yml; do
+  # Anchored on the ASSIGNMENT, not a whole-file grep. A bare `grep -qF` over raw text is
+  # satisfied by a comment recording the OLD pin (`# previous pin: c1434008...`) sitting
+  # above a drifted assignment — the same cq-assert-anchor-not-bare-token failure this suite
+  # was rewritten to fix, in the one leg that reads raw file text instead of `code`.
   if [[ ! -f "$wf" ]]; then
     no "crane pin parity: $wf not found"
-  elif grep -qF "$CRANE_SHA_EXPECTED" "$wf"; then
+  elif grep -qE "^[[:space:]]*CRANE_SHA256=\"${CRANE_SHA_EXPECTED}\"" "$wf"; then
     ok "crane SHA256 pin matches across workflows — $(basename "$wf")"
   else
-    no "crane SHA256 pin DRIFTED in $wf (expected $CRANE_SHA_EXPECTED)"
+    no "crane SHA256 pin DRIFTED in $wf (expected an assignment of $CRANE_SHA_EXPECTED)"
   fi
 done
 
@@ -392,11 +553,17 @@ echo "passed: $pass  failed: $fail"
 # `passed: 0  failed: 0` and exited 0, i.e. CI green over a suite asserting nothing. A green
 # run must carry evidence that the assertions actually executed.
 #
-# A FLOOR (-lt), never equality: one assertion is legitimately conditional, so the count has
-# real variance and pinning it exactly would flake on every addition. Derived from a green
+# A FLOOR (-lt), never equality: a few assertions are legitimately conditional, so the count
+# has real variance and pinning it exactly would flake on every addition. Derived from a green
 # run, not from the number expected. The sibling this file is modelled on
 # (workspaces-luks-cutover-workflow.test.sh) carries the same shape.
-MIN_ASSERTIONS=30
+#
+# Set CLOSE to actual (50 vs 52), not comfortably below it. A floor 12 under actual measures
+# nothing in between: deleting the whole behavioural leg, two parity-loop files and the two
+# most load-bearing structural checks landed exactly on a floor of 30 and still certified the
+# run. A floor catches total neutering; only a tight one catches attrition. Re-derive it when
+# adding assertions — that is the intended maintenance cost.
+MIN_ASSERTIONS=50
 if (( pass + fail < MIN_ASSERTIONS )); then
   echo "FAIL - only $((pass + fail)) assertions ran (floor $MIN_ASSERTIONS) — a green run here would be vacuous"
   exit 1


### PR DESCRIPTION
## Why

A six-agent review of #7203 ran **after** it merged — auto-merge had been armed before the review completed, which is the process failure this PR also documents. Three agents converged independently on the same P1, and a mutation battery found the guard did not pin the property the PR existed to establish.

**The headline finding, measured:** reverting #7203 entirely — `crane copy` back to `docker tag` + `docker push` in *brace* form (`"${IMAGE}:${TAG}"`) — passed all 25 assertions. `check("mirror uses crane copy", "crane copy" in body)` was satisfied by the rationale comment the same commit added inside the step's `run:` body, and the two negative checks pinned *dollar*-form spellings that brace form walks past. Stripping that one comment and re-running the identical mutant turned it RED, proving the comment was the sole anchor.

The suite header claimed immunity from exactly this ("EVERY structural assertion parses the file as YAML, never greps it"). YAML parsing only *extracts the string*; the assertions were then substring greps over shell text carrying its own comments. `cq-assert-anchor-not-bare-token`.

## The #6416 defect was fixed on one path of two

`reusable-release.yml` already solved "a soft-failed bridge skips the mirror and the job stays green" by **removing** the bridge-outcome gate — its mirror branches internally so a bridge failure reaches the same emitter and the same step id every consumer keys on. Its comment says so verbatim: *"Do NOT re-gate this step on zot_bridge — that was the #6416 defect."*

#7203 diagnosed the mechanism correctly and then applied belt-off to the `mirror_only` arm only, leaving the **build** path with the defect intact: bridge soft-fails → mirror skipped → `mirror_status` never written → no `::warning::`, no step summary, no Slack, job green, zot never receives the image. That is also the path the measured fault class actually kills — #7242 has CF Access refusing the websocket upgrade since 17:11, with three Web Platform releases blocked.

Worse, the new suite **pinned the defective shape as a required assertion**, so porting the sibling's known-good fix would have turned it red and read as intentional.

## What changed

**Workflow**

- `zot_mirror` drops the `if:` gate entirely; the bridge result arrives as `BRIDGE_OUTCOME` env (outcome, never conclusion) and is branched on inside the script. The step id is preserved deliberately — outputs are namespaced by id, so handling bridge-down in a sibling step would write an output no consumer reads.
- `!cancelled()` on the Slack gate. Without a status function GitHub prepends an implicit `success()`, so the step was skipped on every `mirror_only` degrade — the one mode whose purpose is authorising a root-exec digest pin had **zero** push signal, while the mirror step's comment claimed a Slack ⚠️ fires.
- `degraded()` takes a named `reason` and emits `mirror_reason`. Six call sites collapsed into one bucket, so a crane tarball **checksum mismatch** — on a binary about to be `sudo tar`-extracted into `/usr/local/bin` — rendered as a message about registry redundancy.
- `parity_unmeasured` split from `parity_mismatch`; `crane digest` stderr captured rather than discarded; digests published to the step summary on **both** paths (they were withheld on failure — inverted).
- `crane validate --remote` added: a matching manifest digest does not prove the blobs survived zot's `gc` + `dedupe`, and `crane copy` skips blobs the destination already HEADs as present. Green parity + `blob unknown` on the host pull was reachable.
- Crane install retried; ERR trap so an unrouted failure cannot fall through to `mirror_status=ok`; the `pin` step gated to match the build step it feeds (ungated it could red a backfill of an old tag over terraform-variable spelling).
- The success path now records **what a green run does not prove** — host-side pull (`ZOT_PULL_*`, private NIC) is unverified for this repo, and zot retention keeps only the 5 most-recent `v*` tags.

**Guard**

- Comments stripped before every run-body assertion.
- Assertions moved from presence to **consequence**: parity branches must *reach* `degraded()`; `sha256sum` must *precede* `tar`; blob validation and the ERR trap anchored at **call position**, because `degraded()`'s own message string names those constructs and a string is not a comment. (I found that one by mutation — my first version of the blob check survived, satisfied by its own error text.)
- The #6416 invariant asserted as a **negative**.
- `MIN_ASSERTIONS` floor — neutering the verdict emitter printed `passed: 0 failed: 0` and exited 0. A floor, never equality: one assertion is legitimately conditional.
- Cover the set, not its head (a second unguarded build step was invisible to `next(...)`); assert GHCR login is **not** gated off; fixture the empty string the push path actually produces; sentinel-detect return-vs-exit; enforce crane pin parity across all three workflows.

**`infra-validation.yml`** gains `build-inngest-bootstrap-image.yml` in its `paths:` filter. The guard could not fire on the file it guards: a PR restoring the belt or re-adding the bridge gate touches no `apps/*/infra/**` path and skipped its own guard. #7203 ran the job only incidentally, by adding the suite file. Same defect class as the `#6454`, `#6178` and `#7025` comments already in that block; the one-line addition also closes it for `cutover-inngest-workflow.test.sh`'s `BUILD_IMG` read.

## Verification

16-mutation battery on sandbox copies, exactly-once edits verified as landed against a pristine backup, green control first: **16/16 KILLED**, including the full-revert mutant, the `#6416` gate restoration, the Slack-gate weakening, the GHCR-login gating, return-vs-exit, and the emitter neuter.

Suite 25 → 40 assertions. `actionlint` clean apart from the pre-existing `SC2015` in the `set +e` teardown; `shellcheck -S warning` clean. Siblings green: `cutover-inngest-workflow` 334/0, `cloud-init-inngest-bootstrap` 80/80, `inngest-host` 41/0. Registered infra suites 88, orphans none.

## Not in scope

The **`ADR-155` citation** #7203 added is corrected here (on `main` that number is `ADR-155-cross-gate-exemption-markers-in-the-rule-corpus`; the intended document was minted under the same number on an unmerged branch, so the citation resolved to an unrelated ADR for every reader). The underlying **number collision** belongs to that branch, not here.

`build-inngest-config-bundle.yml` carries the same bridge-gate shape and is tracked separately in #7243.

## Changelog

Fixed: the inngest-bootstrap zot mirror now reports a bridge failure on the release path instead of skipping silently, names the cause of every degrade, validates blob presence rather than inferring it from the manifest digest, and its guard no longer passes a full revert of the change it guards.

Refs #7144


---

<!-- gate-override: net-issue-flow -->

**net-issue-flow override.** #7256 was filed by this PR's review, and it is a defect in a **different workflow** (`reusable-release.yml`) — the gate's own criterion (c) names "discovered defects in another subsystem that must stay separate". Fixing it inline is not merely out of scope: that file is being actively edited by the in-flight #7242 work (zot-mirror error diagnosis, a release-blocking incident), so a concurrent one-line edit to the same release-critical path risks a conflict for no benefit. The finding is real and would have been suppressed entirely by a false claim in this PR's own comment, which is corrected here.
