### PR TITLE
fix(registry): make the zot crash cause reachable without host access

### DIFF
--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -179,11 +179,17 @@ write_files:
       # default the WHOLE capture to sentinels. Adapted from container-restart-monitor.sh:118-119
       # (adds .State.Status). Loop DETECTION keys on zot_restarts delta (reliable); the exit-reason
       # fields are for CAUSE attribution (often stale when a 4/min loop is sampled mid-run).
-      INSPECT=$(docker inspect -f '{{.Id}} {{.RestartCount}} {{.State.Status}} {{.State.OOMKilled}} {{.State.ExitCode}}' zot 2>/dev/null)
+      # StartedAt joins THIS call rather than getting its own (#7247). A second `docker inspect`
+      # would break the one-inspect invariant above in a way that defeats the field's purpose: the
+      # two calls can straddle a restart and pair an exit_code from one run with an uptime from
+      # the next, and if the first succeeds while the second misses you get
+      # `exit_code=0 state_status=running zot_uptime_s=-1` — ambiguous again, which is the exact
+      # condition zot_uptime_s exists to remove.
+      INSPECT=$(docker inspect -f '{{.Id}} {{.RestartCount}} {{.State.Status}} {{.State.OOMKilled}} {{.State.ExitCode}} {{.State.StartedAt}}' zot 2>/dev/null)
       if [ -n "$INSPECT" ]; then
-        read -r ID ZOT_RESTARTS STATE_STATUS OOM_KILLED EXIT_CODE <<<"$INSPECT"
+        read -r ID ZOT_RESTARTS STATE_STATUS OOM_KILLED EXIT_CODE STARTED_AT <<<"$INSPECT"
       else
-        ID=; ZOT_RESTARTS=-1; STATE_STATUS=unknown; OOM_KILLED=unknown; EXIT_CODE=-1
+        ID=; ZOT_RESTARTS=-1; STATE_STATUS=unknown; OOM_KILLED=unknown; EXIT_CODE=-1; STARTED_AT=
       fi
       # (2b2) #7247 — the exit_code STALENESS discriminator. `.State.ExitCode` is 0 for ANY RUNNING
       # container; it only carries a real value while the container is stopped. A 5-minute probe
@@ -197,11 +203,19 @@ write_files:
       # seconds is positive proof the sample is mid-loop and that exit_code carries no information;
       # a large value means the container is genuinely up and exit_code is trustworthy. One field
       # turns an ambiguous 0 into a self-describing one, with no host access.
-      STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' zot 2>/dev/null)
+      # STARTED_AT comes from the single inspect above. CLAMP is load-bearing: a never-started
+      # container reports StartedAt=0001-01-01T00:00:00Z, which GNU date parses to -62135596800 —
+      # yielding zot_uptime_s≈6.4e10, i.e. "up for 2000 years". That is not the -1 sentinel, it
+      # survives the consumers' non-sentinel filters, and it reads as "exit_code is trustworthy":
+      # the precise inversion of this field's purpose. Negative or absurd => -1 (unknown).
       ZOT_UPTIME_S=-1
       if [ -n "$STARTED_AT" ]; then
         _started_epoch=$(date -u -d "$STARTED_AT" +%s 2>/dev/null || echo "")
-        [ -n "$_started_epoch" ] && ZOT_UPTIME_S=$(( $(date -u +%s) - _started_epoch ))
+        if [ -n "$_started_epoch" ]; then
+          ZOT_UPTIME_S=$(( $(date -u +%s) - _started_epoch ))
+          # Clamp: negative (clock skew) or > 10 years (the 0001-01-01 sentinel) is not a runtime.
+          if [ "$ZOT_UPTIME_S" -lt 0 ] || [ "$ZOT_UPTIME_S" -gt 315360000 ]; then ZOT_UPTIME_S=-1; fi
+        fi
       fi
       # (2c) Container anonymous RSS — the OOM-CONFIRMATION signal (excludes reclaimable page cache,
       # unlike host used-memory). cgroup v2 memory.stat `anon` in bytes → /1048576. Path mirrors
