### PR TITLE
fix(infra): make a luks-monitor that cannot report fail loudly (#6808 AC3/AC4)

### DIFF
--- a/.github/workflows/workspaces-luks-verify.yml
+++ b/.github/workflows/workspaces-luks-verify.yml
@@ -274,7 +274,7 @@ jobs:
           # future producer/consumer drift of exactly this kind.
           is_probe_integrity() {
             case "${1:-}" in
-              readyz_gate_regression|readyz_unparseable|readyz_unreachable|readiness_helper_unavailable|workspace_count_baseline_missing|workspace_count_unreadable|mapper_path_override_refused|doppler_unreachable)
+              readyz_gate_regression|readyz_unparseable|readyz_unreachable|readiness_helper_unavailable|workspace_count_baseline_missing|workspace_count_unreadable|mapper_path_override_refused|doppler_unreachable|heartbeat_url_absent|heartbeat_push_failed)
                 return 0 ;;
             esac
             return 1
@@ -493,6 +493,8 @@ jobs:
           # undone one layer up. `sed` reads the reason off the FAIL line the host already emitted.
           if [[ "$probe_rc" -eq 3 ]]; then
             case "$reason" in
+              heartbeat_url_absent|heartbeat_push_failed)
+                echo "::error::workspaces-luks ALERTING-PATH failure (rc=3, reason=$reason). Every at-rest assert PASSED — the volume is fine and this is NOT data loss. What failed is the probe's ability to REPORT: the Better Stack dead-probe heartbeat was not pushed, so from here on a dead probe and a healthy one look identical off-host (#6808). Do NOT run a data-recovery procedure. Fix: confirm doppler_secret.workspaces_luks_heartbeat_url is applied and that the prd_workspaces_luks boot token can still read it. Sentry: feature=workspaces-luks op=workspaces-luks-drift." ;;
               readyz_gate_regression|readyz_unparseable|readyz_unreachable|readiness_helper_unavailable|workspace_count_baseline_missing|workspace_count_unreadable|mapper_path_override_refused)
                 echo "::error::workspaces-luks PROBE-INTEGRITY failure (rc=3, reason=$reason). This run proves NOTHING about the volume — it is a routing/config/tooling fault, NOT data loss. Do NOT run a data-recovery procedure. Sentry: feature=workspaces-luks op=workspaces-luks-drift." ;;
               *)

--- a/apps/web-platform/infra/luks-monitor.sh
+++ b/apps/web-platform/infra/luks-monitor.sh
@@ -281,14 +281,43 @@ if [ "${LUKS_MONITOR_ASSERT_READYZ:-0}" = "1" ]; then
 fi
 
 # All asserts passed — push the heartbeat so a dead probe FAILS it (P1-4).
+#
+# #6808 AC3 — BOTH arms below are FATAL, not WARN. Until the 2026-08-04 apply, an absent URL logged
+# a WARN and exited 0, so a never-configured probe and a dead probe were indistinguishable and
+# NEITHER paged: "a check that cannot report is indistinguishable from one that passed". The old
+# text ("operator wires it at cutover") described a deferred manual step that no longer exists —
+# the URL is provisioned by terraform as a REFERENCE to betteruptime_heartbeat.workspaces_luks.url
+# (doppler_secret.workspaces_luks_heartbeat_url, uptime-alerts.tf). Its absence is therefore a real
+# regression — a deleted secret, or a boot token that lost its prd_workspaces_luks scope — and
+# never the expected steady state.
+#
+# exit 3 (emit_readiness_and_die), NOT exit 1 (emit_and_die): this is a PROBE-INTEGRITY fault. By
+# the time control reaches here every at-rest assert above has PASSED, so the at-rest exit would
+# classify a broken ALERTING path as plaintext-at-rest — the p0 type/security verdict whose issue
+# body asserts the published Article 32 claim is false. Both reasons are registered in the
+# workflow's is_probe_integrity() + rc=3 headline branch and in the runbook triage table;
+# workspaces-luks-verify-workflow.test.sh (M)/(N) fail loudly if that drifts.
+#
+# NOTE ON WORDING: never write the at-rest helper's name followed by a bare lowercase word anywhere
+# in this file, comments included. The (M)/(N) parity gates derive the producible-reason set by
+# regex over the whole file, so `<helper> would classify ...` registers "would" as an emittable
+# reason and reds the gate. Existing prose uses the possessive form for exactly this reason.
 hb_url="$(doppler secrets get WORKSPACES_LUKS_HEARTBEAT_URL --plain --config prd_workspaces_luks 2>/dev/null || true)"
