### PR TITLE
revert(test-all): run the component project always, restoring #7498's measured decision

### DIFF
--- a/apps/web-platform/test/repo-wide-containment.test.ts
+++ b/apps/web-platform/test/repo-wide-containment.test.ts
@@ -181,10 +181,10 @@ function walk(dir: string): string[] {
   return walkAll(dir).filter((f) => /\.test\.tsx?$/.test(f));
 }
 
-// Every file in a GATED project. Both `unit` (test|lib/**/*.test.ts) and
-// `component` (test/**/*.test.tsx) are declined together, so both need the
-// containment property — a `.test.tsx` that read the repo would fail open
-// exactly as a `.test.ts` would.
+// Candidates for the containment check. `unit` (test|lib/**/*.test.ts) is the
+// gated project, so its containment is load-bearing. `component`
+// (test/**/*.test.tsx) runs always, so its arm is a kept invariant rather than
+// a live guard — see the note on that arm below.
 const gatedCandidates = [...walk("test"), ...walk("lib")].sort();
 const unitFiles = gatedCandidates.filter((f) => f.endsWith(".test.ts"));
 
@@ -238,9 +238,11 @@ describe("repo-wide suite containment (#7498)", () => {
   });
 
   it("no component (.test.tsx) suite escapes the app", () => {
-    // The component project has no manifest — it is gated wholesale, so the
-    // invariant is absolute rather than "declared or app-local". Measured 0 of
-    // 240 at #7498; this keeps it that way.
+    // NOT load-bearing for the gate any more — `component` runs always (#7498
+    // declined gating it on measurement, and that decision was restored). The
+    // invariant is kept because it is true, cheap, and the precondition anyone
+    // would need if gating `component` is ever revisited: measured 0 of 240 at
+    // #7498. Deleting it would make that future decision unmeasurable again.
     const escaping = gatedCandidates.filter((f) => f.endsWith(".test.tsx")).filter(escapesApp);
     expect(
       escaping,

--- a/scripts/test-all-infra-coverage-notice.test.sh
+++ b/scripts/test-all-infra-coverage-notice.test.sh
@@ -379,7 +379,7 @@ GATED=(
   "scripts/cf-tunnel-liveness-gate-mutations|CF_TUNNEL_BATTERY_PATHS"
   "plugins/soleur/test/c4-from-components.test.sh|C4_PRODUCER_PATHS"
   ".github/scripts/test/run-all.sh|GITHUB_SCRIPTS_SUITE_PATHS"
-  "apps/web-platform [unit+component]|WEBPLAT_APP_PATHS"
+  "apps/web-platform [unit]|WEBPLAT_APP_PATHS"
 )
 
 # REGISTRATION FLOOR, derived from $TARGET — not a hand-typed literal.

--- a/scripts/test-all-webplat-gate.test.sh
+++ b/scripts/test-all-webplat-gate.test.sh
@@ -3,7 +3,8 @@
 # Guards the webplat vitest split in scripts/test-all.sh (#7498).
 #
 # The split gives the app-local projects (`unit`, `component`) a relevance gate
-# on `apps/web-platform/`, while `repo-wide` runs always. Two ways that can rot,
+# on `apps/web-platform/`, while `repo-wide` and `component` run always. Two ways
+# that can rot,
 # both silent:
 #
 #   1. `repo-wide` acquires a gate. Then the suites whose entire purpose is to
@@ -45,28 +46,28 @@ extract_block() {
 BLOCK="$(extract_block "$TEST_ALL")"
 
 echo "A1: both webplat suites are declared"
-grep -qF 'run_suite "apps/web-platform [repo-wide]"' <<<"$BLOCK" \
-  && pass "repo-wide suite declared" || fail "repo-wide suite declared"
-grep -qF 'run_suite "apps/web-platform [unit+component]"' <<<"$BLOCK" \
+grep -qF 'run_suite "apps/web-platform [repo-wide+component]"' <<<"$BLOCK" \
+  && pass "repo-wide+component suite declared" || fail "repo-wide+component suite declared"
+grep -qF 'run_suite "apps/web-platform [unit]"' <<<"$BLOCK" \
   && pass "app-local suite declared" || fail "app-local suite declared"
 echo ""
 
 echo "A2: the app-local suite is gated, and its decline is COUNTED"
 grep -qF '_diff_touches "${WEBPLAT_APP_PATHS[@]}"' <<<"$BLOCK" \
   && pass "gate predicate present" || fail "gate predicate present"
-grep -qF 'skip_suite "apps/web-platform [unit+component]"' <<<"$BLOCK" \
+grep -qF 'skip_suite "apps/web-platform [unit]"' <<<"$BLOCK" \
   && pass "decline goes through skip_suite (ADR-181: a decline is a verdict)" \
   || fail "decline goes through skip_suite"
 grep -qF '_relevance_declined=$((_relevance_declined + 1))' <<<"$BLOCK" \
   && pass "decline increments the relevance counter" || fail "decline increments the counter"
 echo ""
 
-echo "A3: repo-wide is NOT gated"
+echo "A3: repo-wide + component are NOT gated"
 # Everything before the `if _diff_touches` line is the ungated region.
 UNGATED="$(awk '/_diff_touches/{exit} {print}' <<<"$BLOCK")"
-grep -qF 'run_suite "apps/web-platform [repo-wide]"' <<<"$UNGATED" \
-  && pass "repo-wide runs outside the gate" \
-  || fail "repo-wide runs outside the gate — it would be declined on the diffs it guards"
+grep -qF 'run_suite "apps/web-platform [repo-wide+component]"' <<<"$UNGATED" \
+  && pass "repo-wide + component run outside the gate" \
+  || fail "repo-wide + component run outside the gate — repo-wide would be declined on the diffs it guards"
 echo ""
 
 echo "A4: the predicate array is declared, non-empty, and app-scoped"
@@ -137,25 +138,25 @@ echo "M2: gating repo-wide must break A3"
 # Deletion is already covered by A1, and a mutant that only deletes leaves A3's
 # real failure mode uncertified. So: delete the ungated pair, then re-emit it
 # immediately after the `if _diff_touches` line, i.e. inside the gated arm.
-mutate m2 '/run_suite "apps\/web-platform \[repo-wide\]"/,+1d' || exit 2
+mutate m2 '/run_suite "apps\/web-platform \[repo-wide+component\]"/,+1d' || exit 2
 M2="$TMP/m2.sh"
 awk '
   /if _diff_touches "\$\{WEBPLAT_APP_PATHS\[@\]\}"; then/ {
     print
-    print "    run_suite \"apps/web-platform [repo-wide]\" env VITEST_SHARD=\"${VITEST_SHARD:-}\" \\"
+    print "    run_suite \"apps/web-platform [repo-wide+component]\" env VITEST_SHARD=\"${VITEST_SHARD:-}\" \\"
     print "      bash -c '"'"'cd apps/web-platform \&\& npm run test:ci -- --project repo-wide'"'"'"
     next
   }
   { print }
 ' "$M2" > "$M2.tmp" && mv "$M2.tmp" "$M2"
-grep -qF 'run_suite "apps/web-platform [repo-wide]"' "$M2" \
+grep -qF 'run_suite "apps/web-platform [repo-wide+component]"' "$M2" \
   && pass "M2 mutant re-emitted repo-wide inside the gate (the mutation A3 targets)" \
   || fail "M2 mutant re-emitted repo-wide inside the gate"
 bash -n "$M2" && pass "M2 mutant is still a parseable script" || fail "M2 mutant parses"
 [[ -n "$(extract_block "$M2")" ]] && pass "M2 mutant still contains the webplat block" \
   || fail "M2 mutant still contains the webplat block"
 M2_UNGATED="$(awk '/_diff_touches/{exit} {print}' <<<"$(extract_block "$M2")")"
-if grep -qF 'run_suite "apps/web-platform [repo-wide]"' <<<"$M2_UNGATED"; then
+if grep -qF 'run_suite "apps/web-platform [repo-wide+component]"' <<<"$M2_UNGATED"; then
   fail "M2 mutant still shows repo-wide ungated — A3 is vacuous"
 else
   pass "gated-repo-wide mutant is detected (A3 can be driven red)"

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1611,16 +1611,27 @@ fi
 # land in the gated project and be silently declined. That guard runs in the
 # repo-wide project, so it is never gated by the thing it guards.
 if want_webplat; then
-  run_suite "apps/web-platform [repo-wide]" env VITEST_SHARD="${VITEST_SHARD:-}" \
-    bash -c 'cd apps/web-platform && npm run test:ci -- --project repo-wide ${VITEST_SHARD:+--shard="$VITEST_SHARD"} 2>&1'
+  # `component` runs ALWAYS, alongside repo-wide. #7498 evaluated gating it and
+  # declined on measurement: at ~80 s it is a ~39 s expected saving, "statistically
+  # the same quantity this PR already declined for the union predicate", and taking
+  # it "would import a new fail-open surface to buy back exactly what was refused".
+  #
+  # #7666 gated it anyway, reasoning that the containment guard covers `component`
+  # at zero marginal cost once it exists for `unit`. That reversed an explicit,
+  # measured decision by the issue author on the strength of an argument about
+  # cost, not about the risk the decision was made on — so it is reverted here.
+  # The invariant the guard asserts (0 of 240 `.test.tsx` escape the app) is kept:
+  # it is true and worth keeping true, it is simply no longer load-bearing.
+  run_suite "apps/web-platform [repo-wide+component]" env VITEST_SHARD="${VITEST_SHARD:-}" \
+    bash -c 'cd apps/web-platform && npm run test:ci -- --project repo-wide --project component ${VITEST_SHARD:+--shard="$VITEST_SHARD"} 2>&1'
 
   if _diff_touches "${WEBPLAT_APP_PATHS[@]}"; then
-    run_suite "apps/web-platform [unit+component]" env VITEST_SHARD="${VITEST_SHARD:-}" \
-      bash -c 'cd apps/web-platform && npm run test:ci -- --project unit --project component ${VITEST_SHARD:+--shard="$VITEST_SHARD"} 2>&1'
+    run_suite "apps/web-platform [unit]" env VITEST_SHARD="${VITEST_SHARD:-}" \
+      bash -c 'cd apps/web-platform && npm run test:ci -- --project unit ${VITEST_SHARD:+--shard="$VITEST_SHARD"} 2>&1'
   else
     _relevance_declined=$((_relevance_declined + 1))
-    skip_suite "apps/web-platform [unit+component]" "relevance" \
-      "cd apps/web-platform && npm run test:ci -- --project unit --project component"
+    skip_suite "apps/web-platform [unit]" "relevance" \
+      "cd apps/web-platform && npm run test:ci -- --project unit"
   fi
 fi
 


### PR DESCRIPTION
## Why

#7498 evaluated gating the `component` vitest project and **declined, on measurement**:

> all 240 `.test.tsx` resolve within `apps/web-platform` (so its containment guard is sound), but it is only ~80 s of the suite — an expected saving of ~39 s/run, statistically the same quantity this PR already declined for the union predicate. Taking it would import a new fail-open surface to buy back exactly what was refused.

**#7666 gated it anyway** — my call. The reasoning was that once the containment guard exists for `unit`, it covers `component` at zero marginal cost, so the saving is free.

That argument addresses the **cost** half of the original decision and not the **risk** half it was actually made on. It also reversed an explicit, measured call by the issue author without their input. Restored here.

## What changes

`component` now runs alongside `repo-wide` on every diff; only `unit` is gated on `apps/web-platform/`.

| Suite | Gated? |
|---|---|
| `apps/web-platform [repo-wide+component]` | no |
| `apps/web-platform [unit]` | on `apps/web-platform/` |

## The containment guard's component arm is kept

It asserts 0 of 240 `.test.tsx` escape the app, and was described as *"what makes gating component safe"*. That justification is now false — nothing gates it.

I kept the arm and corrected the comment rather than deleting it. The invariant is true, cheap, and is precisely the precondition anyone would need if gating `component` is ever revisited. **Deleting it would make that future decision unmeasurable again**, which is the situation #7498 had to spend measurement to escape.

## Verification

- Partition unchanged: **54 / 817 / 240**.
- `test-all-webplat-gate.test.sh` **16/16**, with both mutants still driving their arms red (labels updated, so M2 still re-emits `[repo-wide+component]` inside the gate and A3 still flips).
- `test-all-infra-coverage-notice.test.sh` **127/0** (its `GATED` row relabelled).
- Containment guard **10/10**; `fixture-cd-containment` **8/8**; orphan linter clean.

## Changelog

- `test-all.sh` now runs the `component` vitest project on every diff rather than gating it on `apps/web-platform/`, restoring the measured decision recorded in #7498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
