### PR TITLE
fix: add Devin-native plugin manifest and correct install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Soleur gives a single founder the leverage of a full organization. **68 agents**
 **Devin CLI:**
 
 ```bash
-devin plugins install jikig-ai/soleur
+devin plugins install jikig-ai/soleur#plugins/soleur -y
 ```
 
-Start a Devin session and use `/soleur:go <what you want to do>`.
+Start a Devin session and use `/soleur:go <what you want to do>`. Use `-y` to skip the confirmation prompt. If the install hangs or fails, clone the repository and install from `./soleur/plugins/soleur`.
 
 **Codex:**
 

--- a/plugins/soleur/.devin-plugin/plugin.json
+++ b/plugins/soleur/.devin-plugin/plugin.json
@@ -1,0 +1,42 @@
+{
+  "name": "soleur",
+  "description": "A full AI organization across engineering, finance, marketing, legal, operations, product, sales, and support that compounds your company knowledge over time.",
+  "author": {
+    "name": "Jean Deruelle",
+    "email": "jean.deruelle@jikigai.com",
+    "url": "https://github.com/deruelle"
+  },
+  "homepage": "https://soleur.ai",
+  "repository": "https://github.com/jikig-ai/soleur",
+  "license": "BUSL-1.1",
+  "keywords": [
+    "soleur",
+    "devin",
+    "claude-code",
+    "codex",
+    "grok-build",
+    "ai-agents",
+    "company-as-a-service",
+    "solo-founder",
+    "orchestration",
+    "ux-audit"
+  ],
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "transport": "http"
+    },
+    "cloudflare": {
+      "url": "https://mcp.cloudflare.com/mcp",
+      "transport": "http"
+    },
+    "vercel": {
+      "url": "https://mcp.vercel.com",
+      "transport": "http"
+    },
+    "stripe": {
+      "url": "https://mcp.stripe.com",
+      "transport": "http"
+    }
+  }
+}

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -9,10 +9,10 @@ Install the plugin:
 **Devin CLI:**
 
 ```bash
-devin plugins install jikig-ai/soleur
+devin plugins install jikig-ai/soleur#plugins/soleur -y
 ```
 
-Start a Devin session and use `/soleur:go <what you want to do>`.
+Start a Devin session and use `/soleur:go <what you want to do>`. Use `-y` to skip the confirmation prompt. If the install hangs or fails, clone the repository and install from `./soleur/plugins/soleur`.
 
 **Claude Code (marketplace):**
 
@@ -351,8 +351,10 @@ The `agent-browser` skill provides comprehensive documentation on usage.
 **Devin CLI:**
 
 ```bash
-devin plugins install jikig-ai/soleur
+devin plugins install jikig-ai/soleur#plugins/soleur -y
 ```
+
+Use `-y` to skip the confirmation prompt. You must be signed in (`devin auth login`) for plugin installation. If the remote install hangs or fails, clone the repository and install from `./soleur/plugins/soleur`.
 
 **From the marketplace (recommended):**
 

--- a/plugins/soleur/devin/INSTRUCTIONS.md
+++ b/plugins/soleur/devin/INSTRUCTIONS.md
@@ -15,6 +15,21 @@ set `CLAUDE_PLUGIN_ROOT` to the verified installed root for that command.
 Plugin hooks receive that variable automatically; ordinary shell tools need
 not inherit a plugin hook's environment.
 
+Install the plugin from the monorepo subfolder:
+
+```bash
+devin plugins install jikig-ai/soleur#plugins/soleur -y
+```
+
+You must be signed in (`devin auth login`) for plugin installation. Use `-y` to skip the confirmation prompt. The first install may take a few minutes because Devin clones the `jikig-ai/soleur` repository to reach the `plugins/soleur` subfolder.
+
+If the remote install hangs or fails, clone the repository and install from the local path:
+
+```bash
+git clone https://github.com/jikig-ai/soleur.git
+devin plugins install --local ./soleur/plugins/soleur -y
+```
+
 Use `/soleur:go <intent>`, `/soleur:sync`, and `/soleur:help` as Devin slash commands.
 These are skill invocations, not shell commands.
 


### PR DESCRIPTION
## Summary

- The Devin CLI install command in the docs was missing the `-y` flag, causing `devin plugins install` to wait at the interactive trust prompt and appear to hang.
- The install source was also missing the monorepo subfolder (`#plugins/soleur`), which is required because Soleur's plugin lives below the repository root.
- Added a Devin-native `.devin-plugin/plugin.json` so Devin does not have to rely on the Claude plugin fallback when loading the plugin.
- Updated `devin/INSTRUCTIONS.md` and both `README.md` files with the corrected command, auth note, and a local-install fallback.

## Changelog

- `fix`: Correct Devin CLI install command and add native `.devin-plugin` manifest

#### Test plan

- [x] `bun test plugins/soleur/test/harness.test.ts plugins/soleur/test/devin-harness.test.ts plugins/soleur/test/codex-harness.test.ts` passes (44 tests)
- [x] Local Devin install: `devin plugins install --local ./plugins/soleur -y` succeeds and `devin plugins list` shows `soleur`
- [x] `.devin-plugin/plugin.json` is valid JSON and contains no `version` key
- [x] Markdown lint passes on changed files
- [x] README component counts unchanged

Generated with [Devin](https://devin.ai)