@@ -271,9 +285,37 @@ write_files:
       #
       # grep -a: the buffer may contain binary from a truncated write; without it GNU grep treats
       # the stream as binary and prints nothing, which would silently re-create the empty-field bug.
-      ZOT_ERR_RAW=$(docker logs --tail 2000 zot 2>&1 | grep -aiE 'panic|fatal|"level":"error"|level:error|signal (SIGTERM|SIGKILL|SIGSEGV)|out of memory|runtime error|cannot |failed to ' | tail -n 3)
-      [ -n "$ZOT_ERR_RAW" ] || ZOT_ERR_RAW=$(docker logs --tail 3 zot 2>&1)
-      ZOT_LAST_ERR=$(printf '%s' "$ZOT_ERR_RAW" | tail -c 300 | tr '\n\r\t' ' ' | LC_ALL=C tr -cd '\40-\176' | tr -d '"\\'); [ -n "$ZOT_LAST_ERR" ] || ZOT_LAST_ERR=none
+      # RANKED, not merely widened. A flat grep + `tail -n 3` keeps the NEWEST matches, and the
+      # broadest terms (`cannot `/`failed to `) are exactly what routine zot warn lines hit — so
+      # the current run's chatter evicts the previous run's `panic:`. Try tiers in severity order
+      # and stop at the first that hits.
+      #
+      # `--since 12m` (not `--tail N`): the container runs `--log-driver journald`, so retention is
+      # journald's and a LINE bound is the wrong bound against a variable-chattiness startup scan.
+      # A time bound spans the 5-min cadence regardless of how many restarts occurred.
+      _zlogs() { docker logs --since 12m zot 2>&1; }
+      ZOT_ERR_SRC=none
+      ZOT_ERR_RAW=$(_zlogs | grep -aE 'panic:|fatal error|\[signal SIG|runtime error' | head -n 4)
+      [ -n "$ZOT_ERR_RAW" ] && ZOT_ERR_SRC=panic
+      if [ -z "$ZOT_ERR_RAW" ]; then
+        ZOT_ERR_RAW=$(_zlogs | grep -aE '"level":"(error|fatal)"|level:(error|fatal)|level=(error|fatal)' | head -n 3)
+        [ -n "$ZOT_ERR_RAW" ] && ZOT_ERR_SRC=error
+      fi
+      if [ -z "$ZOT_ERR_RAW" ]; then
+        ZOT_ERR_RAW=$(_zlogs | grep -aiE 'cannot |failed to |unable to |could not |no such file|permission denied' | head -n 3)
+        [ -n "$ZOT_ERR_RAW" ] && ZOT_ERR_SRC=warn
+      fi
+      # Fallback must be DISTINGUISHABLE from a match. Emitting routine tail-3 under the same field
+      # name is how a downstream alarm ends up printing "gc successfully completed" as the cause of
+      # a crash loop — naming a cause nobody measured (ADR-166), which is the defect this whole
+      # change exists to remove. zot_last_err_src says which tier produced the text.
+      if [ -z "$ZOT_ERR_RAW" ]; then ZOT_ERR_RAW=$(docker logs --tail 3 zot 2>&1); ZOT_ERR_SRC=fallback; fi
+      # head -c, NOT tail -c. A Go panic puts `panic: <msg>` on the FIRST line and the frame
+      # offsets after it; tail -c keeps the offsets and discards the only part that names the
+      # cause. Measured: the 2026-08-04 15:00:02Z sample reached Better Stack carrying only
+      # `...scheduler.go:143 +0x265 created by ...poolWorker in goroutine 32` — the panic header
+      # had already been truncated away by exactly this bug.
+      ZOT_LAST_ERR=$(printf '%s' "$ZOT_ERR_RAW" | tr '\n\r\t' ' ' | LC_ALL=C tr -cd '\40-\176' | tr -d '"\\' | head -c 300); [ -n "$ZOT_LAST_ERR" ] || { ZOT_LAST_ERR=none; ZOT_ERR_SRC=none; }
       # (2f) Boot discriminator — the immutable redeploy reuses the terraform hostname, so boot_id is
       # what cleanly separates old-host from new-host events for the automated decision rule.
       BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null); [ -n "$BOOT_ID" ] || BOOT_ID=unknown
