### PR TITLE
fix(workflow): "review-gated" never meant a human approves it

### DIFF
--- a/AGENTS.rules.md
+++ b/AGENTS.rules.md
@@ -132,7 +132,7 @@ owner: founder
 ## Review & Feedback
 
 - After merging, read files from the merged branch (`git show main:<path>`), not the bare repo directory (stale) [id: rf-after-merging-read-files-from-the-merged]. This bare-root assumption holds for local CLI dev; the Concierge agent workspace is a **non-bare** clone (`.git` is a directory) — see ADR-099 for the three git-surface layouts and which code paths each gates.
-- Never skip QA/review before merging [id: rf-never-skip-qa-review-before-merging]. Full pipeline: plan → implement → review → QA → compound → ship.
+- Never skip QA/review before merging, and never wait on a human to do it [id: rf-never-skip-qa-review-before-merging]. Full pipeline: plan → implement → review → QA → compound → ship. "Review-gated" = `/soleur:review` RAN and its findings are fixed inline, never that a person approves. Carry every PR to MERGED in-session; "awaiting review"/"needs a human" as an end state defers to an operator who cannot clear it. Pause only for irreversible prod effects (`hr-menu-option-ack-not-prod-write-auth`). **Why:** 2026-08-04 — read "review-gated" as human-gated and parked a finished PR.
 - Before spawning review agents, push the branch to remote (`git push -u origin <branch>`) [id: rf-before-spawning-review-agents-push-the]. Review subagents use remote state; unpushed commits produce stale analysis. **Why:** 2026-04-13 — 4 of 9 reviewers analyzed pre-push state.
 - Before shipping, verify: (1) review comments resolved, (2) QA run with screenshots if UI, (3) tests pass locally [id: rf-before-shipping-verify-1-review-comments].
 - When a reviewer or user says to keep a feature/phase, do not remove it without explicit confirmation [id: rf-when-a-reviewer-or-user-says-to-keep-a].

--- a/plugins/soleur/skills/review/SKILL.md
+++ b/plugins/soleur/skills/review/SKILL.md
@@ -1022,8 +1022,23 @@ After emitting the marker, the calling skill's continuation gate takes over — 
 
    Run it even when step 2 committed something: the trailer is the durable
    machine-readable signal, and the commit subject is only a legacy fallback.
-4. Display: "Review complete. All findings are tracked as GitHub issues.
-   Run `/clear` then `/soleur:work` or `/soleur:ship` for maximum context headroom."
+4. **Continue to `/soleur:ship` in the same turn — review is not a stopping point.**
+   Findings are fixed inline (§5), so a clean review means the PR is ready to go
+   out, not ready to be handed over. Invoke `skill: soleur:compound` then
+   `skill: soleur:ship`, and let ship carry the PR to MERGED
+   (`rf-never-skip-qa-review-before-merging`, `wg-after-marking-a-pr-ready-run-gh-pr-merge`).
+
+   Do NOT end the turn by telling the operator to run the next skill. This step
+   used to read *"Run `/clear` then `/soleur:work` or `/soleur:ship` for maximum
+   context headroom"*, which reads as an instruction TO THE OPERATOR and is the
+   deferral `wg-verified-work-ships-without-asking` exists to stop — Soleur's
+   operator is non-technical and cannot clear that gate. If context headroom is
+   genuinely the constraint, say so and continue anyway; `/clear` is the
+   operator's choice to make, never a precondition you impose on finishing.
+
+   The only sanctioned pause is an irreversible production effect
+   (`hr-menu-option-ack-not-prod-write-auth`) — surface the exact command and
+   stop. A pending merge is not that.
 
 ### 7. End-to-End Testing (Optional)
 


### PR DESCRIPTION
## Why

Soleur's operator is **non-technical**. A PR left "awaiting human review" is a deferral to someone who structurally cannot clear it — the same failure class as an operator checklist (`hr-ship-message-no-operator-checklist`, `hr-never-label-any-step-as-manual-without`).

I hit this in a live session: I ran a six-agent review myself, fixed every finding, mutation-proved the result 19/19 — and then reported the PR as "needs human review before merge." Nothing in the workflow required that. Two surfaces made it sayable.

## 1. The rule named no actor

`rf-never-skip-qa-review-before-merging` read, in full:

> Never skip QA/review before merging. Full pipeline: plan → implement → review → QA → compound → ship.

`wg-verified-work-ships-without-asking` then says *"Merge stays review-gated"* and points at it. So "gated" is resolvable as **gated on a person** — which is exactly how I resolved it.

It now says review means the `/soleur:review` **skill** ran and its findings are fixed inline, never that a person approves, and that every PR is carried to **MERGED** in-session.

Amended in place: the id is immutable (`cq-rule-ids-are-immutable`), the body stays inside the 600 B cap, and the always-loaded corpus is **43,776 B** — under the 44,000 warn threshold, so no budget regression.

## 2. The review skill ended by instructing the operator

`review/SKILL.md`'s standalone exit gate, step 4:

> Display: "Review complete. All findings are tracked as GitHub issues. Run `/clear` then `/soleur:work` or `/soleur:ship` for maximum context headroom."

That is an instruction addressed **to the user**, emitted at the exact moment the work is finishable — the deferral `wg-verified-work-ships-without-asking` exists to stop. It now continues to `/compound` then `/ship` in the same turn, and records that `/clear` is the operator's choice, never a precondition the agent imposes on finishing.

## Scope

- `one-shot` already carries hard continuation gates ("never hand off to the operator", "each skill's exit summary is a checkpoint, never a stopping point") and needed no change. The gap was **standalone** `/review`, which is how it gets invoked outside one-shot.
- `brainstorm` and `plan` keep their `/clear` resume prompts. Brainstorm completion is the sanctioned operator boundary; this change governs everything after it.
- `work/SKILL.md`'s "Tip: after shipping, run `/clear`" is a tip after the merge, not a gate before it. Left alone.

The one sanctioned pause is unchanged: an irreversible production effect (`hr-menu-option-ack-not-prod-write-auth`) — surface the exact command and stop. A pending merge is not that.

## Verification

`lint-agents-rule-budget.py` OK (43,776 B), `lint-rule-ids.py` OK, `lint-rule-bodies.py --check` OK (no un-acked hr-/wg- body changes), `components.test.ts` 1297/0.

## Changelog

Fixed: "review-gated" is now explicitly the review *skill*, not a human approval, and `/review` continues to ship instead of handing the operator a next-step instruction.
