### PR TITLE
fix(7650): the provider cannot express a frequency trigger — Phase 2 is 16 rules, not 25

### DIFF
--- a/knowledge-base/project/plans/2026-08-25-fix-7650-sentry-issue-alert-to-alert-migration-plan.md
+++ b/knowledge-base/project/plans/2026-08-25-fix-7650-sentry-issue-alert-to-alert-migration-plan.md
@@ -116,15 +116,35 @@ ADR-031's sharp edge: the filter counts nested-block shrink per-type with no `wa
 new type has its shrink counted as **0** and slips the guard silently. This must land before,
 not with, the migration.
 
-## Phase 2 — translate and import (25 resources)
+## Phase 2 — translate and import (16 resources, NOT 25)
+
+> **Re-scoped 2026-09-02.** The provider cannot express a frequency TRIGGER. Importing one
+> routes it through `legacy_trigger_conditions` (List of String), which discards the
+> `comparison`, and the next apply rewrites it as the boolean `true` — destroying the
+> threshold and interval on a live paging rule. Measured in the provider source at v0.15.5;
+> see `knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase2-provider-cannot-express-frequency-triggers.md`.
+>
+> **No guard can catch this, including Phase 1's.** The destroyed value lives only
+> server-side and never appears in the `.tf`, so `terraform plan` shows no diff to count.
+> Invisible to the destroy gate by construction.
+>
+> In scope: the **16 lifecycle-triggered** rules (`first_seen_event` / `reappeared_event` /
+> `regression_event`), whose trigger comparisons are already `true` and round-trip
+> losslessly. Out of scope until the provider gains frequency-trigger support: the 13
+> frequency-triggered rules, which stay on `sentry_issue_alert`. Never import Sentry's own
+> default workflow.
 
 - [ ] **2.1** Translate, per the mapping MEASURED in Phase 0 (this corrects the mapping
       originally written here, which sent frequency conditions to `action_filters` — a
       place Sentry never puts them):
       - lifecycle conditions (`first_seen_event` / `reappeared_event` / `regression_event`)
         -> `trigger_conditions`, `logic_type = any-short`
-      - **frequency conditions -> `trigger_conditions` as `event_frequency_count` /
-        `event_unique_user_frequency_count`, `logic_type = all`** (NOT action filters)
+      - **frequency conditions: NOT MIGRATABLE at v0.15.5.** The API carries them as
+        triggers; the provider models them only under `action_filters[].conditions` and
+        cannot represent a frequency *trigger* at all. An earlier revision of this line
+        sent them to `trigger_conditions`, which is wrong for the provider — corrected
+        twice now, so state the source: provider docs + `resource_alert_impl.go` at the
+        pinned tag, not the API shape and not this plan's prose.
       - `tagged_event` / `level` filters -> `action_filters[].conditions` — measured to be
         the only condition type Sentry puts there
       - `filter_match` -> `action_filters[].logic_type`

--- a/knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase0-fidelity-evidence.md
+++ b/knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase0-fidelity-evidence.md
@@ -4,7 +4,17 @@ Measured 2026-08-26 against **live** Sentry (org `jikigai-eu`), read-only, using
 `SENTRY_IAC_AUTH_TOKEN` from Doppler `soleur/prd`. No object was created, mutated, or
 deleted; every call below is a GET.
 
-## Verdict: PASS, and the plan's translation mapping was wrong
+> **SCOPE RETRACTED 2026-09-02.** The PASS below holds for the 16 **lifecycle-triggered**
+> rules and NOT for the 13 frequency-triggered ones. This file measured how Sentry's **API**
+> represents our rules; it never checked whether the **provider** can express that
+> representation, and it cannot. A frequency trigger round-trips through
+> `legacy_trigger_conditions` (a List of String) which discards the `comparison` payload,
+> and the write path reconstructs it as the boolean `true` — destroying the threshold and
+> interval on a live paging rule. The mapping "correction" below is also wrong for the
+> provider, whose frequency conditions live under `action_filters[].conditions`.
+> See `phase2-provider-cannot-express-frequency-triggers.md`.
+
+## Verdict: PASS for lifecycle rules only, and the plan's translation mapping was wrong
 
 Phase 0 asked whether a **pure-frequency** rule (`event_frequency`, no lifecycle trigger)
 fires faithfully once bound to a default monitor, since binding one to an issue-stream
