### PR TITLE
docs(6808): record the P.1 rehearsal, and add the compensating channel the failure-signals list was missing

### DIFF
--- a/knowledge-base/engineering/operations/runbooks/workspaces-luks-cutover-6604.md
+++ b/knowledge-base/engineering/operations/runbooks/workspaces-luks-cutover-6604.md
@@ -257,4 +257,21 @@ T0 remount + replay from LUKS", never a total loss.
   heartbeat rows spanning ≥7d, so that clock has not started.
   A worked consequence: on 2026-07-20 the daily probe stopped running entirely for ~6 hours and no
   dead-probe signal fired, because there is no live heartbeat to miss (#6812).
+- **`workspaces-luks-verify.yml` (daily `schedule: 41 4 * * *`) — the COMPENSATING channel while the
+  heartbeat above is unfed (#6808/#7196).** This is the only automatic verification of the at-rest
+  claim today. A failing scheduled run files one `ci/luks-verify` issue classified `drift` (the
+  at-rest claim itself — p0, `type/security`, and the counsel re-evaluation trigger), `readiness`
+  (an ops or inventory event; a `workspace_count_shortfall` files under its own title at p0 because
+  it is irreversible sole-copy data loss) or `unavailable` (nothing proven in either direction — do
+  NOT run a data-recovery procedure for it). `drift` and `readiness` also page ops by email;
+  `unavailable` deliberately does not.
+  Pull it without a dashboard:
+  `gh run list --workflow=workspaces-luks-verify.yml --event=schedule --limit 40 --json databaseId,conclusion,createdAt`
+  and `gh issue list --label ci/luks-verify --label action-required --state open`
+  (the `action-required` filter excludes the `luks/class-selftest` rehearsal issues).
+  **It is a compensating control, not a replacement for the heartbeat.** It runs on GitHub's
+  scheduler, which drops runs (#4189), and it cannot see a host-side probe that stops between its
+  own fires — which is exactly what the heartbeat exists to catch. The run-that-never-fires mode is
+  covered one layer out by the `workspaces-luks-verify` Sentry Crons monitor, which pages on two
+  consecutive missed or errored check-ins.
 - **`betteruptime_monitor.app`** — a refused container (failed unlock) is a hard down.

--- a/knowledge-base/project/specs/feat-one-shot-6808-luks-verify-schedule/tasks.md
+++ b/knowledge-base/project/specs/feat-one-shot-6808-luks-verify-schedule/tasks.md
@@ -158,7 +158,23 @@ The monitor itself needs no step here: `apply-sentry-infra.yml` applies
 `sentry_cron_monitor.workspaces_luks_verify` automatically on push to main
 (`paths: apps/web-platform/infra/sentry/**`). P.2 verifies that apply landed rather than performing it.
 
-- [ ] P.1 **Rehearse the alarm against real GitHub expression evaluation.** The committed suite
+- [x] P.1 **Rehearse the alarm against real GitHub expression evaluation.** — **DONE 2026-08-04.**
+      Run [30907963898](https://github.com/jikig-ai/soleur/actions/runs/30907963898) (dispatched
+      immediately after #7196 merged) filed issue #7260
+      `[ci/luks-verify] SELF-TEST — ignore` with labels `ci/luks-verify, luks/class-selftest`;
+      closed after verification. What the rehearsal proved, none of which a test could reach:
+      the alarm `if:` fired on a `workflow_dispatch`, which requires `inputs.alarm_selftest` to
+      arrive as a genuine **boolean** (`inputs.<name>` preserves the declared type;
+      `github.event.inputs.<name>` stringifies, and GitHub casts any non-empty string to true — so
+      under a string the literal `false` would be truthy and every failed operator dispatch would
+      file an issue); the new `luks/class-selftest` label was **created on first fire**, which
+      matters because `gh issue create` exits non-zero on a `--label` naming a label that does not
+      exist, and on that step a non-zero exit means filing nothing; and the alarm body ran to
+      completion under `set -euo pipefail` against the live `gh` API. `Page ops by email` and
+      `Sentry Crons check-in` both correctly **skipped** — the latter being the "a manual dispatch
+      must not forge liveness while the cron is dark" property, confirmed against real GitHub.
+      The original instructions are kept below for the next rehearsal.
+- [ ] ~~P.1 (original instructions, retained)~~ **Rehearse the alarm against real GitHub expression evaluation.** The committed suite
       evaluates OUR MODEL of GHA expressions; this evaluates GitHub's, and it is the only execution
       of the operator-reaching path before a genuine incident.
       ```bash


### PR DESCRIPTION
Docs-only follow-up to #7196. No code, no workflow, no Terraform.

## 1. P.1 is done — recorded with what it actually proved

The `alarm_selftest` rehearsal ran immediately after #7196 merged: run
[30907963898](https://github.com/jikig-ai/soleur/actions/runs/30907963898) filed
`[ci/luks-verify] SELF-TEST — ignore` (#7260, since closed) with labels
`ci/luks-verify, luks/class-selftest`.

It is worth recording *why* this step exists rather than just ticking it. The committed gate suite
evaluates **our model** of GitHub's expression grammar — a Python translator over a fixed subset.
This run evaluated **GitHub's**. Three things only it could establish:

- **The alarm `if:` fired on a `workflow_dispatch`**, which requires `inputs.alarm_selftest` to
  arrive as a genuine boolean. `inputs.<name>` preserves the declared type; `github.event.inputs.<name>`
  stringifies everything, and GitHub casts any non-empty string to true — so under a string-typed
  input the literal `false` would be truthy and every failed operator dispatch would file an issue.
- **`luks/class-selftest` was created on first fire.** That label did not previously exist, and
  `gh issue create` exits non-zero on a `--label` naming one that does not — which on that step
  means the alarm classifies correctly and files nothing.
- **The alarm body completed under `set -euo pipefail`** against the live `gh` API.

`Page ops by email` and `Sentry Crons check-in` both correctly **skipped** — the latter being the
"a manual dispatch must not forge liveness while the cron is dark" property, confirmed against real
GitHub rather than against a 72-cell grid.

## 2. The failure-signals list was missing the signal that now does the work

`workspaces-luks-cutover-6604.md` §Failure signals listed Sentry, the struck-through Better Stack
heartbeat, and `betteruptime_monitor.app` — but not the daily scheduled verify #7196 added, which is
currently the **only** automatic verification of the at-rest claim. A failure-signals list that omits
the live signal is the same staleness the heartbeat entry is already struck through for.

Added with its three outcome classes, the no-dashboard pull commands, and — importantly — the reason
it is a **compensating control and not a replacement**: it runs on GitHub's scheduler, which drops
runs (#4189), and it cannot see a host-side probe that dies between its own fires. That gap is what
the heartbeat exists to close, which is why #6808 stays open.

## What is NOT in this PR

`luks-monitor.sh:290` still logs the absent `WORKSPACES_LUKS_HEARTBEAT_URL` as a `WARN` rather than
failing loudly (#6808 AC3). That change is deliberately **not** here, because it must land *after*
the Doppler secret exists — flipping it now would fail the daily probe on every run and convert a
silent gap into a self-inflicted outage.

Measured root cause for #6808, for whoever picks it up: the Terraform is written but never applied.

```
$ doppler secrets get WORKSPACES_LUKS_HEARTBEAT_URL --plain --config prd_workspaces_luks
Doppler Error: Could not find requested secret
```

`betteruptime_heartbeat.workspaces_luks` (`uptime-alerts.tf:161`) and
`doppler_secret.workspaces_luks_heartbeat_url` (`:187`, sourced as a **reference** to
`betteruptime_heartbeat.workspaces_luks.url`, exactly as AC1 requires) both exist in code and are
`OPERATOR_APPLIED_EXCLUSIONS`. AC1 is code-complete and unapplied.

Ref #6808 — never `Closes`. That issue's closure condition is a conjunction (heartbeat wired **and**
schedule exists); only the schedule limb is satisfied.