@@ -325,7 +367,7 @@ write_files:
       fi
       # zot_last_err is free-text (may contain spaces) → keep it the LAST field so it never corrupts
       # key=value parsing of the fields before it.
-      LINE="SOLEUR_ZOT_DISK pcent=$PCENT fs_size_gb=$FS_GB block_size_gb=$block_size_gb resize_ok=$resize_ok zot_restarts=$ZOT_RESTARTS ping_rc=$PING_RC mem_total_mb=$MEM_TOTAL zot_anon_mb=$ZOT_ANON_MB zot_memory_cap_mb=$ZOT_MEMORY_CAP_MB zot_memory_capped=$ZOT_MEMORY_CAPPED zot_oom_kills=$ZOT_OOM_KILLS state_status=$STATE_STATUS oom_killed=$OOM_KILLED exit_code=$EXIT_CODE zot_uptime_s=$ZOT_UPTIME_S oom_kills_5m=$OOM_KILLS_5M boot_id=$BOOT_ID htpasswd_pull_matches=$HTP_PULL htpasswd_push_matches=$HTP_PUSH host=$(hostname) zot_last_err=$ZOT_LAST_ERR"
+      LINE="SOLEUR_ZOT_DISK pcent=$PCENT fs_size_gb=$FS_GB block_size_gb=$block_size_gb resize_ok=$resize_ok zot_restarts=$ZOT_RESTARTS ping_rc=$PING_RC mem_total_mb=$MEM_TOTAL zot_anon_mb=$ZOT_ANON_MB zot_memory_cap_mb=$ZOT_MEMORY_CAP_MB zot_memory_capped=$ZOT_MEMORY_CAPPED zot_oom_kills=$ZOT_OOM_KILLS state_status=$STATE_STATUS oom_killed=$OOM_KILLED exit_code=$EXIT_CODE zot_uptime_s=$ZOT_UPTIME_S zot_last_err_src=$ZOT_ERR_SRC oom_kills_5m=$OOM_KILLS_5M boot_id=$BOOT_ID htpasswd_pull_matches=$HTP_PULL htpasswd_push_matches=$HTP_PUSH host=$(hostname) zot_last_err=$ZOT_LAST_ERR"
       TOKEN="$${BETTERSTACK_LOGS_TOKEN:-}"
       if [ -n "$TOKEN" ]; then
         # Fail-loud-but-not-wedge: retry ONCE, then breadcrumb to journald. ping_rc is carried in

--- a/apps/web-platform/infra/cloud-init-registry.yml
+++ b/apps/web-platform/infra/cloud-init-registry.yml
@@ -185,6 +185,24 @@ write_files:
       else
         ID=; ZOT_RESTARTS=-1; STATE_STATUS=unknown; OOM_KILLED=unknown; EXIT_CODE=-1
       fi
