### PR TITLE
feat: add Devin CLI harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Soleur gives a single founder the leverage of a full organization. **68 agents**
 
 ## Installation
 
+**Devin CLI:**
+
+```bash
+devin plugins install jikig-ai/soleur
+```
+
+Start a Devin session and use `/soleur:go <what you want to do>`.
+
 **Codex:**
 
 ```bash

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -6,6 +6,16 @@ A full AI organization across engineering, finance, marketing, legal, operations
 
 Install the plugin:
 
+**Devin CLI:**
+
+```bash
+devin plugins install jikig-ai/soleur
+```
+
+Start a Devin session and use `/soleur:go <what you want to do>`.
+
+**Claude Code (marketplace):**
+
 ```bash
 claude plugin marketplace add jikig-ai/soleur-marketplace
 claude plugin install soleur@soleur-marketplace
@@ -17,6 +27,10 @@ claude plugin install soleur@soleur-marketplace
 then `codex plugin add soleur@soleur`. Start a new session, review `/hooks`,
 and use `$soleur:go <intent>`. Codex shares the same skills and agent
 definitions; see [compatibility instructions](codex/INSTRUCTIONS.md).
+
+**Devin CLI:** install with `devin plugins install jikig-ai/soleur`. Start a Devin session
+and use `/soleur:go <intent>`. Devin shares the same skills and agent definitions; see
+[compatibility instructions](devin/INSTRUCTIONS.md).
 
 The recommended way to use Soleur is through the unified entry point:
 
@@ -333,6 +347,12 @@ agent-browser install  # Downloads Chrome for Testing
 The `agent-browser` skill provides comprehensive documentation on usage.
 
 ## Installation
+
+**Devin CLI:**
+
+```bash
+devin plugins install jikig-ai/soleur
+```
 
 **From the marketplace (recommended):**
 

--- a/plugins/soleur/commands/go.md
+++ b/plugins/soleur/commands/go.md
@@ -101,19 +101,25 @@ Before applying the routing table, detect the active harness and use the correct
 | Claude Code | **Skill tool** — `soleur:<skill>` | **Task tool** — `subagent_type` | `/soleur:go` |
 | Grok Build | **Slash command** — `/<skill>` (e.g. `/one-shot`) | **spawn_subagent** | `/go` (not `/soleur:go`) |
 | Codex | Load `$soleur:<skill>` through `skills.read` or the installed SKILL.md | **spawn_agent** with canonical instructions | `$soleur:go` |
+| Devin CLI | **Skill tool** — `soleur:<skill>` | **run_subagent** with agent id | `/soleur:go` |
 
 **Codex harness:** read [Codex compatibility instructions](../codex/INSTRUCTIONS.md).
 Use the installed plugin root for plugin-owned paths. Reading the full named
 skill is the Codex entry point when no skill-loading tool is available; execute
 all of its phases. Do not invoke a nonexistent Skill tool or a Grok slash command.
 
+**Devin CLI harness:** read [Devin compatibility instructions](../devin/INSTRUCTIONS.md).
+Devin uses the same Skill tool format as Claude Code with `soleur:<skill>` namespace and `run_subagent` for agents.
+
 **Routing contract (never improvise):** when a table row names `soleur:<skill>` or an agent, invoke it via the harness adapter (`invokeSkill` / `spawnAgent` semantics in `harness.ts` — or `routingInstructions()`). Pass the original user input as args/prompt. **Do NOT** improvise workflow steps, explore the filesystem as a substitute, or hand-roll plan/work/review phases when a registered route exists.
 
 **Grok Build harness:** entry is `/go` (slash command); agents via `spawn_subagent`. Map `soleur:<skill>` → `/<skill>` (strip prefix) at invocation time. **Agent spawn keys:** Grok matches `subagent_type` to the `.grok/agents/` **filename stem** (colons → hyphens), e.g. `soleur:product:cpo` → `soleur-product-cpo`. Colon form is listed in some error catalogs but is **rejected** at spawn — always use `spawnAgent()` / `agentIdToGrokSubagentType()`. See `lib/harness.ts:detectHarness`, `formatSkillInvocation`, `spawnAgent`.
 
