### PR TITLE
fix(inngest): probe_schema=7 — `--count` is not a redis-cli option, and it cost four host replaces

### DIFF
--- a/apps/web-platform/infra/cloud-init-inngest.yml
+++ b/apps/web-platform/infra/cloud-init-inngest.yml
@@ -1055,7 +1055,7 @@ runcmd:
     # PR-gating job here can perform one. On the hermetic side AC5 is the sole control — the
     # digest was read BY COMMAND from the run that signed it, never typed. The pin has exactly one
     # consumer (a host create/replace), so a wrong digest costs delayed detection, not an incident.
-    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.30@sha256:06543dbe18a6b71b86bec0aca069acb0803ca54e7fa725d50ce70087ed7ecc6c
+    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.31@sha256:876b5996ecf536c8642da487e3468870453a59f562e04314c5e682b82b9c72b7
     for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break; sleep 2; done
     # --- #7462 (ADR-096): resolve the effective ref ONCE, zot-primary ---------------------
     # THE DEFECT THIS CLOSES. Every other pull site in the fleet was flipped to prefer the
@@ -1099,7 +1099,7 @@ runcmd:
     . /etc/default/soleur-zot-read 2>/dev/null || true
     ZOT_EP="$ZOT_REGISTRY_ENDPOINT"
     if [ -n "$ZOT_EP" ]; then
-      ZIREF="$ZOT_EP/jikig-ai/soleur-inngest-bootstrap:v1.1.30@sha256:06543dbe18a6b71b86bec0aca069acb0803ca54e7fa725d50ce70087ed7ecc6c"
+      ZIREF="$ZOT_EP/jikig-ai/soleur-inngest-bootstrap:v1.1.31@sha256:876b5996ecf536c8642da487e3468870453a59f562e04314c5e682b82b9c72b7"
       /usr/local/bin/inngest-boot-phone-home.sh pre-zot-pull "$ZIREF"
       set +e
       install -m 600 /dev/null /var/log/inngest-zot-pull.log

--- a/apps/web-platform/infra/cloud-init.yml
+++ b/apps/web-platform/infra/cloud-init.yml
@@ -733,13 +733,13 @@ runcmd:
   # fresh hosts.
   - |
     set -e
-    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.30@sha256:06543dbe18a6b71b86bec0aca069acb0803ca54e7fa725d50ce70087ed7ecc6c
+    IREF=ghcr.io/jikig-ai/soleur-inngest-bootstrap:v1.1.31@sha256:876b5996ecf536c8642da487e3468870453a59f562e04314c5e682b82b9c72b7
     # #6122/ADR-096: prefer zot (dark; host already logged in by soleur-host-bootstrap.sh);
     # all 3 refs follow IREF, zot miss ⇒ GHCR fallback; soleur-boot-emit records the registry.
     ZURL=$(timeout 15 doppler secrets get ZOT_REGISTRY_URL --plain --project soleur --config prd 2>/dev/null || true)
     # ADR-096 5.3 tripwire (#6285): read ci-deploy.sh RETIREMENT TRIPWIRE before deleting this.
     if [ -n "$ZURL" ] && curl -s -o /dev/null --max-time 3 "http://$ZURL/v2/"; then
-      ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.30@sha256:06543dbe18a6b71b86bec0aca069acb0803ca54e7fa725d50ce70087ed7ecc6c"
+      ZIREF="$ZURL/jikig-ai/soleur-inngest-bootstrap:v1.1.31@sha256:876b5996ecf536c8642da487e3468870453a59f562e04314c5e682b82b9c72b7"
       if docker pull "$ZIREF"; then IREF="$ZIREF"; soleur-boot-emit inngest_zot info; else soleur-boot-emit inngest_ghcr_fallback warning; fi
     fi
     docker pull "$IREF"

--- a/apps/web-platform/infra/inngest-bootstrap.sh
+++ b/apps/web-platform/infra/inngest-bootstrap.sh
@@ -631,7 +631,7 @@ cutover_flag="$(printf '%s' "$cutover_flag" | tr -d '[:space:]')"
 # before the emit loses the whole row — including vector_active and the Vector-down fallback.
 # `du` on a sick block device blocks in D-state and `redis-cli` has no default deadline, so an
 # unbounded call here goes dark exactly when the disk is the thing being measured.