+      # (2b2) #7247 — the exit_code STALENESS discriminator. `.State.ExitCode` is 0 for ANY RUNNING
+      # container; it only carries a real value while the container is stopped. A 5-minute probe
+      # against a ~14-second restart cycle therefore reads `exit_code=0 state_status=running`
+      # forever, which reads as "clean exit" and is in fact "we sampled mid-run". That is not a
+      # hypothetical misreading: it is the one this issue's own triage had to back out of.
+      # The comment at (2b) already warns these fields are "often stale when a 4/min loop is
+      # sampled mid-run" — but nothing EMITTED let a reader tell stale from real.
+      #
+      # zot_uptime_s closes that: it is the age of the CURRENT run. A value that is always a few
+      # seconds is positive proof the sample is mid-loop and that exit_code carries no information;
+      # a large value means the container is genuinely up and exit_code is trustworthy. One field
+      # turns an ambiguous 0 into a self-describing one, with no host access.
+      STARTED_AT=$(docker inspect -f '{{.State.StartedAt}}' zot 2>/dev/null)
+      ZOT_UPTIME_S=-1
+      if [ -n "$STARTED_AT" ]; then
+        _started_epoch=$(date -u -d "$STARTED_AT" +%s 2>/dev/null || echo "")
+        [ -n "$_started_epoch" ] && ZOT_UPTIME_S=$(( $(date -u +%s) - _started_epoch ))
+      fi
       # (2c) Container anonymous RSS — the OOM-CONFIRMATION signal (excludes reclaimable page cache,
       # unlike host used-memory). cgroup v2 memory.stat `anon` in bytes → /1048576. Path mirrors
       # container-restart-monitor.sh:129-132. Guard -1 if the container/cgroup is absent (mid-restart).
@@ -239,7 +257,23 @@ write_files:
       # mid-sequence-sliced UTF-8 — both invalid unescaped in a JSON string, RFC 8259 §7, so an
       # unstripped tab-indented Go crash trace would make Better Stack reject the WHOLE payload in
       # the exact crash case this field targets); finally drop "/\ so it can't corrupt the JSON.
-      ZOT_LAST_ERR=$(docker logs --tail 3 zot 2>&1 | tail -c 300 | tr '\n\r\t' ' ' | LC_ALL=C tr -cd '\40-\176' | tr -d '"\\'); [ -n "$ZOT_LAST_ERR" ] || ZOT_LAST_ERR=none
+      # (#7247) `--tail 3` was STRUCTURALLY incapable of carrying the crash line this field exists
+      # to carry. zot logs EVERY request at info (:128) and this host's own liveness probe GETs
+      # /v2/ every 5 min, so the last 3 lines are near-always routine HTTP traffic. Across a 21-hour
+      # 4.4-restarts/min loop (2026-08-03 17:08Z onward) the field carried a cause exactly zero
+      # times — every sample was an HTTP 200/401 session line or a gc/dedupe info line. The comment
+      # above already called this "the exact crash case this field targets"; the window was the bug.
+      #
+      # Scan WIDE and FILTER for cause-bearing lines instead. Falls back to the original tail-3 when
+      # nothing matches, so this is never emptier than what it replaces. `--restart unless-stopped`
+      # restarts the SAME container (RestartCount 5032 on one container id), so `docker logs`
+      # accumulates ACROSS restarts and a prior run's fatal line is still in the buffer.
+      #
+      # grep -a: the buffer may contain binary from a truncated write; without it GNU grep treats
+      # the stream as binary and prints nothing, which would silently re-create the empty-field bug.
+      ZOT_ERR_RAW=$(docker logs --tail 2000 zot 2>&1 | grep -aiE 'panic|fatal|"level":"error"|level:error|signal (SIGTERM|SIGKILL|SIGSEGV)|out of memory|runtime error|cannot |failed to ' | tail -n 3)
+      [ -n "$ZOT_ERR_RAW" ] || ZOT_ERR_RAW=$(docker logs --tail 3 zot 2>&1)
+      ZOT_LAST_ERR=$(printf '%s' "$ZOT_ERR_RAW" | tail -c 300 | tr '\n\r\t' ' ' | LC_ALL=C tr -cd '\40-\176' | tr -d '"\\'); [ -n "$ZOT_LAST_ERR" ] || ZOT_LAST_ERR=none
       # (2f) Boot discriminator — the immutable redeploy reuses the terraform hostname, so boot_id is
       # what cleanly separates old-host from new-host events for the automated decision rule.
       BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null); [ -n "$BOOT_ID" ] || BOOT_ID=unknown
