### PR TITLE
revert(infra): roll the apex back to the GitHub Pages A record (ADR-194)

### DIFF
--- a/apps/web-platform/infra/dns.tf
+++ b/apps/web-platform/infra/dns.tf
@@ -355,24 +355,12 @@ resource "cloudflare_record" "protonmail_dkim_3" {
 #
 # The right time to remove this is when the rollback window formally closes,
 # together with the ssl rule, as one deliberate change — not as tidy-up.
-moved {
-  from = cloudflare_record.github_pages["185.199.108.153"]
-  to   = cloudflare_record.pages_apex
-}
 
-resource "cloudflare_record" "pages_apex" {
-  zone_id = var.cf_zone_id
-  name    = "soleur.ai" # never "@" -- see AC43; the two are not interchangeable on read-back
-  content = cloudflare_pages_project.docs.subdomain
-  type    = "CNAME"
-  proxied = true
-  ttl     = 1
-}
 
 resource "cloudflare_record" "www" {
   zone_id = var.cf_zone_id
   name    = "www"
-  content = cloudflare_pages_project.docs.subdomain
+  content = "jikig-ai.github.io"
   type    = "CNAME"
   proxied = true
   ttl     = 1
@@ -411,4 +399,28 @@ resource "cloudflare_record" "buttondown_ns2" {
 # Verify: dig soleur.ai DS @8.8.8.8 +short
 resource "cloudflare_zone_dnssec" "soleur_ai" {
   zone_id = var.cf_zone_id
+}
+resource "cloudflare_record" "github_pages" {
+  # Restored by generate-apex-rollback-pr.sh. NO `for_each`: the rollback target
+  # is a single address, so the reverse `moved` below is a single-address move
+  # and the A<-CNAME change is one replace that Terraform core serialises —
+  # the same property the forward cutover relied on.
+  zone_id = var.cf_zone_id
+  name    = "soleur.ai"
+  content = "185.199.108.153"
+  type    = "A"
+  proxied = true
+  ttl     = 1
+}
+
+# --- ADR-194 apex rollback (reverse moved) ---
+# Emitted by generate-apex-rollback-pr.sh.
+#
+# It returns the apex to its pre-cutover address so the CNAME->A change is a
+# single-address replace that Terraform core serialises. Without it the rollback
+# is two unrelated addresses dispatched concurrently, which is Cloudflare 81053
+# in the reverse direction — the measured reason 'git revert' is forbidden here.
+moved {
+  from = cloudflare_record.pages_apex
+  to   = cloudflare_record.github_pages
 }


### PR DESCRIPTION
revert(infra): roll the apex back to the GitHub Pages A record (ADR-194)

Generated by apps/web-platform/infra/generate-apex-rollback-pr.sh. This is the
rollback for the #7640 PR4b apex cutover, and it is NOT a `git revert` of it.

A revert restores cloudflare_record.github_pages and deletes
cloudflare_record.pages_apex with no `moved` block, so Terraform plans two
unrelated addresses and dispatches them concurrently. Cloudflare rejects an A and
a CNAME at one name (81053), so that reproduces the collision in the reverse
direction, on an apex that is already failing. Measured, not assumed.

This carries a reverse `moved` block instead, returning the apex to
cloudflare_record.github_pages["185.199.108.153"] so the CNAME->A change is a single-address replace that core
serialises. `dns.tf` is otherwise byte-identical to the shape PR4a left.

[ack-destroy]

Ref #7640