-if [ -n "$hb_url" ]; then
-  # -g (--globoff): the URL is a bearer capability; without -g a URL with [ ]/{ } prints the full
-  # URL in curl's glob-parse error, which SyslogIdentifier would ship to Better Stack.
-  curl -gfsS --max-time 10 "$hb_url" >/dev/null 2>&1 || log "WARN: heartbeat push failed (URL present)"
-else
-  log "WARN: WORKSPACES_LUKS_HEARTBEAT_URL absent — heartbeat not pushed (operator wires it at cutover)"
-fi
+[ -n "$hb_url" ] || emit_readiness_and_die heartbeat_url_absent
+# -g (--globoff): the URL is a bearer capability; without -g a URL with [ ]/{ } prints the full
+# URL in curl's glob-parse error, which SyslogIdentifier would ship to Better Stack.
+#
+# RETRIED before it is fatal, unlike the absent-URL arm above. An absent secret is a config fault
+# that no retry can fix, but a push is one outbound HTTPS call: making a single transient egress
+# blip red the daily probe and file an issue would trade a silent gap for a noisy one. Three
+# attempts, each capped at 10s, 2s apart: ~36s worst case, well inside the unit's runtime. An
+# EXHAUSTED push is the same "cannot report" state as an absent URL, so it ends the same way.
+hb_pushed=false
+for _ in 1 2 3; do
+  if curl -gfsS --max-time 10 "$hb_url" >/dev/null 2>&1; then hb_pushed=true; break; fi
+  sleep 2
+done
+[ "$hb_pushed" = true ] || emit_readiness_and_die heartbeat_push_failed
 
 log "OK: /mnt/data is LUKS-backed (device_type=crypto_LUKS mount_source=$MAPPER escrow=ok header=readable)"
 exit 0

--- a/apps/web-platform/infra/luks-monitor.test.sh
+++ b/apps/web-platform/infra/luks-monitor.test.sh
@@ -391,6 +391,56 @@ else
   no "the workflow's positive-control anchor [$wf_anchor] does NOT match the emitted verdict line — the workflow would fail closed on every run: ${MON_OUT:0:200}"
 fi
 