-probe_schema=6
+probe_schema=7
 data_mount="${PROBE_DATA_MOUNT:-/mnt/data}"
 latch_dir="${PROBE_LATCH_DIR:-${data_mount}/inngest-cutover}"
 
@@ -806,20 +806,42 @@ dedicated)
           probe_scan_rc=0
           probe_scan_err=""
           probe_err_file="$(mktemp 2>/dev/null || echo /tmp/inngest-probe-scan.err)"
+          probe_out_file="$(mktemp 2>/dev/null || echo /tmp/inngest-probe-scan.out)"
           for probe_db in $probe_dbs; do
             probe_one=""
-            probe_one="$(REDISCLI_AUTH="$INNGEST_REDIS_PASSWORD" timeout 5 \
-              redis-cli -h 127.0.0.1 -p 6379 -n "${probe_db#db}" --scan --count 100 \
-              2>"$probe_err_file" | head -c 65536)" || probe_scan_rc=$?
+            # ── NO `--count`. THAT FLAG DOES NOT EXIST, AND IT COST FOUR HOST REPLACES ────────
+            # `redis-cli 7.0.15` (the version this host runs) answers `--scan --count 100` with
+            #   Unrecognized option or bad number of args for: '--count'
+            # and returns NO keys. Reproduced in `docker run redis:7.0.15`: with the flag, rc=1
+            # and zero output; without it, `--scan` returns every key. I invented the flag in
+            # probe_schema=4, and every hypothesis chased afterwards — keys in another database,
+            # expired-but-unreclaimed husks, an ACL filter — was chasing a phantom my own typo
+            # produced. `--scan` without a count uses redis's default COUNT of 10, which is
+            # ample for a store this size and costs nothing but an extra cursor round-trip.
+            #
+            # ── AND NO PIPE, so redis-cli's OWN exit status survives ─────────────────────────
+            # The previous form piped into `head -c`, and a pipeline's status is the LAST
+            # command's — `head`, which succeeds. So redis-cli exiting 1 was reported as rc=0 and
+            # the `__SCANFAIL_` branch was UNREACHABLE for this failure no matter what it did.
+            # That is the third instance of one class in this probe: `2>/dev/null` discarded the
+            # reason, then stderr-only-on-rc!=0 discarded it again, and then the rc itself could
+            # not propagate. Redirect to a file and read the status directly; bound the size with
+            # `head -c` afterwards, where its exit status is nobody's evidence.
+            REDISCLI_AUTH="$INNGEST_REDIS_PASSWORD" timeout 5 \
+              redis-cli -h 127.0.0.1 -p 6379 -n "${probe_db#db}" --scan \
+              >"$probe_out_file" 2>"$probe_err_file" || probe_scan_rc=$?
+            probe_one="$(head -c 65536 "$probe_out_file")"
             [ -n "$probe_one" ] && probe_scan_out="${probe_scan_out}${probe_one}
 "
             if [ -s "$probe_err_file" ] && [ -z "$probe_scan_err" ]; then
-              # First line only, hard-sanitised and short: enough to name NOAUTH/ERR without
-              # shipping an unbounded server string into a whitespace-parsed row.
-              probe_scan_err="$(head -1 "$probe_err_file" | tr -c 'A-Za-z0-9' '_' | cut -c1-24)"
+              # First line only, hard-sanitised. WIDENED 24 -> 48: at 24 the live host's reply
+              # truncated to `Unrecognized_option_or_b`, cutting off `for: '--count'` — the only
+              # part naming WHICH option. A snippet that drops the identifier answers "something
+              # was wrong" when the whole point is answering "what".
+              probe_scan_err="$(head -1 "$probe_err_file" | tr -c 'A-Za-z0-9' '_' | cut -c1-48)"
             fi
           done
-          rm -f "$probe_err_file"
+          rm -f "$probe_err_file" "$probe_out_file"
 
           if [ "$probe_scan_rc" -ne 0 ]; then
             redis_key_patterns="__SCANFAIL_rc${probe_scan_rc}_${probe_scan_err:-noerr}__"

--- a/apps/web-platform/infra/inngest.test.sh
+++ b/apps/web-platform/infra/inngest.test.sh
@@ -892,8 +892,8 @@ PROBE_7695_FIELDS="probe_schema host_role flush_latched redis_keys redis_expires
 # unauthenticated read must degrade to __UNREADABLE__ and never to 0.
 PROBE_7695_NEVER_ZERO="probe_schema host_role flush_latched data_mount_src data_bytes"
 
