### PR TITLE
fix(sentry): bump to 0.15.7 — the frequency-trigger fix is in, verified in the tag

### DIFF
--- a/apps/web-platform/infra/sentry/.terraform.lock.hcl
+++ b/apps/web-platform/infra/sentry/.terraform.lock.hcl
@@ -2,25 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/jianyuan/sentry" {
-  version     = "0.15.5"
-  constraints = "0.15.5"
+  version     = "0.15.7"
+  constraints = "0.15.7"
   hashes = [
-    "h1:AYFYRkb7VFOB3/siP9FzfRYb/ZewW29+kdNnkgZS3W8=",
-    "h1:OyxV0UHmjHjOIUz3nKhY4iOk20oLOGR4pMc80uHFGzc=",
-    "h1:TiBTS+dke+bExR766ow5E3TiNGPDFhsp1FNq26Iw3Rs=",
+    "h1:AKJYJgIwJ5VNOmJDwWez39ZWmA/6vtPmir8DXd4X4Bg=",
+    "h1:F++TMOq7ytNcS8SzfCHpkuupKEFJ8LNLrP9ty4ySlwI=",
+    "h1:KHr42E7qjgylzScVlai8qIBaarHlzlh50/uv3IItfhA=",
+    "zh:04de519f7e36c8a6d3c83e70d3aeec706a34594620df9bb8d598ba6020666f9b",
     "zh:0dde99e7b343fa01f8eefc378171fb8621bedb20f59157d6cc8e3d46c738105f",
-    "zh:3e7f703f7e6c1b56680a96710cac94e7ca48b7c4e03a961d8e32af7f554bc018",
-    "zh:5d2d35177d2ea3691391cf42e3b4c57dca80af3efa77e37065a487e573fa7c87",
-    "zh:6ef5c24d3ae8a1e589024522392639cb3cdc46f8bd5e4af69efaf3b899901300",
-    "zh:76f5ef16dbf35f0fe4765a4b10950621d01c5868572d5ed767a5cfb10c41862f",
-    "zh:9f436586157ca9803eb1f9bddafd7724a0f4ab99c96dd24a5ca2121442f781d8",
-    "zh:9f86931c2f7bdf440f1e3b40cfe35fa464d44f510e379e73588b247045c9a239",
-    "zh:b02f28cb360dfd77ffb2bbda7380b7e99217ebca74633bdcfc5c1b4f12a32d9a",
-    "zh:befc0fbaaa690a8a96e5ac68fa4e0e8d5affa07751a816ecede118ef90e58edc",
-    "zh:c993b4c2dfd5a3a7440c4675581f4129201aaa9aa200712d61b680357ff38937",
-    "zh:d35c79c86b2b23cc45fea08f0b34f7bd7def84005ff7c19cfdd71b7e0f92cd7c",
-    "zh:d4e7e501b57647018aeb4c4a5b0d91c10e5a13c660d821facbd1820f847e22eb",
-    "zh:d6f7c2742eeca5f9b23d66bd4ab22210a2d87836587625fb3697870d473daf25",
-    "zh:f88f39743dcc3ceb27742b7d35170816f6f94839e2d40270885b6f68d9abdbd5",
+    "zh:11789c053d38b73b7bb250a412ce76ef7e73bb27863586f0d98d5e66434a18e5",
+    "zh:2c765ee097f7e84117330970bbff2fb36f28b34feff8a8986fe89892480c5768",
+    "zh:2ccc782287d1addf5e70ed63cf32ef7291fd4f83395b16e13f36d6f9ffc3c19b",
+    "zh:4958e8d74b92196f76f546710df8b5c831297379093ce118ea007a8610905c3d",
+    "zh:7469dbbd5c4c7fafac96c44033c8e62314938ae12f8f2c795cbc4d23f0fbdb20",
+    "zh:80d1b1ac2f9ceb80311a15cea1cda2d3fbe49ea83c131bb06b4bd7028a223739",
+    "zh:8dbb4e8d90b9494e906fc8fcc9ccfbe32db4b48d3500037d8560ba08e8b67972",
+    "zh:a4b83ad8549782b2a38cbc3018480697e0f3face659b5a294e2bc6ab853f934b",
+    "zh:c16b56416065ec4f748724e21d84291d465f9552e2a24953429cb804d3b70caa",
+    "zh:cd5a045470697af3892b507a65e4fed3e41dfe285f65d9ea5769f6b02349e2eb",
+    "zh:dc027c65e28368ef05a26373396b0f16d4ced654808f1e7e9e63ba8ec03ff7fc",
+    "zh:e7f792cc50087267f2d4ef743ccd41e99ae09b05f46457ebcac3f520dd4f5272",
   ]
 }