@@ -291,7 +325,7 @@ write_files:
       fi
       # zot_last_err is free-text (may contain spaces) → keep it the LAST field so it never corrupts
       # key=value parsing of the fields before it.
-      LINE="SOLEUR_ZOT_DISK pcent=$PCENT fs_size_gb=$FS_GB block_size_gb=$block_size_gb resize_ok=$resize_ok zot_restarts=$ZOT_RESTARTS ping_rc=$PING_RC mem_total_mb=$MEM_TOTAL zot_anon_mb=$ZOT_ANON_MB zot_memory_cap_mb=$ZOT_MEMORY_CAP_MB zot_memory_capped=$ZOT_MEMORY_CAPPED zot_oom_kills=$ZOT_OOM_KILLS state_status=$STATE_STATUS oom_killed=$OOM_KILLED exit_code=$EXIT_CODE oom_kills_5m=$OOM_KILLS_5M boot_id=$BOOT_ID htpasswd_pull_matches=$HTP_PULL htpasswd_push_matches=$HTP_PUSH host=$(hostname) zot_last_err=$ZOT_LAST_ERR"
+      LINE="SOLEUR_ZOT_DISK pcent=$PCENT fs_size_gb=$FS_GB block_size_gb=$block_size_gb resize_ok=$resize_ok zot_restarts=$ZOT_RESTARTS ping_rc=$PING_RC mem_total_mb=$MEM_TOTAL zot_anon_mb=$ZOT_ANON_MB zot_memory_cap_mb=$ZOT_MEMORY_CAP_MB zot_memory_capped=$ZOT_MEMORY_CAPPED zot_oom_kills=$ZOT_OOM_KILLS state_status=$STATE_STATUS oom_killed=$OOM_KILLED exit_code=$EXIT_CODE zot_uptime_s=$ZOT_UPTIME_S oom_kills_5m=$OOM_KILLS_5M boot_id=$BOOT_ID htpasswd_pull_matches=$HTP_PULL htpasswd_push_matches=$HTP_PUSH host=$(hostname) zot_last_err=$ZOT_LAST_ERR"
       TOKEN="$${BETTERSTACK_LOGS_TOKEN:-}"
       if [ -n "$TOKEN" ]; then
         # Fail-loud-but-not-wedge: retry ONCE, then breadcrumb to journald. ping_rc is carried in

--- a/apps/web-platform/infra/registry-boot-guard.test.sh
+++ b/apps/web-platform/infra/registry-boot-guard.test.sh
@@ -102,14 +102,24 @@ assert "SOLEUR_ZOT_DISK marker line emitted" "grep -qF 'SOLEUR_ZOT_DISK pcent=' 
 # shellcheck disable=SC2034  # used inside the eval'd `assert` condition strings below (shellcheck can't see it)
 LINE_ASSIGN="$(grep -F 'LINE="SOLEUR_ZOT_DISK' "$CI" | head -1)"
 assert "LINE=\"SOLEUR_ZOT_DISK assignment found" "[ -n \"\$LINE_ASSIGN\" ]"
-# zot_uptime_s (#7247): the exit_code staleness discriminator. Guarded here so it cannot be
-# silently dropped — without it `exit_code=0 state_status=running` is unfalsifiable mid-loop.
+# zot_uptime_s + zot_last_err_src (#7247): the two ambiguity discriminators. Guarded here so
+# neither can be silently dropped — without zot_uptime_s, `exit_code=0 state_status=running` is
+# unfalsifiable mid-loop; without zot_last_err_src, a routine-traffic FALLBACK is indistinguishable
+# from a real match and a downstream alarm will print it as the crash cause (ADR-166).
 for f in pcent= fs_size_gb= block_size_gb= resize_ok= zot_restarts= ping_rc= \
          mem_total_mb= zot_anon_mb= zot_oom_kills= state_status= oom_killed= exit_code= \