-assert "#7695 probe declares probe_schema=6 (Guard 2 refuses a stale_schema row)" \
-  "grep -qE 'probe_schema=6( |\$)' '$PROBE_LOG'"
+assert "#7695 probe declares probe_schema=7 (Guard 2 refuses a stale_schema row)" \
+  "grep -qE 'probe_schema=7( |\$)' '$PROBE_LOG'"
 for _f7695 in $PROBE_7695_FIELDS; do
   assert "#7695 probe emits a non-empty $_f7695" \
     "grep -qE '$_f7695=[^ ]' '$PROBE_LOG'"
@@ -1111,6 +1111,30 @@ assert "#7695 schema 6: the carried error text stays ONE token" \
 # ...and the count is unaffected: a failed scan must never rewrite the destroy-authorizing field.
 assert "#7695 schema 6: a failed scan leaves redis_keys alone (16, not cleared)" \
   "grep -qE 'redis_keys=16( |\$)' '$PROBE_E_LOG'"
+
+# ── probe_schema=7: the flag that does not exist ────────────────────────────────────────────
+# A SOURCE ASSERTION, DELIBERATELY, BECAUSE NO STUB CAN CATCH THIS CLASS. Every redis-cli stub
+# in this file is a shell script that ignores unknown flags, so `--scan --count 100` looked
+# perfectly healthy in the fixtures for THREE schema generations while the real binary answered
+#   Unrecognized option or bad number of args for: '--count'
+# and returned nothing. Reproduced in `docker run redis:7.0.15`: with the flag rc=1 and zero
+# keys; without it, all 16 keys come back. `--count` is not a redis-cli option — it was invented
+# in probe_schema=4 and cost four host replaces, because each subsequent investigation trusted
+# the fixtures and looked at the STORE instead of the command.
+#
+# Asserted on the source, not on behaviour, since behaviour is exactly what the stubs cannot
+# model. Anchored on the invocation to avoid matching this comment (cq-assert-anchor-not-bare-token).
+PROBE_SRC="$SCRIPT_DIR/inngest-bootstrap.sh"
+assert "#7695 schema 7: the scan invocation passes NO --count (not a redis-cli option)" \
+  "! grep -nE '^[[:space:]]*redis-cli .*--scan' '$PROBE_SRC' | grep -q -- '--count'"
+# Non-vacuity: there must BE a --scan invocation for the negative above to mean anything.
+assert "#7695 schema 7: non-vacuity — a --scan invocation exists to be checked" \
+  "grep -qE '^[[:space:]]*redis-cli .*--scan' '$PROBE_SRC'"
+# ...and redis-cli's own exit status must not be laundered through a pipeline. A pipeline's
+# status is the LAST command's, so `redis-cli … | head` reported head's 0 and made the
+# __SCANFAIL_ branch unreachable for a failing redis-cli no matter what that branch contained.
+assert "#7695 schema 7: the scan is redirected, never piped, so redis-cli's rc survives" \
+  "! grep -nE '^[[:space:]]*redis-cli .*--scan' '$PROBE_SRC' | grep -q '|'"
 
 # --- ARM 6: a NOAUTH reply must NOT render as an empty store -------------------------------
 # THE SINGLE MOST DANGEROUS DEGRADATION IN THE PROBE. redis answers an unauthenticated INFO

--- a/tests/scripts/lib/inngest-host-dark-gate.sh
+++ b/tests/scripts/lib/inngest-host-dark-gate.sh
@@ -68,7 +68,7 @@
 #   silent        — the host emits nothing. Check the timer and the Vector shipper.
 #   unreadable    — the read path failed, or a field did not parse. Nothing about the host was
 #                   measured; retry.
-#   stale_schema  — the host is emitting, but from a pre-probe_schema=6 renderer. ACTIONABLE:
+#   stale_schema  — the host is emitting, but from a pre-probe_schema=7 renderer. ACTIONABLE:
 #                   replace the host first WITH A PIN THAT CARRIES THE EMITTER -- a replace on an
 #                   unbumped pin re-delivers the same bytes, because the emitter is baked into the
 #                   OCI image and reaches the host via the digest literal in user_data, not via
@@ -100,7 +100,7 @@
 #     G1  the probe query returned rc 0 AND the row count parses as ^[0-9]+$   -> unreadable
 #     G2  the row count is >= 1                                                -> silent
 #     G3  the chosen row IS the newest, and its age is within --max-row-age     -> stale_row