--- a/apps/web-platform/infra/sentry/versions.tf
+++ b/apps/web-platform/infra/sentry/versions.tf
@@ -46,7 +46,7 @@ terraform {
   required_providers {
     sentry = {
       source  = "jianyuan/sentry"
-      version = "0.15.5"
+      version = "0.15.7"
     }
   }
 }


### PR DESCRIPTION
`v0.15.7` (2026-09-02 23:21Z) carries #943, *"fix(alert): support event frequency count triggers"* — the upstream fix for the Phase 2 blocker.

Verified in the **released tag source**, not the release notes. Reading a changelog instead of the code is the specific error behind the wrong resolution of issue #6636, which cost four months, and it recurred twice more inside #7650.

## What the tag actually contains

`internal/provider/resource_alert_impl.go` @ `v0.15.7`:

- **Read** — `case "event_frequency_count":` (893) sits ahead of `default:` (913) and parses the object comparison into `{Interval, Value}` instead of discarding it.
- **Write** — line 722 emits `FromOrganizationWorkflowTriggerConditionComparison1`, the **object** form. The hardcoded boolean `true` at 740 now serves only genuine legacy types.

The destructive round-trip documented in the Phase 2 blocker is fixed for `event_frequency_count`.

## What it does *not* contain — measured, not assumed

```
grep -c 'case "event_unique_user_frequency_count"'  →  0
```

The gap filed upstream as [#950](https://github.com/jianyuan/terraform-provider-sentry/issues/950) is genuinely still open at this tag, not quietly fixed alongside. Recomputed against released behaviour: **27 of 30 migratable**; `auth-per-user-loop` and `sandbox-startup-failure` still blocked, plus Sentry's own default which must never be imported.

**One edge worth naming:** v0.15.7's read path still routes an `event_frequency_count` whose comparison is a bare **boolean** to `legacy_trigger_conditions`. Measured across our 11 such rules — all 11 carry object comparisons, so none hits it. Had even one been boolean it would still be lossy despite the fix.

## Supply chain

- **14/14** `zh:` hashes corroborated against upstream's signed `SHA256SUMS` for v0.15.7; **zero** uncorroborated.
- All three platforms re-derived independently and confirmed present (`linux_amd64`, `darwin_arm64`, `darwin_amd64`) — the delete-and-regenerate dropped nothing.
- Exact pin, no constraint drift.

## Live verification

`terraform init -lockfile=readonly` succeeds — the constraint CI itself applies. Full-root plan against live state:

```
No changes. Your infrastructure matches the configuration.
88 resources refreshed: 29 issue alerts + 55 cron + 4 uptime
zero 410s
```

Destroy guard on the real plan: `{"resource_deletes":0,"resource_creates":0,"nested_deletes":0}`. Type-scope guard: all 3 types in `.tf ∪ state` covered.

## What this does and does not buy

The zero 410s means this ran **outside** a brownout window. Per the retracted 2026-07-17 finding, that is **not** evidence the deprecation lifted.

This bump does **not** move `sentry_issue_alert` off the deprecated read path — 29 resources still refresh through it, so **the retry stays load-bearing**. What it buys is that Phase 2 becomes possible for 27 rules.

**State surgery is deliberately not in this PR.**

Refs #7650. Refs #950.