+**Devin CLI harness:** entry is `/soleur:go` (slash command); agents via `run_subagent`. Skills use the same `soleur:<skill>` namespace as Claude Code. See `lib/harness.ts:detectHarness`, `formatSkillInvocation`, `spawnAgent`.
+
 **Self-reference (Phase C #6323 / epic #6320):** This document + the eval-harness Grok arm were produced and shipped by invoking `/go 6320 implement and ship the next open feature` (next open = Phase C #6323) inside worktree `feat-one-shot-6323-grok-phase-c` (draft PR #6329). The routing contract above is the enforceable spec exercised by this very run. Edits to the go-routing block are gated by eval-harness (see `gated-skills.json` + `eval-gate:block:go-routing`).
 
-If harness is unknown and Skill/slash tools are unavailable, STOP and suggest `grok inspect` + `grok --trust` (Grok) or `claude --plugin-dir ./plugins/soleur` (Claude).
+If harness is unknown and Skill/slash tools are unavailable, STOP and suggest `grok inspect` + `grok --trust` (Grok), `claude --plugin-dir ./plugins/soleur` (Claude), or `devin plugins install ./plugins/soleur` (Devin).
 
 Analyze the user input and classify intent using semantic assessment:
 

--- a/plugins/soleur/devin/INSTRUCTIONS.md
+++ b/plugins/soleur/devin/INSTRUCTIONS.md
@@ -1,0 +1,77 @@
+# Soleur on Devin CLI
+
+These mappings apply when running Soleur instructions in Devin CLI. Keep the
+canonical skill phases, decision gates, and completion checks. Tool names in
+those instructions describe intent; use the tools actually available in the
+current Devin session.
+
+## Paths and entry points
+
+The installed plugin root is available via `${CLAUDE_PLUGIN_ROOT}` (Devin inherits this from Claude plugin format compatibility).
+Resolve Soleur's `plugins/soleur/...` references against that root; resolve project
+files and `knowledge-base/` against the user's current project or worktree.
+Never search another harness's cache for the plugin. In shell examples,
+set `CLAUDE_PLUGIN_ROOT` to the verified installed root for that command.
+Plugin hooks receive that variable automatically; ordinary shell tools need
+not inherit a plugin hook's environment.
+
+Use `/soleur:go <intent>`, `/soleur:sync`, and `/soleur:help` as Devin slash commands.
+These are skill invocations, not shell commands.
+
+## Tools
+
+| Soleur instruction | Devin execution |
+| --- | --- |
+| Read / Glob / Grep | read, grep, glob tools |
+| Write / Edit | write, edit tools |
+| Bash / Shell | exec tool |
+| Skill `soleur:<name>` | Skill tool with `soleur:<skill>` namespace |
+| Task / Agent / spawn_subagent | run_subagent tool |
+| AskUserQuestion | ask_user_question tool |
+| TodoWrite / TodoRead | todo_write tool |
+| Monitor / AwaitShell / TaskOutput | get_output with timeout for polling |
+| WebSearch / WebFetch / ToolSearch | web_search, webfetch tools |
+| Workflow scripts | Translate orchestration to available tools; do not execute Claude tool calls as shell JavaScript |
+
+Loading a skill file is Devin's execution entry point. Follow its full workflow and referenced files; do not stop after reading it, reproduce it selectively, or ask the user to run the next stage.
+Treat `$ARGUMENTS` as the supplied request, never as an environment variable that needs shell interpolation.
+
+## Domain agents
+
+Canonical definitions live in `agents/<domain>/**/*.md`. Find an agent by
+its qualified ID (`soleur:engineering:review:security-sentinel` maps to
+`agents/engineering/review/security-sentinel.md`) or its frontmatter name.
+Read the definition before delegation. Spawn using the available tool's
+actual schema, passing its absolute definition path, this instruction file,
+the task, and the current worktree path. Do not pass a Claude registry ID as
+a Devin agent type. Inherit the session model and permission policy; Claude
+model aliases are not Devin model identifiers.
+
+If subagents are unavailable, execute the requested role sequentially with
+the same definition and disclose the lack of parallel execution. Never
+claim that an independent review occurred when it did not.
+
+## Hooks and completion
+
+Review and trust the plugin hooks through `/hooks` before relying on them.
+Installation does not grant hook trust. Devin supports the bundled Bash
+credential guard and Stop hooks, but hook execution does not prove that every
+Claude-only workflow primitive has an equivalent.
+
+Keep long-running workflows bounded by their iteration and cost gates.
+Soleur's subscription and model usage are separate charges; substitute
+Devin's model pricing in harness-specific billing disclosures. Soleur disclaims
+warranty for runtime cost.
+
+For asynchronous CI and merge work, own the wait, report changes, resolve
+`BEHIND`, and finish the prescribed postmerge checks before claiming success.
+If a required capability cannot be mapped, report the exact unsupported gate
+and retain incomplete status instead of silently skipping it.
+
+## Devin-specific considerations
+
+- **Skill invocation**: Devin uses the same Skill tool format as Claude Code with `soleur:<skill>` namespace
+- **Agent spawning**: Devin uses `run_subagent` tool instead of Claude's `Task` tool
+- **Polling**: Use `get_output` with timeout instead of Claude's Monitor tool
+- **Permissions**: Devin's permission system differs from Claude's; use permissive defaults initially
+- **MCP servers**: Devin supports the same MCP server format as Claude, so existing servers should work without modification

--- a/plugins/soleur/lib/harness.ts
+++ b/plugins/soleur/lib/harness.ts
@@ -1,8 +1,10 @@
 /**
- * Harness adapter — maps Soleur workflow invocations to Claude Code, Grok Build, or Codex.
+ * Harness adapter — maps Soleur workflow invocations to Claude Code, Grok Build, Codex, or Devin CLI.
  *
  * Claude: Skill tool (`soleur:<skill>`), Task tool (agents), `/soleur:<command>` slash commands.
  * Grok:   slash commands (`/<skill>`, `/go`), spawn_subagent (agents).
+ * Codex:  $soleur:<skill> skill mentions, spawn_agent (agents).
+ * Devin:  Skill tool (`soleur:<skill>`), run_subagent (agents), `/soleur:<command>` slash commands.
  *
  * Skills and go.md must call these helpers (or follow routingInstructions) — never improvise workflows.
  */
@@ -17,7 +19,7 @@ import {
 import { behindSyncInstructions } from "./pr-merge-poll";
 import { pipelineInvocationSuffix, workflowFidelityInstructions } from "./workflow-fidelity";
 
-export type Harness = "claude" | "grok" | "codex" | "unknown";
+export type Harness = "claude" | "grok" | "codex" | "devin" | "unknown";
 
 /** Env vars set by Grok Build (see https://docs.x.ai/build/settings/reference). */
 const GROK_ENV_MARKERS = [
@@ -25,6 +27,12 @@ const GROK_ENV_MARKERS = [
   "GROK_AGENT",
   "GROK_DEFAULT_MODEL",
   "GROK_SUBAGENTS",
+] as const;
+
+/** Env vars set by Devin CLI. */
+const DEVIN_ENV_MARKERS = [
+  "DEVIN",
+  "DEVIN_HOME",
 ] as const;
 
 export interface SkillInvocation {
@@ -37,7 +45,7 @@ export interface SkillInvocation {
 
 export interface AgentSpawn {
   harness: Harness;
-  tool: "Task" | "spawn_subagent" | "spawn_agent";
+  tool: "Task" | "spawn_subagent" | "spawn_agent" | "run_subagent";
   agent: string;
   prompt: string;
   instruction: string;
@@ -67,7 +75,7 @@ export function normalizeAgentName(agent: string): string {
 
 /**
  * Detect the active harness from environment markers and process metadata.
- * Detection order: CLAUDECODE → GROK_* → CODEX_THREAD_ID → process title/argv heuristics.
+ * Detection order: CLAUDECODE → GROK_* → CODEX_THREAD_ID → DEVIN_* → process title/argv heuristics.
  */
 export function detectHarness(env: NodeJS.ProcessEnv = process.env): Harness {
   if (env.CLAUDECODE) {
@@ -84,6 +92,12 @@ export function detectHarness(env: NodeJS.ProcessEnv = process.env): Harness {
     return "codex";
   }
 
+  for (const key of DEVIN_ENV_MARKERS) {
+    if (env[key]) {
+      return "devin";
+    }
+  }
+
   // Process heuristics apply only when inspecting the live runtime env — not
   // injected test fixtures (Grok Build's argv/title would false-positive "grok").
   if (env === process.env && typeof process !== "undefined") {
@@ -91,6 +105,9 @@ export function detectHarness(env: NodeJS.ProcessEnv = process.env): Harness {
     const argv = process.argv.join(" ").toLowerCase();
     if (title.includes("grok") || /\bgrok\b/.test(argv)) {
       return "grok";
+    }
+    if (title.includes("devin") || /\bdevin\b/.test(argv)) {
+      return "devin";
     }
   }
 
@@ -111,6 +128,11 @@ export function formatSkillInvocation(skill: string, args?: string): string {
 
   if (harness === "grok") {
     return trimmedArgs ? `/${name} ${trimmedArgs}` : `/${name}`;
+  }
+
+  if (harness === "devin") {
+    const skillId = `soleur:${name}`;
+    return trimmedArgs ? `${skillId} (args: ${trimmedArgs})` : skillId;
   }
 
   const skillId = `soleur:${name}`;
@@ -155,6 +177,21 @@ export function invokeSkill(skill: string, args?: string): SkillInvocation {
     };
   }
 
+  if (harness === "devin") {
+    const command = `soleur:${name}`;
+    return {
+      harness,
+      tool: "Skill",
+      command,
+      args: trimmedArgs,
+      instruction:
+        `Invoke via the **Skill tool** with skill \`${command}\`` +
+        (trimmedArgs ? ` and args: \`${trimmedArgs}\`` : "") +
+        ". Do NOT improvise workflow steps." +
+        pipelineSuffix,
+    };
+  }
+
   const command = `soleur:${name}`;
   return {
     harness: harness === "claude" ? "claude" : harness,
@@ -191,13 +228,19 @@ export function formatAgentSpawn(agent: string, prompt: string): string {
     );
   }
 
+  if (harness === "devin") {
+    return (
+      `Use the **run_subagent** tool with agent \`${agentId}\` and this prompt:\n\n${prompt}`
+    );
+  }
+
   return (
     `Use the **Task tool** with subagent_type \`${agentId}\` and this prompt:\n\n${prompt}`
   );
 }
 
 /**
- * Structured agent spawn — maps Claude Task tool to Grok spawn_subagent.
+ * Structured agent spawn — maps Claude Task tool to Grok spawn_subagent, Codex spawn_agent, and Devin run_subagent.
  */
 export function spawnAgent(agent: string, prompt: string): AgentSpawn {
   const harness = detectHarness();
@@ -233,6 +276,26 @@ export function spawnAgent(agent: string, prompt: string): AgentSpawn {
         `Spawn via **spawn_subagent** with subagent_type \`${grokType}\` ` +
         `(not colon form \`${agentId}\` — Grok matches the \`.grok/agents/\` filename stem). ` +
         "Enable with `GROK_SUBAGENTS=1` or `[subagents] enabled = true` in config. " +
+        "Pass the prompt verbatim — do NOT substitute a manual workflow.",
+    };
+  }
+
+  if (harness === "devin") {
+    const entries = discoverAgentEntries().filter(
+      (entry) => entry.id === agentId || entry.name === agentId,
+    );
+    if (entries.length !== 1) {
+      throw new Error(`Unknown or ambiguous Soleur agent: ${agent}`);
+    }
+    const entry = entries[0];
+    return {
+      harness,
+      tool: "run_subagent",
+      agent: entry.id,
+      prompt: `Read and follow the Soleur agent definition at ${resolve(PLUGIN_ROOT, entry.path)}.\nApply the Devin compatibility instructions at ${resolve(PLUGIN_ROOT, "devin/INSTRUCTIONS.md")}.\n\n${prompt}`,
+      instruction:
+        `Spawn via **run_subagent** with agent \`${entry.id}\`. ` +
+        "Inherit the session model and permissions. " +
         "Pass the prompt verbatim — do NOT substitute a manual workflow.",
     };
   }
@@ -314,6 +377,19 @@ export function pollInstructions(harness: Harness): string {
         behind,
       ].join("\n");
 
+    case "devin":
+      return [
+        "**Merge/deploy polling (Devin CLI)**",
+        "- Poll `gh pr view --json state,mergeStateStatus` on every tick — **pending checks alone miss BEHIND**.",
+        "- Use **exec** with adequate timeout for short `gh` probes.",
+        "- Use **get_output** with timeout for long loops — match `MERGED`, `BEHIND detected`, `auto-sync.*pushed`, `BEHIND resolved`, `postmerge verification complete`.",
+        "- NEVER ask the operator to monitor merge, CI, or deploy — you own the wait.",
+        "- After `/soleur:ship` merge: poll release workflows, invoke `/soleur:postmerge <PR>`, then emit `<promise>DONE</promise>`.",
+        "- FORBIDDEN: heartbeating on CI while `mergeStateStatus` is `BEHIND`.",
+        "",
+        behind,
+      ].join("\n");
+
     default:
       return [
         "**Merge/deploy polling**",
@@ -364,6 +440,20 @@ export function routingInstructions(harness: Harness): string {
         "- Agents: **spawn_subagent** (not Task). Use `spawnAgent()` so registry colon ids map to hyphen filename stems (`soleur:product:cpo` → `soleur-product-cpo`).",
         "- Commands: `/go`, `/sync`, `/help` — **not** `/soleur:go`.",
         "- **Never improvise** — invoke the registered slash command or subagent.",
+        "",
+        fidelity,
+        "",
+        polling,
+      ].join("\n");
+
+    case "devin":
+      return [
+        "**Harness: Devin CLI**",
+        "- Skills: **Skill tool** with `soleur:<skill>` namespace.",
+        "- Agents: **run_subagent** with agent id.",
+        "- Commands: `/soleur:go`, `/soleur:sync`, `/soleur:help`.",
+        "- **Never improvise** when a route names a `soleur:<skill>` or agent — invoke it.",
+        "- Read devin/INSTRUCTIONS.md in the installed plugin for tool and path mappings.",
         "",
         fidelity,
         "",

--- a/plugins/soleur/test/codex-harness.test.ts
+++ b/plugins/soleur/test/codex-harness.test.ts
@@ -9,7 +9,7 @@ import {
   spawnAgent,
 } from "../lib/harness";
 
-const markers = ["CLAUDECODE", "GROK_HOME", "GROK_AGENT", "GROK_DEFAULT_MODEL", "GROK_SUBAGENTS", "CODEX_THREAD_ID"];
+const markers = ["CLAUDECODE", "GROK_HOME", "GROK_AGENT", "GROK_DEFAULT_MODEL", "GROK_SUBAGENTS", "CODEX_THREAD_ID", "DEVIN", "DEVIN_HOME"];
 let saved: Record<string, string | undefined>;
 
 beforeEach(() => {

--- a/plugins/soleur/test/devin-harness.test.ts
+++ b/plugins/soleur/test/devin-harness.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  detectHarness,
+  formatAgentSpawn,
+  formatSkillInvocation,
+  invokeSkill,
+  pollInstructions,
+  routingInstructions,
+  spawnAgent,
+} from "../lib/harness";
+
+const markers = [
+  "CLAUDECODE",
+  "GROK_HOME",
+  "GROK_AGENT",
+  "GROK_DEFAULT_MODEL",
+  "GROK_SUBAGENTS",
+  "CODEX_THREAD_ID",
+  "DEVIN",
+  "DEVIN_HOME",
+];
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = Object.fromEntries(markers.map((key) => [key, process.env[key]]));
+  for (const key of markers) delete process.env[key];
+  process.env.DEVIN = "1";
+});
+
+afterEach(() => {
+  for (const key of markers) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("Devin harness", () => {
+  test("detects a session, but does not mistake an installed CLI for one", () => {
+    expect(detectHarness({ DEVIN: "1" })).toBe("devin");
+    expect(detectHarness({ DEVIN_HOME: "/home/user/.devin" })).toBe("devin");
+    expect(detectHarness({ CLAUDECODE: "1", DEVIN: "1" })).toBe("claude");
+    expect(detectHarness({ GROK_HOME: "/home/user/.grok", DEVIN: "1" })).toBe("grok");
+    expect(detectHarness({ CODEX_THREAD_ID: "test-thread", DEVIN: "1" })).toBe("codex");
+  });
+
+  test("routes a workflow to its namespaced Devin skill with arguments intact", () => {
+    const invocation = invokeSkill("soleur:one-shot", "  fix the checkout  ");
+    expect(invocation.harness).toBe("devin");
+    expect(invocation.tool).toBe("Skill");
+    expect(invocation.command).toBe("soleur:one-shot");
+    expect(invocation.args).toBe("fix the checkout");
+    expect(invocation.instruction).toContain("Skill tool");
+    expect(invocation.instruction).toContain("Steps 0–8");
+    expect(formatSkillInvocation("brainstorm", "new feature")).toBe("soleur:brainstorm (args: new feature)");
+  });
+
+  test("supplies canonical agent instructions to a Devin subagent", () => {
+    const spawned = spawnAgent("engineering/review/security-sentinel", "Review checkout");
+    expect(spawned.harness).toBe("devin");
+    expect(spawned.tool).toBe("run_subagent");
+    expect(spawned.agent).toBe("soleur:engineering:review:security-sentinel");
+    expect(spawned.prompt).toContain("/agents/engineering/review/security-sentinel.md");
+    expect(spawned.prompt).toContain("Review checkout");
+    expect(spawned.prompt).toContain("devin/INSTRUCTIONS.md");
+    expect(spawned.instruction).toContain("run_subagent");
+    expect(formatAgentSpawn("product/cpo", "Assess")).toContain("run_subagent");
+  });
+
+  test("explains skill loading and owned polling without unavailable tools", () => {
+    const routing = routingInstructions("devin");
+    expect(routing).toContain("/soleur:go");
+    expect(routing).toContain("run_subagent");
+    expect(routing).toContain("devin/INSTRUCTIONS.md");
+    expect(routing).not.toContain("**Monitor tool**");
+    expect(pollInstructions("devin")).toContain("get_output");
+    expect(pollInstructions("devin")).toContain("BEHIND");
+    expect(pollInstructions("devin")).toContain("/soleur:postmerge");
+    expect(pollInstructions("devin")).toContain("/soleur:ship");
+  });
+
+  test("handles Devin-specific skill invocation format", () => {
+    process.env.DEVIN = "1";
+    const inv = invokeSkill("plan", "implement feature");
+    expect(inv.harness).toBe("devin");
+    expect(inv.tool).toBe("Skill");
+    expect(inv.command).toBe("soleur:plan");
+    expect(inv.args).toBe("implement feature");
+    expect(inv.instruction).toContain("Skill tool");
+    expect(inv.instruction).toContain("Do NOT improvise");
+  });
+
+  test("handles Devin-specific agent spawning format", () => {
+    process.env.DEVIN = "1";
+    const spawn = spawnAgent("clo", "Legal attestation");
+    expect(spawn.harness).toBe("devin");
+    expect(spawn.tool).toBe("run_subagent");
+    expect(spawn.agent).toBe("soleur:legal:clo");
+    expect(spawn.instruction).toContain("run_subagent");
+    expect(spawn.instruction).toContain("Inherit the session model");
+  });
+});

--- a/plugins/soleur/test/harness.test.ts
+++ b/plugins/soleur/test/harness.test.ts
@@ -32,6 +32,8 @@ beforeEach(() => {
     GROK_AGENT: process.env.GROK_AGENT,
     GROK_DEFAULT_MODEL: process.env.GROK_DEFAULT_MODEL,
     GROK_SUBAGENTS: process.env.GROK_SUBAGENTS,
+    DEVIN: process.env.DEVIN,
+    DEVIN_HOME: process.env.DEVIN_HOME,
   };
   delete process.env.CLAUDECODE;
   delete process.env.CODEX_THREAD_ID;
@@ -39,6 +41,8 @@ beforeEach(() => {
   delete process.env.GROK_AGENT;
   delete process.env.GROK_DEFAULT_MODEL;
   delete process.env.GROK_SUBAGENTS;
+  delete process.env.DEVIN;
+  delete process.env.DEVIN_HOME;
 });
 
 afterEach(() => {
@@ -64,10 +68,30 @@ describe("detectHarness", () => {
     expect(detectHarness(env({ GROK_AGENT: "grok-build" }))).toBe("grok");
   });
 
+  test("DEVIN → devin", () => {
+    expect(detectHarness(env({ DEVIN: "1" }))).toBe("devin");
+  });
+
+  test("DEVIN_HOME → devin", () => {
+    expect(detectHarness(env({ DEVIN_HOME: "/home/user/.devin" }))).toBe("devin");
+  });
+
   test("CLAUDECODE wins over GROK_* when both set", () => {
     expect(
       detectHarness(env({ CLAUDECODE: "1", GROK_HOME: "/home/user/.grok" })),
     ).toBe("claude");
+  });
+
+  test("CLAUDECODE wins over DEVIN when both set", () => {
+    expect(
+      detectHarness(env({ CLAUDECODE: "1", DEVIN: "1" })),
+    ).toBe("claude");
+  });
+
+  test("GROK wins over DEVIN when both set", () => {
+    expect(
+      detectHarness(env({ GROK_HOME: "/home/user/.grok", DEVIN: "1" })),
+    ).toBe("grok");
   });
 
   test("empty env → unknown", () => {
@@ -117,6 +141,14 @@ describe("formatSkillInvocation", () => {
     );
     expect(formatSkillInvocation("plan")).toBe("/plan");
   });
+
+  test("devin formats soleur: skill with args", () => {
+    process.env.DEVIN = "1";
+    expect(formatSkillInvocation("one-shot", "fix auth")).toBe(
+      "soleur:one-shot (args: fix auth)",
+    );
+    expect(formatSkillInvocation("brainstorm")).toBe("soleur:brainstorm");
+  });
 });
 
 describe("invokeSkill", () => {
@@ -140,6 +172,18 @@ describe("invokeSkill", () => {
     expect(inv.tool).toBe("slash_command");
     expect(inv.command).toBe("/drain-labeled-backlog --label security");
     expect(inv.instruction).toContain("slash command");
+  });
+
+  test("devin returns Skill tool invocation", () => {
+    process.env.DEVIN = "1";
+    const inv = invokeSkill("one-shot", "fix bug");
+
+    expect(inv.harness).toBe("devin");
+    expect(inv.tool).toBe("Skill");
+    expect(inv.command).toBe("soleur:one-shot");
+    expect(inv.args).toBe("fix bug");
+    expect(inv.instruction).toContain("Skill tool");
+    expect(inv.instruction).toContain("Do NOT improvise");
   });
 
   test("one-shot invocation includes pipeline completion suffix", () => {
@@ -174,6 +218,19 @@ describe("spawnAgent", () => {
     expect(spawn.instruction).toContain("soleur-legal-clo");
     expect(spawn.instruction).toContain("soleur:legal:clo");
   });
+
+  test("devin uses run_subagent", () => {
+    process.env.DEVIN = "1";
+    delete process.env.CLAUDECODE;
+    delete process.env.GROK_HOME;
+    const spawn = spawnAgent("clo", "Review issue #123");
+
+    expect(spawn.harness).toBe("devin");
+    expect(spawn.tool).toBe("run_subagent");
+    expect(spawn.agent).toBe("soleur:legal:clo");
+    expect(spawn.instruction).toContain("run_subagent");
+    expect(spawn.prompt).toContain("devin/INSTRUCTIONS.md");
+  });
 });
 
 describe("formatAgentSpawn", () => {
@@ -192,6 +249,15 @@ describe("formatAgentSpawn", () => {
     expect(text).toContain("soleur-legal-clo");
     expect(text).toContain("soleur:legal:clo");
   });
+
+  test("devin mentions run_subagent", () => {
+    process.env.DEVIN = "1";
+    delete process.env.CLAUDECODE;
+    delete process.env.GROK_HOME;
+    const text = formatAgentSpawn("clo", "prompt body");
+    expect(text).toContain("run_subagent");
+    expect(text).toContain("prompt body");
+  });
 });
 
 describe("routingInstructions", () => {
@@ -207,6 +273,14 @@ describe("routingInstructions", () => {
     expect(md).toContain("/go");
     expect(md).toContain("**not** `/soleur:go`");
     expect(md).toContain("spawn_subagent");
+    expect(md).toContain("Workflow fidelity");
+  });
+
+  test("devin documents /soleur:go and run_subagent", () => {
+    const md = routingInstructions("devin");
+    expect(md).toContain("/soleur:go");
+    expect(md).toContain("run_subagent");
+    expect(md).toContain("devin/INSTRUCTIONS.md");
     expect(md).toContain("Workflow fidelity");
   });
 
@@ -230,5 +304,14 @@ describe("pollInstructions", () => {
     const md = pollInstructions("claude");
     expect(md).toContain("Monitor tool");
     expect(md).toContain("postmerge");
+  });
+
+  test("devin documents get_output merge-deploy polling", () => {
+    const md = pollInstructions("devin");
+    expect(md).toContain("get_output");
+    expect(md).toContain("/soleur:postmerge");
+    expect(md).toContain("NEVER ask");
+    expect(md).toContain("BEHIND");
+    expect(md).toContain("/soleur:ship");
   });
 });


### PR DESCRIPTION
## Summary

- Add Devin CLI as the fourth harness in Soleur's multi-harness architecture, alongside Claude Code, Grok Build, and Codex.
- Extend `lib/harness.ts` with Devin detection (`DEVIN`, `DEVIN_HOME`) and routing for skills, agents, polling, and workflow fidelity.
- Create `devin/INSTRUCTIONS.md` with Devin-specific tool mappings (Skill tool, `run_subagent`, `get_output` polling).
- Update `commands/go.md` harness table and routing guidance for Devin CLI.
- Update both `README.md` files with Devin CLI installation instructions.
- Add comprehensive test coverage in `test/devin-harness.test.ts` and extend existing harness tests.

## Changelog

- `feat`: Add Devin CLI harness support — skills, agents, routing, and tests.

#### Test plan

- [x] `bun test test/harness.test.ts` passes (34 tests)
- [x] `bun test test/devin-harness.test.ts` passes (6 tests)
- [x] `bun test test/codex-harness.test.ts` passes (4 tests)
- [x] No version keys added to plugin manifests
- [x] README component counts accurate

Generated with [Devin](https://devin.ai)