### PR TITLE
docs: add Devin plugin update instructions and fix stale install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ devin plugins install jikig-ai/soleur#plugins/soleur -y
 
 Start a Devin session and use `/soleur:go <what you want to do>`. Use `-y` to skip the confirmation prompt. If the install hangs or fails, clone the repository and install from `./soleur/plugins/soleur`.
 
+Update to the latest version with `devin plugins update soleur`, or `devin plugins update` to refresh all installed plugins. If you see a transient "content could not be fetched" warning, Devin will retry automatically; run the update command again if it persists.
+
 **Codex:**
 
 ```bash

--- a/plugins/soleur/README.md
+++ b/plugins/soleur/README.md
@@ -28,7 +28,7 @@ then `codex plugin add soleur@soleur`. Start a new session, review `/hooks`,
 and use `$soleur:go <intent>`. Codex shares the same skills and agent
 definitions; see [compatibility instructions](codex/INSTRUCTIONS.md).
 
-**Devin CLI:** install with `devin plugins install jikig-ai/soleur`. Start a Devin session
+**Devin CLI:** install with `devin plugins install jikig-ai/soleur#plugins/soleur -y` and update with `devin plugins update soleur`. Start a Devin session
 and use `/soleur:go <intent>`. Devin shares the same skills and agent definitions; see
 [compatibility instructions](devin/INSTRUCTIONS.md).
 

--- a/plugins/soleur/devin/INSTRUCTIONS.md
+++ b/plugins/soleur/devin/INSTRUCTIONS.md
@@ -33,6 +33,24 @@ devin plugins install --local ./soleur/plugins/soleur -y
 Use `/soleur:go <intent>`, `/soleur:sync`, and `/soleur:help` as Devin slash commands.
 These are skill invocations, not shell commands.
 
+## Updating the plugin
+
+Devin caches plugin content locally. To pull the latest `main` from the monorepo source, run:
+
+```bash
+devin plugins update soleur
+```
+
+To refresh every installed plugin at once:
+
+```bash
+devin plugins update
+```
+
+For local-folder installs (`--local`), edits are reflected in the next session with no `update` needed.
+
+If you see a transient warning such as "plugin ... is in your settings but its content could not be fetched; it will be retried automatically", the cloud-side fetcher is having trouble reaching GitHub. The CLI copy usually still works; run `devin plugins update soleur` again after a moment, or switch to a `--local` install if the remote source stays unreachable.
+
 ## Tools
 
 | Soleur instruction | Devin execution |


### PR DESCRIPTION
## Summary

- Add `devin plugins update soleur` guidance to root `README.md`.
- Fix the lingering `devin plugins install jikig-ai/soleur` (missing `#plugins/soleur` subfolder) in `plugins/soleur/README.md` and add update note.
- Add an "Updating the plugin" section to `plugins/soleur/devin/INSTRUCTIONS.md` covering `devin plugins update`, local-folder installs, and the transient "content could not be fetched" warning.

## Changelog

- `docs`: Document Devin plugin update flow and correct stale install command

#### Test plan

- [x] `npx markdownlint` passes on changed files
- [x] `bash scripts/sync-readme-counts.sh --check` passes
- [x] `bun test plugins/soleur/test/harness.test.ts plugins/soleur/test/devin-harness.test.ts plugins/soleur/test/codex-harness.test.ts` passes (44 tests)

Generated with [Devin](https://devin.ai)