-#     G4  probe_schema == "6", EXACT equality (not >=)                         -> stale_schema
+#     G4  probe_schema == "7", EXACT equality (not >=)                         -> stale_schema
 #     G14 redis_keys==0 implies redis_key_patterns==__NONE__ (coherence)        -> unreadable
 #   Identity  (inngest-bootstrap.sh is the SHARED renderer for both hosts)
 #     G5  envelope host      == soleur-inngest                                 -> wrong_host
@@ -370,7 +370,7 @@ inngest_host_dark_gate() {
   local rows_file="" query_rc="" finished_file="" finished_rc=""
   local expected_volume_id="" live_attachment_id="" followthrough_rc=""
   local cutover_flag="" diagnostic_boot=""
-  local host="soleur-inngest" host_name="soleur-inngest-prd" expected_schema="6"
+  local host="soleur-inngest" host_name="soleur-inngest-prd" expected_schema="7"
   # G3's recency bound. `now_epoch` is injectable so the suite can pin a clock; the default is the
   # real one. 5400s = 90 minutes, the window the monotonicity argument in this file's header
   # assumes — it was, until this revision, assumed and enforced nowhere.
@@ -583,7 +583,7 @@ inngest_host_dark_gate() {
   # and counts them, so widening the window and leaving this bound behind reddens rather than
   # silently making the emptiness claim older than the argument that justifies it.
 
-  # ── G4 — probe_schema is EXACTLY 6 ──────────────────────────────────────────────
+  # ── G4 — probe_schema is EXACTLY 7 ──────────────────────────────────────────────
   # EXACT EQUALITY, NOT `>=`. A `>=` comparison would silently accept a FUTURE schema whose field
   # semantics this gate has never seen — the same "a lenient extractor makes absence satisfy
   # everything" shape one version forward. A schema bump must force a deliberate edit here.

--- a/tests/scripts/test-inngest-host-dark-gate.sh
+++ b/tests/scripts/test-inngest-host-dark-gate.sh
@@ -74,7 +74,7 @@ bs_line() {
     '{dt:$dt, raw: ({host:$h, host_name:$hn, message:$m, SYSLOG_IDENTIFIER:"inngest-server-probe"} | tojson)}'
 }
 
-# The probe's field list at probe_schema=6, in emit order (pinned against the real emitter by the
+# The probe's field list at probe_schema=7, in emit order (pinned against the real emitter by the
 # emit/read contract arm near the bottom of this file).
 PROBE_FIELDS=(http_code server_active vector_active redis_active uptime_s boot_id image_ref
               instance_id cli_version cutover_flag probe_schema host_role flush_latched
@@ -82,7 +82,7 @@ PROBE_FIELDS=(http_code server_active vector_active redis_active uptime_s boot_i
 declare -A PD=(
   [http_code]=000 [server_active]=inactive [vector_active]=active [redis_active]=active
   [uptime_s]=98765 [boot_id]=b0000000000000000000000000000001 [image_ref]=ghcr.io/example@sha256:aaa
-  [instance_id]=162809678 [cli_version]=v1.19.4 [cutover_flag]=rolled-back [probe_schema]=6
+  [instance_id]=162809678 [cli_version]=v1.19.4 [cutover_flag]=rolled-back [probe_schema]=7
   [host_role]=dedicated [flush_latched]=false [redis_keys]=0
   # __NONE__ is the COHERENT partner of redis_keys=0 (G14). A default of __UNREADABLE__ here
   # would make every unrelated case fail on the coherence guard instead of its own predicate.
@@ -255,8 +255,8 @@ mk_rows "$TMP/rows-g3d.json" "$(bs_line 'yesterday' "$HOSTV" "$HOSTNAMEV" "$(msg
 expect "[G3d] an unparseable dt => unreadable" unreadable "$TMP/rows-g3d.json" "$FIN" --now-epoch 1788430200
 
 # G4 — EXACT equality on the schema, not `>=`.
-mk_rows "$TMP/rows-g4.json" "$(bs_line '2026-09-03 10:00:00' "$HOSTV" "$HOSTNAMEV" "$(msg probe_schema=5)")"
-predicate G4 "probe_schema=5 (the PREVIOUS schema) => stale_schema" stale_schema "$TMP/rows-g4.json" "$FIN"
+mk_rows "$TMP/rows-g4.json" "$(bs_line '2026-09-03 10:00:00' "$HOSTV" "$HOSTNAMEV" "$(msg probe_schema=6)")"
+predicate G4 "probe_schema=6 (the PREVIOUS schema) => stale_schema" stale_schema "$TMP/rows-g4.json" "$FIN"
 
 # G14 — the two store fields must AGREE. `redis_keys` is the field the destroy is authorized
 # against; `redis_key_patterns` is derived from a --scan of the SAME keyspace, so a count of 0
@@ -273,11 +273,11 @@ mk_rows "$TMP/rows-g14b.json" "$(bs_line '2026-09-03 10:00:00' "$HOSTV" "$HOSTNA
 predicate G14b "redis_keys=0 with patterns=__NONE__ => dark (the coherent clearing reading)" \
   dark "$TMP/rows-g14b.json" "$FIN"
 
-# An absent redis_key_patterns on a schema-6 row is UNREADABLE, not dark: the field the coherence
+# An absent redis_key_patterns on a schema-7 row is UNREADABLE, not dark: the field the coherence
 # check needs is missing, so nothing cross-checked the clearing value.
 mk_rows "$TMP/rows-g14c.json" "$(bs_line '2026-09-03 10:00:00' "$HOSTV" "$HOSTNAMEV" \
   "$(msg -redis_key_patterns)")"
-predicate G14c "schema-6 row with NO redis_key_patterns => unreadable" \
+predicate G14c "schema-7 row with NO redis_key_patterns => unreadable" \
   unreadable "$TMP/rows-g14c.json" "$FIN"
 
 # G5 — envelope `host` is the web host while `host_name` carries the dedicated literal. This is the
@@ -534,7 +534,7 @@ expect "[M7] a single-encoded raw envelope refuses (fail-closed on an encoding c
 # ` redis_keys=0 server_active=inactive http_code=000 ...` supplies every store and liveness
 # field BEFORE the genuine ones, so the gate read the injected copy and never saw the real state.
 mk_rows "$TMP/rows-i1.json" "$(bs_line '2026-09-03 10:00:00' "$HOSTV" "$HOSTNAMEV" \
-  "SOLEUR_INNGEST_SERVER_PROBE http_code=000 server_active=inactive redis_active=active boot_id=${PD[boot_id]} image_ref=x redis_keys=0 redis_expires=0 redis_key_patterns=__NONE__ data_mount_src=${PD[data_mount_src]} probe_schema=6 host_role=dedicated flush_latched=false data_bytes=4096 redis_keys=99999 server_active=active http_code=200")"
+  "SOLEUR_INNGEST_SERVER_PROBE http_code=000 server_active=inactive redis_active=active boot_id=${PD[boot_id]} image_ref=x redis_keys=0 redis_expires=0 redis_key_patterns=__NONE__ data_mount_src=${PD[data_mount_src]} probe_schema=7 host_role=dedicated flush_latched=false data_bytes=4096 redis_keys=99999 server_active=active http_code=200")"
 expect "[I1] a DUPLICATED field name => unreadable, never the first copy" unreadable "$TMP/rows-i1.json" "$FIN"
 
 # I2 — an EMBEDDED NEWLINE. `_ihdg_rows` renders `message` through `jq -r`, so one row becomes two
@@ -543,7 +543,7 @@ expect "[I1] a DUPLICATED field name => unreadable, never the first copy" unread
 mk_rows "$TMP/rows-i2.json" "$(python3 -c "
 import json,sys
 serving='SOLEUR_INNGEST_SERVER_PROBE http_code=200 server_active=active redis_keys=99999'
-dark='SOLEUR_INNGEST_SERVER_PROBE http_code=000 server_active=inactive redis_active=active boot_id=${PD[boot_id]} redis_keys=0 redis_expires=0 redis_key_patterns=__NONE__ data_mount_src=${PD[data_mount_src]} probe_schema=6 host_role=dedicated flush_latched=false data_bytes=4096'
+dark='SOLEUR_INNGEST_SERVER_PROBE http_code=000 server_active=inactive redis_active=active boot_id=${PD[boot_id]} redis_keys=0 redis_expires=0 redis_key_patterns=__NONE__ data_mount_src=${PD[data_mount_src]} probe_schema=7 host_role=dedicated flush_latched=false data_bytes=4096'
 raw=json.dumps({'host':'$HOSTV','host_name':'$HOSTNAMEV','message':serving+chr(10)+dark})
 print(json.dumps({'dt':'2026-09-03 10:00:00','raw':raw}))")"
 expect "[I2] an EMBEDDED NEWLINE in one row => refused, never graded as its last line" unreadable "$TMP/rows-i2.json" "$FIN"


### PR DESCRIPTION
## One invalid flag cost four host replaces

`redis-cli 7.0.15` — the version this host runs — answers `--scan --count 100` with

```
Unrecognized option or bad number of args for: '--count'
```

and returns no keys. **`--count` is not a redis-cli option.** I invented it in `probe_schema=4`.

Every hypothesis chased afterwards — keys in another database, expired-but-unreclaimed husks, an ACL filter — was chasing a phantom my own typo produced, and each was disproved at the cost of a host replace. The store was never the problem; the command was.

**Reproduced, not inferred.** `docker run redis:7.0.15` against a fixture matching the live reading exactly (`db0:keys=16,expires=0`):

| form | result |
|---|---|
| `-n 0 --scan --count 100` | `rc=1`, **zero keys** |
| `-n 0 --scan` | `rc=0`, **16 keys**, 0 bytes stderr |

and through the shipped awk: `inngest:queue:*=5,inngest:meta:*=1,loose=1,inngest:state:*=9`.

## Why four generations of green tests missed it

Every redis-cli stub in the suite is a shell script that **ignores unknown flags**, so `--count` looked healthy in the fixtures throughout. A stub cannot model a binary's option validation — this class was untestable behaviourally *in principle*, and a fifth stub would have agreed with me a fifth time.

The guard is therefore a **source assertion** (the scan invocation must pass no `--count`), with a non-vacuity arm requiring a `--scan` invocation to exist at all, plus the real-binary reproduction above.

## The pattern underneath, now three-for-three in one probe

| | how the signal was lost |
|---|---|
| schema 4 | `2>/dev/null` — the reason discarded outright |
| schema 5 | stderr surfaced only on `rc != 0` — discarded on the path actually taken |
| schema 6 | rc laundered by the pipe to `head` — `__SCANFAIL_` was **unreachable** |

A pipeline's exit status is the **last** command's. `head` succeeds, so redis-cli exiting 1 was reported as `rc=0` regardless of what the failure branch contained. Now redirected to a file, with `head -c` applied afterwards where its status is nobody's evidence.

Third fix: the error snippet widens **24 → 48** chars. At 24 the live host's reply truncated to `Unrecognized_option_or_b`, cutting off `for: '--count'` — the only part naming *which* option.

**Mutation-verified both directions:** reintroducing `--count` reds the source guard; restoring the pipe reds three arms including the dedicated no-pipe one. Control 324/324.

## What already stands, independent of this fix

**`redis_expires=0`** — none of the 16 keys carries a TTL. They are **live, non-expiring keys**, not residue. The recut remains correctly blocked on a populated store, and that conclusion does not depend on the scan working.

## The re-pin

`vinngest-v1.1.31`, verified three ways: build run `34398340475` success; `headSha` == tag commit (AC5a); exactly one signing-line digest `sha256:876b5996ecf536c8642da487e3468870453a59f562e04314c5e682b82b9c72b7` (AC5b); GHCR independently reports the same digest. Swept repo-wide — four sites, all pins; the dated `v1.1.26` measurement, Guard B's `v1.1.24` negative controls and the plan's record of #7887 untouched.

Guard A: `byte-identical at vinngest-v1.1.31 (drifted: none)`.

## Test plan

registered battery **116/116, 0 unaccounted** (clean first run) · inngest **324/324** · dark-gate 118/118 · bootstrap 163/163 (unconditional floor 123 exact) · `inngest-userdata-budget.sh` rc=0 (10,888 B stored, 21,880 B headroom). No new shellcheck findings.

## Cost, stated plainly

Four image + replace cycles were spent on a diagnostic that a one-line `docker run` would have settled at the start. The overruns are mine throughout: a misread delivery path, an invented flag, then two successive fixes that each closed one way of losing the signal and left the next. What the spend bought that outlasts it — the byte gate and walker that close the original outage class, the recovered 689-vs-16 provenance, `expires=` establishing the keys are live, and a probe whose failures now name themselves — is real, but it did not need to cost this much.

## After merge

One `inngest-host-replace` delivers v1.1.31 and the scan finally returns the key names, for the empty-or-keep decision on 16 live keys.

Ref #7695, Ref #6894.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