-         zot_uptime_s= \
+         zot_uptime_s= zot_last_err_src= \
          oom_kills_5m= zot_last_err= boot_id= htpasswd_pull_matches= htpasswd_push_matches=; do
   assert "SOLEUR_ZOT_DISK LINE carries field ${f}" "grep -qF '${f}' <<<\"\$LINE_ASSIGN\""
 done
+# zot_last_err MUST be the LAST field. This is a SECURITY invariant, not cosmetics:
+# scripts/lib/zot-telemetry-parse.sh strips `zot_last_err=` and everything after it so a crafted
+# zot log line cannot spoof boot_id=/exit_code=137. Any field emitted after it is (a) outside the
+# trusted region and (b) invisible to every consumer. This had ZERO coverage before #7247 — the
+# first field insertion next to it got the placement right, and nothing would have caught it if
+# it had not.
+assert "zot_last_err is the LAST field in the LINE (trusted-region boundary)" \
+  "[[ \"\$LINE_ASSIGN\" == *'zot_last_err=\$ZOT_LAST_ERR\"' ]]"
 
 # --- #6497: the htpasswd-divergence probe -------------------------------------------------
 # zot-disk-heartbeat.sh runs `set -u`. A BARE "$ZOT_PULL_TOKEN" on an unset token raises
@@ -142,7 +152,7 @@ assert "probe emits a boolean/sentinel only — never the token" \
 # EXIT_CODE` must match the `docker inspect -f` template column order, else oom_killed/exit_code
 # transpose silently (values still look plausible in telemetry). Pin the exact 5-field template.
 assert "docker inspect -f template order matches the read target order" \
-  "grep -qF \"docker inspect -f '{{.Id}} {{.RestartCount}} {{.State.Status}} {{.State.OOMKilled}} {{.State.ExitCode}}' zot\" '$CI'"
+  "grep -qF \"docker inspect -f '{{.Id}} {{.RestartCount}} {{.State.Status}} {{.State.OOMKilled}} {{.State.ExitCode}} {{.State.StartedAt}}' zot\" '$CI'"
 assert "read targets are in the same order as the inspect template" \
   "grep -qF 'read -r ID ZOT_RESTARTS STATE_STATUS OOM_KILLED EXIT_CODE' '$CI'"
 

--- a/apps/web-platform/infra/registry-boot-guard.test.sh
+++ b/apps/web-platform/infra/registry-boot-guard.test.sh
@@ -102,8 +102,11 @@ assert "SOLEUR_ZOT_DISK marker line emitted" "grep -qF 'SOLEUR_ZOT_DISK pcent=' 
 # shellcheck disable=SC2034  # used inside the eval'd `assert` condition strings below (shellcheck can't see it)
 LINE_ASSIGN="$(grep -F 'LINE="SOLEUR_ZOT_DISK' "$CI" | head -1)"
 assert "LINE=\"SOLEUR_ZOT_DISK assignment found" "[ -n \"\$LINE_ASSIGN\" ]"
+# zot_uptime_s (#7247): the exit_code staleness discriminator. Guarded here so it cannot be
+# silently dropped — without it `exit_code=0 state_status=running` is unfalsifiable mid-loop.
 for f in pcent= fs_size_gb= block_size_gb= resize_ok= zot_restarts= ping_rc= \
          mem_total_mb= zot_anon_mb= zot_oom_kills= state_status= oom_killed= exit_code= \
+         zot_uptime_s= \
          oom_kills_5m= zot_last_err= boot_id= htpasswd_pull_matches= htpasswd_push_matches=; do
   assert "SOLEUR_ZOT_DISK LINE carries field ${f}" "grep -qF '${f}' <<<\"\$LINE_ASSIGN\""
 done


### PR DESCRIPTION
## Why

