### PR TITLE
chore(legal): fill the two blanks in the Convergence reply so only the send remains

### DIFF
--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -497,7 +497,7 @@
 - [anthropic](legal/data-processing-agreements/anthropic.md)
 - [flagsmith](legal/data-processing-agreements/flagsmith.md)
 - [Soleur BYOK Delegation Consent Arrangement (Versioned In-App Consent)](legal/delegation-consent-side-letter-template.md)
-- [Draft reply — Convergence Corporate CLA request](legal/drafts/2026-09-04-convergence-ccla-reply.md)
+- [Reply — Convergence Corporate CLA request (SENT 2026-09-09)](legal/drafts/2026-09-04-convergence-ccla-reply.md)
 - [GDPR-gate report — feat-soleur-managed-deploy-substrate-3723](legal/gdpr-gate-report-2026-05-14.md)
 - [gdpr-gate report — feat-oauth-tc-consent-3205](legal/gdpr-gate-report-2026-05-15-feat-oauth-tc-consent-3205.md)
 - [Legitimate Interest Assessment — Tenant deploy substrate orchestration-plane meta-audit log](legal/legitimate-interest-assessments/2026-05-14-tenant-deploy-substrate-lia.md)

--- a/knowledge-base/legal/drafts/2026-09-04-convergence-ccla-reply.md
+++ b/knowledge-base/legal/drafts/2026-09-04-convergence-ccla-reply.md
@@ -1,19 +1,25 @@
 ---
-title: "Draft reply — Convergence Corporate CLA request"
+title: "Reply — Convergence Corporate CLA request (SENT 2026-09-09)"
 date: 2026-09-04
-type: correspondence-draft
+type: correspondence
 custodian: clo
-status: awaiting-operator-send
+status: sent
 counterparty: Convergence (Islamabad, Pakistan)
 inbound: support@convergence.pk → legal@jikigai.com
+sent_at: 2026-09-09
+sent_by: operator (legal@jikigai.com → support@convergence.pk)
 related: [3210]
 ---
 
-# Draft reply to Convergence
+# Reply to Convergence — sent 2026-09-09
 
-**Status: DRAFT — not sent.** Operator sends from `legal@jikigai.com`.
+**Status: SENT — 2026-09-09**, by the operator from `legal@jikigai.com` to
+`support@convergence.pk`. This file is now a RECORD of outbound correspondence, not a draft:
+append a dated note rather than editing the body, so what is on file stays what was sent.
+The text below is the text as prepared; it is not independently attested byte-for-byte against
+the message the mail client transmitted.
 
-**Both blanks are now filled; nothing remains but the send.** The turnaround commitment in
+Both blanks were filled before sending. The turnaround commitment in
 paragraph 4 is **5 business days** (operator decision, 2026-09-09), and the closing note on the
 harness contribution is **kept** — it sets review expectations before the counterparty invests
 heavily, which is the reason it was drafted. Neither was a technical call, which is why they sat

--- a/knowledge-base/legal/drafts/2026-09-04-convergence-ccla-reply.md
+++ b/knowledge-base/legal/drafts/2026-09-04-convergence-ccla-reply.md
@@ -11,7 +11,13 @@ related: [3210]
 
 # Draft reply to Convergence
 
-**Status: DRAFT — not sent.** Operator sends from `legal@jikigai.com`. Two blanks to fill before sending: the turnaround commitment in paragraph 4, and whether to name the harness review point (see "Operator notes" below).
+**Status: DRAFT — not sent.** Operator sends from `legal@jikigai.com`.
+
+**Both blanks are now filled; nothing remains but the send.** The turnaround commitment in
+paragraph 4 is **5 business days** (operator decision, 2026-09-09), and the closing note on the
+harness contribution is **kept** — it sets review expectations before the counterparty invests
+heavily, which is the reason it was drafted. Neither was a technical call, which is why they sat
+as blanks rather than being defaulted.
 
 Basis for the content: CLO rulings D1 (both instruments), D2 (PR not blocked), D3 (role mailbox insufficient, and the exact field list with its no-extra-PII boundary).
 
@@ -42,7 +48,7 @@ Please do not send us any further personal information — no phone numbers, hom
 
 To be explicit about why we ask for both: the Corporate CLA secures Convergence's rights as your employee's employer, and the Individual CLA secures the author's own — including moral rights, which under French law cannot be transferred by an employer on an employee's behalf. They cover different things, so we need both. This is the same approach the Apache Software Foundation takes.
 
-We will come back to you within [**N business days** — operator to set] of receiving the details above with a countersigned copy for your records.
+We will come back to you within **5 business days** of receiving the details above with a countersigned copy for your records.
 
 One note on the contribution itself, so it is not a surprise at review time: adding a third agent harness widens a type union that several parts of the codebase consume, so the review will look at those call sites as well as at the new harness code. Happy to talk through the shape before you invest heavily in it.
 


### PR DESCRIPTION
The reply to the inbound Corporate CLA request sat at `awaiting-operator-send` from **2026-09-04**. It has now been **sent** (2026-09-09), and this PR carries both halves: filling the two blanks, then recording the send.

## 1. The two blanks

Neither was a technical call, which is why they were left rather than defaulted.

| Blank | Decision (2026-09-09) |
|---|---|
| Turnaround commitment, paragraph 4 — `[N business days — operator to set]` | **5 business days** |
| Whether to keep the closing note on the harness contribution | **Kept** |

**5 business days** is holdable even if the executed instrument arrives mid-sprint, and still reads as responsive to a counterparty who approached us unprompted. The **harness note** stays because it warns that widening the harness type union pulls several call sites into review — better heard before investing than at review time.

## 2. The send, recorded as evidence rather than as a status flip

The file stops being a draft and becomes a record of outbound correspondence:

- `status: awaiting-operator-send` → `sent`, plus `sent_at` / `sent_by`
- `type: correspondence-draft` → `correspondence` — safe: grep shows no script, workflow or gate keys on that value; it appeared in this file and nowhere else
- Title and H1 no longer say "Draft"
- An **append-only** instruction, because it is now evidence: add a dated note rather than editing the body, so what is on file stays what was sent

**What the record deliberately does not claim.** It states the text is the text as *prepared*, and says plainly that it is **not attested byte-for-byte** against what the mail client transmitted. I did not send it and cannot verify the wire copy, so the file does not imply otherwise.

**The file stays in `drafts/`** despite no longer being one. Moving it would dangle three citations — one of them `scripts/followthroughs/ccla-representative-icla-7922.sh:67`, the probe's CLO-verified note that the counterparty *is* named in the corpus, which is exactly what bounds the opacity claim in its own header. A mildly wrong directory name beats a dangling legal citation. #7911 owns the intake-file reshape and is where a move belongs.

## What this unblocks

#7922's probe has been reporting `NOT YET` accurately because the counterparty had not been asked. The chain is now started:

**reply sent** → counterparty returns the executed instrument → register row (event A) → a designated representative signs the Individual CLA at or after the notice epoch → roster row via `ccla-add.sh` (event B) → #7922 closes by hand.

The 5-business-day clock runs from **receipt of their details**, not from this send.

Closes #7846 — the send it tracked has happened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