+# ===========================================================================
+# (t) #6808 — THE HEARTBEAT PUSH, both arms fatal.
+#
+# Until 2026-08-04 an absent URL logged a WARN and the probe exited 0, so a never-configured probe
+# and a dead one were indistinguishable off-host and NEITHER paged. Nothing in this suite covered
+# the heartbeat at all — in either direction — so the WARN could not have been caught here.
+#
+# All three cases assert on the REASON, not merely on a non-zero rc: rc=3 is shared with every
+# readiness/inventory failure, so an rc-only assertion would pass against a probe that died at
+# workspace_count_baseline_missing having never reached the heartbeat block.
+# ===========================================================================
+
+# (t1) POSITIVE CONTROL FIRST. A healthy probe must actually PUSH — without this, (t2)/(t3) below
+# would both pass against a build that removed the push entirely.
+mon_prepare "$PROBE"; mkdir -p "$WSDIR/ws-a"; seed_count 1
+mon_run LUKS_MONITOR_ASSERT_READYZ=1
+if [ "$MON_RC" -eq 0 ] && has 'curl .*betterstack.test'; then
+  ok "healthy probe PUSHES the heartbeat and exits 0 (positive control for the two fatal arms)"
+else
+  no "healthy probe did not push the heartbeat (rc=$MON_RC, pushes=$(cnt 'curl .*betterstack.test')): ${MON_OUT:0:200}"
+fi
+
+# (t2) ABSENT URL => fatal. The exact state #6808 existed to remove.
+mon_prepare "$PROBE"; mkdir -p "$WSDIR/ws-a"; seed_count 1
+mon_run LUKS_MONITOR_ASSERT_READYZ=1 MON_HB_URL=
+if [ "$MON_RC" -eq 3 ] && monOut 'heartbeat_url_absent'; then
+  ok "absent WORKSPACES_LUKS_HEARTBEAT_URL is FATAL (rc=3 heartbeat_url_absent), never a survivable WARN"
+else
+  no "an absent heartbeat URL did not fail loudly (rc=$MON_RC): ${MON_OUT:0:300}"
+fi
+
+# (t3) EXHAUSTED PUSH => fatal, and only after retrying. The retry count is asserted because a
+# build that dropped the loop would still be "fatal on a failing push" and pass a bare rc check,
+# while turning one transient egress blip into a red daily probe.
+mon_prepare "$PROBE"; mkdir -p "$WSDIR/ws-a"; seed_count 1
+mon_run LUKS_MONITOR_ASSERT_READYZ=1 MON_HB_PUSH_RC=7
+if [ "$MON_RC" -eq 3 ] && monOut 'heartbeat_push_failed' && [ "$(cnt 'curl .*betterstack.test')" -eq 3 ]; then
+  ok "an exhausted heartbeat push is FATAL (rc=3 heartbeat_push_failed) and is retried 3x first"
+else
+  no "failing heartbeat push wrong (rc=$MON_RC, attempts=$(cnt 'curl .*betterstack.test')): ${MON_OUT:0:300}"
+fi
+
+# (t4) The absent-URL arm must NOT be classified as at-rest drift. It exits 3, not 1 — an alerting
+# fault must never file the p0 type/security issue whose body asserts the Article 32 claim is false.
+if [ "$MON_RC" -ne 1 ]; then
+  ok "a heartbeat fault never exits 1 (would classify a broken alerting path as plaintext-at-rest)"
+else
+  no "a heartbeat fault exited 1 — it would file the p0 at-rest drift verdict"
+fi
+
 echo ""
 echo "=== luks-monitor.test.sh: ${passes} passed, ${fails} failed ==="
 [ "$fails" -eq 0 ] || exit 1

--- a/apps/web-platform/infra/workspaces-luks-harness.sh
+++ b/apps/web-platform/infra/workspaces-luks-harness.sh
@@ -456,6 +456,10 @@ run_case() {
 #   MON_READYZ_CODE   readyz HTTP status             (default 200)
 #   MON_READYZ_BODY   readyz body                    (default ready:true with both checks true)
 #   MON_DF_USE        df -P use% column              (default 41%)
+#   MON_HB_URL        doppler WORKSPACES_LUKS_HEARTBEAT_URL (default a .test stub URL; empty =
+#                     the secret is absent → rc=3 heartbeat_url_absent)
+#   MON_HB_PUSH_RC    heartbeat push curl rc         (default 0; non-zero on all 3 attempts =
+#                     rc=3 heartbeat_push_failed)
 # Split into mon_prepare / mon_run so a case can BUILD A FIXTURE (workspace dirs, a seeded baseline)
 # between the two. A single call that creates the case dir and immediately executes cannot express
 # the inventory cases at all — the fixture has to exist in the same dir the run will read.
@@ -513,7 +517,12 @@ STUB
 #!/usr/bin/env bash
 printf 'doppler %s\n' "$*" >> "$CALLS"
 case "$*" in
-  *WORKSPACES_LUKS_HEARTBEAT_URL*) printf '%s' "${MON_HB_URL-}" ;;
+  # #6808 — default NON-EMPTY. It defaulted to empty while an absent URL was a survivable WARN;
+  # that arm is now fatal (emit_readiness_and_die heartbeat_url_absent), so an empty default would
+  # exit 3 out of every otherwise-healthy fixture in the suite. A case that wants the absent arm
+  # sets MON_HB_URL= explicitly. `.test` TLD so a stub that ever escaped the mock PATH cannot
+  # resolve to a real endpoint.
+  *WORKSPACES_LUKS_HEARTBEAT_URL*) printf '%s' "${MON_HB_URL-https://uptime.betterstack.test/api/v1/heartbeat/stub-token}" ;;
   *WORKSPACES_LUKS_KEY*)           printf '%s' "${MON_KEY-k}" ;;
 esac
 STUB