zot has been restarting **~4.4×/min on the registry host for ~21 hours** (#7247), blocking five releases. `zot_restarts` was 5032 and climbing at 14:25Z.

**This PR does not claim a cause.** It fixes the two reasons nobody could measure one — the deciding datum was structurally unreachable via telemetry, and the escalation path #7247 proposed (journald via the Vector allowlist) does not exist: **the registry host has no log shipper at all.** `vector.tf` is co-located with `inngest-server.service` and installed by `inngest-bootstrap.sh` — Inngest host only. The registry host's sole Better Stack egress is one `curl` POST of the `SOLEUR_ZOT_DISK` line every 5 minutes.

That is the 2026-07-28 sshd-allowlist precedent in a stronger form: an empty journald query would have read as "no crashes" when the channel was never shipped.

## Defect 1 — `zot_last_err` could not carry a crash line

It was `docker logs --tail 3 zot`. zot logs **every** request at info (`:128`), and this host's own liveness probe GETs `/v2/` every 5 minutes, so the last 3 lines are near-always routine HTTP traffic. Across the entire 21-hour loop the field carried a cause **zero times** — every sample was an HTTP 200/401 session line or a gc/dedupe info line.

The existing comment already called this *"the exact crash case this field targets."* The window was the bug.

Now scans a wide buffer and **filters** for cause-bearing lines, falling back to the original tail-3 when nothing matches — so it is never emptier than what it replaces. `--restart unless-stopped` restarts the **same** container (5032 restarts on one container id), so `docker logs` accumulates across restarts and a prior run's fatal line is still buffered.

`grep -a` is load-bearing: a truncated binary write would otherwise make GNU grep print nothing and silently re-create the empty-field bug.

## Defect 2 — `exit_code=0` was unfalsifiable

`.State.ExitCode` is `0` for **any running container**; it only carries a real value while stopped. A 5-minute probe against a ~14-second restart cycle reads `exit_code=0 state_status=running` forever — which reads as *"clean exit"* and actually means *"sampled mid-run."*

Not hypothetical: this is the misreading #7247's triage had to back out of. The `(2b)` comment warned these fields are *"often stale when a 4/min loop is sampled mid-run,"* but nothing **emitted** let a reader tell stale from real.

Adds **`zot_uptime_s`** — the age of the current run. Always-a-few-seconds is positive proof the sample is mid-loop and `exit_code` carries no information; a large value means `exit_code` is trustworthy. One field turns an ambiguous `0` into a self-describing one, with no host access.

## Placement is load-bearing

`zot_uptime_s` sits **before** `zot_last_err`. `scripts/lib/zot-telemetry-parse.sh` strips `zot_last_err=` and everything after it as an anti-spoof measure (a crafted log tail must not spoof `boot_id=`/`exit_code=137`), so a field emitted after it would be invisible to every consumer. Guarded in `registry-boot-guard.test.sh`'s field allowlist so it cannot be silently dropped later.

## Deployment note

The heartbeat script is written by cloud-init `write_files`, so this reaches the host via the existing gated `workflow_dispatch` (`apply_target=registry-host-replace`). That replace will also clear the current loop — which is why instrumenting **first** matters: the replace deploys the probe, so a recurrence self-reports instead of leaving us blind a third time. This is already a recurrence of #6288's non-OOM class.

## Verification

| Suite | Result |
|---|---|
| `registry-boot-guard.test.sh` | 80/80 |
| `zot-restart-loop-alarm.test.sh` | 54/54 |
| `zot-mirror-diagnosis.test.sh` | 54/54 |
| `reusable-release-zot-mirror-retry.test.sh` | 24/24 |

Also verified: no bare `${` introduced (Terraform templatefile safety), and the filter picks a `panic:` line out of a buffer dominated by routine HTTP traffic.

No cause is asserted anywhere in this change (ADR-166).

Ref #7247
Ref #7248

🤖 Generated with [Claude Code](https://claude.com/claude-code)