@@ -90,8 +100,11 @@ shells.
 
 ## Consequences for the migration
 
-- **Phase 0 passes.** All 25 non-`auth-*` rules, including the 9 pure-frequency ones, are
-  faithfully expressible. No rule needs to stay on `sentry_issue_alert` for fidelity.
+- ~~**Phase 0 passes.** All 25 non-`auth-*` rules, including the 9 pure-frequency ones, are
+  faithfully expressible. No rule needs to stay on `sentry_issue_alert` for fidelity.~~
+  **RETRACTED 2026-09-02:** true for the 16 lifecycle rules, false for the 9 pure-frequency
+  ones. Measuring the API's representation is not the same as measuring the provider's, and
+  only the first was done here.
 - **The work is closer to an import than a re-creation.** The target objects already
   exist server-side with correct semantics; the task is getting Terraform to manage them,
   not to author them. That is materially lower risk than the plan assumed.

--- a/knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase2-provider-cannot-express-frequency-triggers.md
+++ b/knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase2-provider-cannot-express-frequency-triggers.md
@@ -1,0 +1,114 @@
+# Phase 2 blocker — the provider cannot express a frequency TRIGGER, and round-trips it destructively
+
+Measured 2026-09-02, from the provider source at `v0.15.5` and live org state. Read-only.
+**This retracts the scope of the Phase 0 "PASS".**
+
+## What Phase 0 got wrong
+
+Phase 0 measured how **Sentry's API** represents our rules and concluded all 25 non-`auth-*`
+rules were faithfully expressible. It never checked whether the **provider** can express
+that representation. Those are different questions, and they diverge here.
+
+- The **API** puts frequency conditions in `triggers.conditions`
+  (`event_frequency_count`, `event_unique_user_frequency_count`) — measured, still true.
+- The **provider** models frequency only under `action_filters[].conditions`.
+  `trigger_conditions` accepts exactly four types: `first_seen_event`,
+  `issue_resolved_trigger`, `reappeared_event`, `regression_event`.
+
+So the mapping correction I made to the plan on 2026-08-26 — moving frequency into
+`trigger_conditions` — was right about the API and **wrong about the provider**. The plan's
+*original* mapping (frequency → `action_filters[].conditions`) was correct for authoring
+new alerts. Both are now stated explicitly, because the two shapes genuinely differ.
+
+## The destructive round-trip
+
+`internal/provider/resource_alert_impl.go` at `v0.15.5`.
+
+**Read** — any trigger type outside the four falls through to a default that keeps only the
+type string:
+
+```go
+default:
+    legacyTriggerConditions = append(legacyTriggerConditions, triggerCondition.Type)
+```
+
+`legacy_trigger_conditions` is a `List of String`. The `comparison` payload —
+`{"value": 3, "interval": "5m"}` — has nowhere to go and is discarded.
+
+**Write** — the comparison is reconstructed as a hardcoded boolean:
+
+```go
+comp.FromOrganizationWorkflowTriggerConditionComparison0(true)
+...
+Type:            inLegacyTriggerCondition,
+Comparison:      comp,          // literally `true`
+```
+
+So an import followed by any apply rewrites the live trigger from
+`{"value": 3, "interval": "5m"}` to `true`. The threshold and the interval are destroyed
+on a live paging rule.
+
+## Blast radius: 14 of 30 workflows
+
+Faithfully importable (trigger types all within the provider's four): **16**.
+Threshold destroyed on round-trip: **14**.
+
+```
+auth-per-user-loop              event_unique_user_frequency_count {"value":3,"interval":"5m"}
+auth-signout-burst              event_frequency_count
+auth-exchange-code-burst        event_frequency_count
+auth-callback-no-code-burst     event_frequency_count
+sandbox-startup-failure         event_unique_user_frequency_count
+zot-mirror-fallback-rate        event_frequency_count {"value":0,"interval":"1h"}
+web-host-terminal-boot-fatal    event_frequency_count
+web-host-private-nic-boot-gate  event_frequency_count
+workspaces-luks-drift           event_frequency_count
+local-cache-reload-rate         event_frequency_count
+seccomp-remediation-failed      event_frequency_count
+gh-pages-cert-reissue-failed    event_frequency_count
+git-data-boot-fatal             event_frequency_count {"value":0,"interval":"1h"}
+"Send a notification for high priority issues"   (Sentry's own default — do not import)
+```
+
+`byok-art-33-breach` is lifecycle-triggered and therefore **not** affected: the GDPR
+Art. 33 paging path is safe either way.
+
+## Why no guard catches this, including the one shipped in Phase 1
+
+Phase 1's destroy guard counts `legacy_trigger_conditions` **shrink**. This hazard is not a
+shrink: the list keeps its length and its type string. What changes is a value that exists
+only server-side and is never present in the `.tf` at all — so `terraform plan` shows no
+diff to count. It is invisible to the destroy gate **by construction**, not by omission.
+
+That makes this a hard blocker for the affected 14 rather than something to guard and
+proceed through. The Phase 1 guard remains correct and worth having; it simply cannot see
+this failure mode, and the plan should not imply that it can.
+
+## Re-scope
+
+- **Phase 2 covers 16 rules, not 25.** Those are exactly the lifecycle-triggered ones,
+  whose trigger conditions carry `comparison: true` already and round-trip losslessly.
+- The 13 frequency-triggered rules of ours stay on `sentry_issue_alert` until the provider
+  can express a frequency trigger with its comparison. That keeps them on the deprecated
+  read path, so the brownout retry stays load-bearing for them — Phase 3.4's condition
+  ("remove the retry when zero `sentry_issue_alert` remain") is unchanged but is now much
+  further away.
+- Sentry's own default workflow must never be imported, for the same reason plus the
+  `new_high_priority_issue` / `existing_high_priority_issue` types it carries.
+- The `auth-*` four are now blocked twice over: by #7634's write shape and by this.
+
+## Reproduce
+
+```sh
+# which rules survive a provider round-trip
+jq -r '.[] | . as $w
+  | ([$w.triggers.conditions[].type]
+     | map(select(. == "first_seen_event" or . == "reappeared_event"
+                  or . == "regression_event" or . == "issue_resolved_trigger"))
+     | length) as $ok
+  | ([$w.triggers.conditions[]] | length) as $tot
+  | "\($w.name)|\($ok)|\($tot)"' wf-all.json
+```
+
+Provider source: `internal/provider/resource_alert_impl.go` at tag `v0.15.5`, the `default:`
+branch of the trigger read switch and the `LegacyTriggerConditions` write loop.

--- a/knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase2-provider-cannot-express-frequency-triggers.md
+++ b/knowledge-base/project/specs/fix-7650-sentry-alert-migration/phase2-provider-cannot-express-frequency-triggers.md
@@ -97,6 +97,56 @@ this failure mode, and the plan should not imply that it can.
   `new_high_priority_issue` / `existing_high_priority_issue` types it carries.
 - The `auth-*` four are now blocked twice over: by #7634's write shape and by this.
 
+## Can the 13 be RESTRUCTURED instead of blocked? No.
+
+The obvious workaround is to move frequency from the trigger to an action filter, which the
+provider *does* support (`action_filters[].conditions[].event_frequency_count`) and the API
+permits (`OrganizationWorkflow_ActionFilter_Condition_EventFrequencyCount`). It does not
+work, for a structural reason rather than a fiddly one.
+
+A workflow evaluates as: **detector produces an issue event → trigger decides whether the
+workflow runs → action filters gate whether the action fires.** So an action filter can only
+narrow something a trigger already started.
+
+The provider's entire trigger vocabulary is four types — `first_seen_event`,
+`issue_resolved_trigger`, `reappeared_event`, `regression_event`. **None of them means
+"every event".** So there is no trigger to pair a frequency filter with that reproduces
+"fire whenever this issue exceeds N in `interval`". Any available trigger narrows evaluation
+to a lifecycle moment, which is a different rule: `zot-mirror-fallback-rate` would stop
+firing on a sustained fallback rate on an *existing* issue and only fire if the threshold
+happened to be crossed at first-seen.
+
+That is a semantic change to live paging, which is precisely what Phase 0 existed to
+prevent. Restructuring is therefore rejected, not deferred.
+
+## Where the actual fix is
+
+The API is not the constraint. `OrganizationWorkflow_Trigger_Condition.comparison` is
+declared `oneOf: [boolean, object]` in the provider's own vendored `api.yaml` — carrying
+`{"value": 3, "interval": "5m"}` on a trigger is already legal, and the generated client
+can hold it. The loss happens one layer up, in the resource model: `trigger_conditions`
+exposes only the four lifecycle types, so everything else is funnelled into the
+string-only `legacy_trigger_conditions`.
+
+The unblock is provider-side: `trigger_conditions` variants for `event_frequency_count`,
+`event_unique_user_frequency_count`, and `event_frequency_percent` that carry the comparison
+object. Upstream appears aware the shape is unsettled — the vendored spec annotates that
+`oneOf` with `# TODO: Legacy?`.
+
+## Recommendation: do not migrate the 16 now
+
+Migrating the 16 lifecycle rules is possible but **buys nothing operationally and costs
+risk.** `apply-sentry-infra.yml` plans the FULL ROOT, so all 13 remaining
+`sentry_issue_alert` resources still refresh through the deprecated endpoint on every run.
+The gate would keep wedging on exactly the same brownout, and the retry would stay
+load-bearing. Meanwhile the change would be `state rm` + `import` against 16 live paging
+rules, and would split one concern across two resource types for an unknown wait.
+
+So Phase 2 is parked until the provider can express a frequency trigger. What is already
+shipped — the scoped retry, the frequency meter, the destroy guard — is what carries the
+operational load in the meantime, and the meter FAILs if the brownout ever outgrows the
+retry budget.
+
 ## Reproduce
 
 ```sh


### PR DESCRIPTION
**This retracts the scope of my own Phase 0 "PASS."** Found by reading the provider source before generating any HCL — it would otherwise have been found by destroying the thresholds on 13 live paging rules.

## What Phase 0 got wrong

Phase 0 measured how **Sentry's API** represents our rules and concluded all 25 non-`auth-*` rules were faithfully expressible. It never checked whether the **provider** can express that representation. Different questions, and they diverge:

| | Frequency conditions live in |
|---|---|
| **API** | `triggers.conditions` (`event_frequency_count`, `event_unique_user_frequency_count`) |
| **Provider** | `action_filters[].conditions` only. `trigger_conditions` accepts exactly four types: `first_seen_event`, `issue_resolved_trigger`, `reappeared_event`, `regression_event` |

So the mapping correction I made on 2026-08-26 was right about the API and **wrong about the provider**. The plan's *original* mapping was correct for authoring. Both shapes are now stated, because they genuinely differ — and that is why this got corrected twice.

## The round-trip is destructive, not merely lossy

`resource_alert_impl.go` @ `v0.15.5`. **Read** — any trigger outside the four falls to a default keeping only the type string:

```go
default:
    legacyTriggerConditions = append(legacyTriggerConditions, triggerCondition.Type)
```

`legacy_trigger_conditions` is a `List of String`, so `{"value":3,"interval":"5m"}` has nowhere to go. **Write** — the comparison is reconstructed as a hardcoded boolean:

```go
comp.FromOrganizationWorkflowTriggerConditionComparison0(true)
Type: inLegacyTriggerCondition, Comparison: comp
```

Import then apply rewrites a live trigger from `{"value":3,"interval":"5m"}` → `true`. `auth-per-user-loop` is precisely that case.

## Blast radius: 16 importable, 14 destroyed

13 of ours plus Sentry's own default workflow. `byok-art-33-breach` is lifecycle-triggered, so **the GDPR Art. 33 paging path is unaffected** either way.

## No guard catches this — including the one I shipped in Phase 1

Phase 1 counts `legacy_trigger_conditions` **shrink**. This is not a shrink: the list keeps its length *and* its type string. The destroyed value exists only server-side and never appears in the `.tf`, so `terraform plan` has no diff to count. It is invisible to the destroy gate **by construction**, not by omission.

That makes it a hard blocker for the affected rules rather than something to guard and proceed through. The Phase 1 guard is still correct and worth having; the plan simply must not imply it covers this.

## Re-scope

- **Phase 2 covers 16 rules, not 25** — the lifecycle-triggered ones, whose trigger comparisons are already `true` and round-trip losslessly.
- The 13 frequency rules stay on `sentry_issue_alert` until the provider can express a frequency trigger. They therefore stay on the deprecated read path, so **the brownout retry stays load-bearing** and Phase 3.4's "remove the retry when zero `sentry_issue_alert` remain" moves much further out.
- Sentry's own default workflow must never be imported.
- The `auth-*` four are now blocked twice: by #7634's write shape and by this.

Docs-only. No `.tf`, no state, nothing applied.

Refs #7650. Refs #7634. Refs #4781.