@@ -529,6 +538,10 @@ for a in "$@"; do
   prev="$a"
 done
 case "$*" in
+  # #6808 — the heartbeat push. Matched BEFORE the catch-all so a case can drive a failing push
+  # (MON_HB_PUSH_RC=7) and reach the heartbeat_push_failed arm; the catch-all's unconditional
+  # `exit 0` below makes every push succeed and leaves that arm unreachable.
+  *betterstack.test*|*heartbeat*) exit "${MON_HB_PUSH_RC:-0}" ;;
   *readyz*)
     body="${MON_READYZ_BODY-{\"ready\":true,\"checks\":{\"workspaces_writable\":true,\"workspaces_populated\":true\}\}}"
     if [ -n "$outfile" ]; then

--- a/knowledge-base/engineering/operations/runbooks/workspaces-luks-cutover-6604.md
+++ b/knowledge-base/engineering/operations/runbooks/workspaces-luks-cutover-6604.md
@@ -188,6 +188,8 @@ forever — which the escrow proof + off-host header backup exist to prevent.
    | `rc=1` `cryptsetup_status_missing` | `unavailable` | The mapper node exists and IS serving the mount, but `cryptsetup status` failed | **Tooling/parse fault, not plaintext.** Reached only after mountpoint, mount-source and mapper-node checks all passed, so at-rest encryption is in effect. Check `cryptsetup` on the host |
    | `rc=1` `mapper_device_link_missing` | `unavailable` | `cryptsetup status` succeeded but its `device:` line did not parse | **Parse fault, not data loss.** Same reasoning as above |
    | `rc=1` `doppler_unreachable` | `unavailable` | The host could not read `WORKSPACES_LUKS_KEY` from Doppler | Probe-integrity: the escrow assert never ran. Check the boot token's `prd_workspaces_luks` scope |
+   | `rc=3` `heartbeat_url_absent` | `unavailable` | Every at-rest assert PASSED, but `WORKSPACES_LUKS_HEARTBEAT_URL` could not be read, so the dead-probe heartbeat was not pushed | **Alerting-path fault, NOT data loss** — the volume is fine; what broke is the probe's ability to report, which is what makes a dead probe indistinguishable from a healthy one (#6808). Confirm `doppler_secret.workspaces_luks_heartbeat_url` is applied and the boot token still reads `prd_workspaces_luks`. Never run a data-recovery procedure for this |
+   | `rc=3` `heartbeat_push_failed` | `unavailable` | The URL was present but all 3 push attempts to Better Stack failed | **Alerting-path fault, NOT data loss.** Egress or Better Stack outage. The heartbeat will also miss on its own (period 86400 + 1h grace), so expect a dead-probe alert to follow; re-dispatch once egress is healthy |
    | `app_health_structural` | `readiness` | `/health` returned a structural code (307/401/403/404/405/525/526) after the full retry budget | **Routing/endpoint regression the operator can act on.** Not data loss. Check the custom server and the CF route |
    | `app_health_unreachable` | `unavailable` | `/health` exhausted its retry budget on a retryable CF-edge code | Transport outage. Nothing proven about the volume — do **not** run a data-recovery procedure |
    | `verdict_line_absent` | `unavailable` | rc=0 but the readiness/inventory verdict line never appeared | The assert did not run (`LUKS_MONITOR_ASSERT_READYZ` lost before reaching the host). Treat as FAILED, re-dispatch |
@@ -225,9 +227,12 @@ forever — which the escrow proof + off-host header backup exist to prevent.
    the `follow-through` label. It PASSes only on observed completion (drift=0 ∧ heartbeat spanning
    ≥7d ∧ ADR-119 `accepted`).
 
-   > **The soak clock has not started and cannot until #6808 lands.** The heartbeat it gates on is
-   > UNFED (see Failure signals), so no rows accumulate and the ≥7d span can never be satisfied.
-   > #6808 is the critical path to this step, not an optional tidy-up.
+   > **The soak clock STARTED 2026-08-04**, when the heartbeat it gates on took its first observed
+   > push (#6808 — see Failure signals). Rows now accumulate daily, so the ≥7d span is first
+   > satisfiable on **2026-08-11**. Before that date the soak has not failed, it has merely not
+   > matured — do not read a short span as a drift finding.
+   > The blocker this note used to record is cleared; #6897's plaintext-volume soak is no longer
+   > waiting on #6808.
 
 7. **Wipe + converge + PR 3 (separate, environment-gated).** After the soak comments "SOAK PASSED —
    wipe authorized", a human authorizes the **separate** environment-gated destructive dispatch:
@@ -250,16 +255,33 @@ T0 remount + replay from LUKS", never a total loss.
   (`device_type`, `mount_source`, `mapper_present`, `luks_open_result`, `header_uuid_match`,
   `cryptsetup_unit_result`, `doppler_reachable`, `mountpoint_ok`, `host`, `reason`) tell the failure
   modes apart in one event.
-- ~~**Better Stack** `betteruptime_heartbeat.workspaces_luks` — a missed daily push = a dead probe.~~
-  **UNFED pending #6808.** The Terraform resource exists, but `WORKSPACES_LUKS_HEARTBEAT_URL` is not
-  wired, so `luks-monitor.sh` (the heartbeat push, `WORKSPACES_LUKS_HEARTBEAT_URL` block) logs the URL as absent and pushes nothing. This channel pages on
-  **nothing today** — do not count it as a failure signal, and note that the 7-day soak gates on
-  heartbeat rows spanning ≥7d, so that clock has not started.
-  A worked consequence: on 2026-07-20 the daily probe stopped running entirely for ~6 hours and no
-  dead-probe signal fired, because there is no live heartbeat to miss (#6812).
-- **`workspaces-luks-verify.yml` (daily `schedule: 41 4 * * *`) — the COMPENSATING channel while the
-  heartbeat above is unfed (#6808/#7196).** This is the only automatic verification of the at-rest
-  claim today. A failing scheduled run files one `ci/luks-verify` issue classified `drift` (the
+- **Better Stack** `betteruptime_heartbeat.workspaces_luks` — a missed daily push = a dead probe.
+  **LIVE as of 2026-08-04** (#6808). `WORKSPACES_LUKS_HEARTBEAT_URL` is provisioned by terraform as a
+  reference to the heartbeat resource, and `luks-monitor.sh` (the heartbeat push,
+  `WORKSPACES_LUKS_HEARTBEAT_URL` block) pushes it on a fully-green probe. Period 86400 + 1h grace,
+  so a probe that dies goes `up` → `down` about 25h later. First observed push: the verify run of
+  2026-08-04, which took the heartbeat `pending` → `up`.
+  Pull it without a dashboard (the heartbeat id is stable; the URL itself is a bearer capability and
+  must never be echoed):
+  `curl -s -H "Authorization: Bearer $(doppler secrets get BETTERSTACK_API_TOKEN --plain -p soleur -c prd_terraform)" https://uptime.betterstack.com/api/v2/heartbeats/478794 | jq '.data.attributes | {paused, status}'`
+  A `status` of `up` means a push landed inside the window; `down` means the probe stopped; `paused`
+  means someone re-paused it (terraform will NOT un-pause it for you — the resource ships
+  `paused = true` behind `lifecycle { ignore_changes = [paused] }`, so a re-pause survives every
+  apply and is invisible in a plan).
+  Two things it still does not cover, so do not over-read a green heartbeat. It is
+  `policy_id`-gated on the paid tier (`var.betterstack_paid_tier`); on the free tier it alerts by
+  **email only** and does not page. And the readyz/inventory dimension has no host-side coverage at
+  all, because `LUKS_MONITOR_ASSERT_READYZ` is default-OFF and the daily unit carries
+  `RequiresMountsFor=/mnt/data` — a shortfall is still seen only by the scheduled verify below.
+  Historical note, kept because it is the worked example of why this channel matters: on 2026-07-20
+  the daily probe stopped running entirely for ~6 hours and no dead-probe signal fired, because at
+  that time there was no live heartbeat to miss (#6812).
+- **`workspaces-luks-verify.yml` (daily `schedule: 41 4 * * *`) — the SECOND independent channel,
+  alongside the heartbeat above (#6808/#7196).** It was introduced as the compensating control while
+  the heartbeat was unfed; now that the heartbeat is live it is no longer the only automatic
+  verification of the at-rest claim, but it is still not redundant — it remains the ONLY channel that
+  sees the readyz/inventory dimension (a `workspace_count_shortfall`), which the heartbeat cannot
+  observe. A failing scheduled run files one `ci/luks-verify` issue classified `drift` (the
   at-rest claim itself — p0, `type/security`, and the counsel re-evaluation trigger), `readiness`
   (an ops or inventory event; a `workspace_count_shortfall` files under its own title at p0 because
   it is irreversible sole-copy data loss) or `unavailable` (nothing proven in either direction — do

--- a/knowledge-base/engineering/operations/runbooks/workspaces-luks-cutover-6604.md
+++ b/knowledge-base/engineering/operations/runbooks/workspaces-luks-cutover-6604.md
@@ -267,7 +267,16 @@ T0 remount + replay from LUKS", never a total loss.
   A `status` of `up` means a push landed inside the window; `down` means the probe stopped; `paused`
   means someone re-paused it (terraform will NOT un-pause it for you — the resource ships
   `paused = true` behind `lifecycle { ignore_changes = [paused] }`, so a re-pause survives every
-  apply and is invisible in a plan).
+  apply and is invisible in a plan). Un-pausing does not need the UI:
+  `curl -X PATCH -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"paused":false}' https://uptime.betterstack.com/api/v2/heartbeats/478794`
+  **Margin, because it is thinner than it looks.** Two independent pushers feed this heartbeat: the
+  host unit (`luks-monitor.timer`, `OnCalendar=daily` + `RandomizedDelaySec=1800`) and the daily
+  verify at 04:41 UTC. Together the largest gap is ~20h, comfortably inside the 25h window. But the
+  host unit ALONE can space two pushes up to **24h30m** apart at opposite jitter extremes, against a
+  25h window — about 30 minutes of headroom. So if the scheduled verify is ever paused, dropped, or
+  retired, this heartbeat moves from comfortable to marginal, and a slow probe or a `Persistent=true`
+  catch-up after a reboot can tip it into a false `down`. Widen `grace` before removing the verify,
+  not after the first spurious page.
   Two things it still does not cover, so do not over-read a green heartbeat. It is
   `policy_id`-gated on the paid tier (`var.betterstack_paid_tier`); on the free tier it alerts by
   **email only** and does not page. And the readyz/inventory dimension has no host-side coverage at


### PR DESCRIPTION
The heartbeat limb of #6808 is now applied and live, so the `WARN` that described it as pending
becomes the error it always should have been.

## What was done out-of-band first (not in this diff)

AC1 was code-complete and unapplied. No `workflow_dispatch` target set in
`apply-web-platform-infra.yml` contains either resource — grep confirms both are absent from every
`-target` list — so the sanctioned path is the agent-run targeted apply under the
`OPERATOR_APPLIED_EXCLUSIONS` contract, not an operator checklist.

```
betteruptime_heartbeat.workspaces_luks          Plan: 2 to add, 0 to change, 0 to destroy
doppler_secret.workspaces_luks_heartbeat_url    value = betteruptime_heartbeat...url (a reference)
```

Then **unpaused via the Better Stack v2 API, not the UI** — `PATCH /api/v2/heartbeats/{id}`
`{"paused": false}`, confirmed by an independent `GET` (`paused=false`, `paused_at=null`).
Terraform's `lifecycle { ignore_changes = [paused] }` means later applies will not revert it.

**AC2, pulled rather than eyeballed.** The heartbeat went `pending` -> `up` on verify run
[30913027207](https://github.com/jikig-ai/soleur/actions/runs/30913027207), whose probe logged
`rc=0`, `workspace_count=8 expected=8`, and `OK: /mnt/data is LUKS-backed`. A transition to `up`
can only be caused by a received push, so this is not an empty result read as a pass. Negative
control: the `WORKSPACES_LUKS_HEARTBEAT_URL absent` WARN is gone from that run. Positive control:
the same string is present in run 29783424497, the run that opened the issue.

One credential note, recorded rather than left silent: the first heartbeat's push URL was printed
to a session transcript by a redaction pattern that did not match the real host. It was rotated
immediately via `-replace` of both resources — the old heartbeat (id 478793) now returns HTTP 404,
and the live secret was re-verified equal to the new heartbeat's URL by SHA-256 comparison rather
than by echoing either value.

## AC3 — both heartbeat arms are now fatal

| condition | outcome | why |
| --- | --- | --- |
| URL absent | `rc=3` `heartbeat_url_absent` | no retry — a config fault does not heal |
| push exhausted | `rc=3` `heartbeat_push_failed` | 3 attempts, so one transient blip is not an outage |

**`exit 3`, never `exit 1`.** Every at-rest assert has already passed by the time control reaches
this block, so routing an alerting fault through the at-rest exit would file the p0 `type/security`
verdict whose body asserts the published Article 32 claim is false. Both reasons are registered in
the workflow's `is_probe_integrity()` and its `rc=3` headline branch, and in the runbook triage
table — the `(M)`/`(N)` parity gates fail loudly if that ever drifts.

The suite had **no coverage of the heartbeat in either direction**, which is why the WARN could
never have been caught here. Added a positive control (a healthy probe really pushes) *before* the
two fatal arms, so neither can pass against a build that dropped the push entirely, plus an
assertion that a heartbeat fault never exits 1. The harness already modelled `MON_HB_URL` but
defaulted it empty — correct while absent was survivable, fatal to every healthy fixture now — so
that default flips and `MON_HB_PUSH_RC` is added.

## AC4 — the runbook claim is now true rather than aspirational

Un-struck the Better Stack entry, with a no-dashboard pull command and an explicit statement of
what a green heartbeat still does **not** cover: it is `policy_id`-gated on the paid tier so on the
free tier it emails rather than pages, and it has no host-side readyz/inventory visibility. The
scheduled verify stays beside it — it is no longer the only automatic check, but it remains the
only channel that can see a `workspace_count_shortfall`. The soak note flips from blocked to
started; the >=7d span is first satisfiable **2026-08-11**, which unblocks #6897.

## Known residual, stated rather than implied

`/usr/local/bin/luks-monitor` is baked by `workspaces-cutover.sh` (`install -D -m 0755`), while the
verify workflow ships a fresh copy of the script per run. So this AC3 flip binds the **verify path
immediately** and the host's **daily systemd unit only at the next cutover-channel re-bake**. The
host's daily probe keeps pushing the heartbeat either way — that code has been in `main` since
#6604 and only ever lacked the secret, which now exists.

## Verification

- `luks-monitor.test.sh` — 43 passed, 0 failed (was 36/3 mid-change; the 3 were this change, now covered)
- `workspaces-luks-verify-workflow.test.sh` — 121 passed, 0 failed
- `workspaces-luks-freeze.test.sh` — 91 passed, 0 failed
- `workspaces-luks.test.sh` — 26 passed, 0 failed
- `shellcheck -S warning luks-monitor.sh` — clean

Ref #6808 — deliberately never `Closes`. That issue's closure condition is a conjunction (heartbeat
wired **and** schedule exists). Both limbs are now satisfied, but closure is the operator's call
once the daily scheduled run and the host-side push are both observed in steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)